### PR TITLE
docs: link directly to try_files in performance docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -113,7 +113,7 @@ other.example.com {
 Using the `php_server` directive is generally what you need,
 but if you need full control, you can use the lower-level `php` directive.
 The `php` directive passes all input to PHP, instead of first checking whether
-it's a PHP file or not. Read more about it in the [performance page](performance.md).
+it's a PHP file or not. Read more about it in the [performance page](performance.md#try_files).
 
 Using the `php_server` directive is equivalent to this configuration:
 

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -112,7 +112,7 @@ other.example.com {
 L'utilisation de la directive `php_server` est généralement suffisante,
 mais si vous avez besoin d'un contrôle total, vous pouvez utiliser la directive `php`, qui permet un plus grand niveau de finesse dans la configuration.
 La directive `php` transmet toutes les entrées à PHP, au lieu de vérifier d'abord si
-c'est un fichier PHP ou pas. En savoir plus à ce sujet dans la [page performances](performance.md).
+c'est un fichier PHP ou pas. En savoir plus à ce sujet dans la [page performances](performance.md#try_files).
 
 Utiliser la directive `php_server` est équivalent à cette configuration :
 


### PR DESCRIPTION
While looking for some unrelated documentation, I ran into this link and was curious what it had to say. However, I noticed it didn’t go directly to the topic. This updates the link to go directly to the related performance section.