### PR TITLE
Handle symlinking edge cases

### DIFF
--- a/caddy/module.go
+++ b/caddy/module.go
@@ -148,7 +148,10 @@ func (f *FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 		if documentRoot == "" && frankenphp.EmbeddedAppPath != "" {
 			documentRoot = frankenphp.EmbeddedAppPath
 		}
-		documentRootOption = frankenphp.WithRequestDocumentRoot(documentRoot, *f.ResolveRootSymlink)
+		//If we do not have a resolved document root, then we cannot resolve the symlink of our cwd because it may
+		//resolve to a different directory than the one we are currently in.
+		//This is especially important if there are workers running.
+		documentRootOption = frankenphp.WithRequestDocumentRoot(documentRoot, false)
 	} else {
 		documentRoot = f.resolvedDocumentRoot
 		documentRootOption = frankenphp.WithRequestResolvedDocumentRoot(documentRoot)

--- a/worker.go
+++ b/worker.go
@@ -75,6 +75,9 @@ func getWorkerKey(name string, filename string) string {
 }
 
 func newWorker(o workerOpt) (*worker, error) {
+	//Order is important!
+	//This order ensures that FrankenPHP started from inside a symlinked directory will properly resolve any paths.
+	//If it is started from outside a symlinked directory, it is resolved to the same path that we use in the Caddy module.
 	absFileName, err := filepath.EvalSymlinks(o.fileName)
 	if err != nil {
 		return nil, fmt.Errorf("worker filename is invalid %q: %w", o.fileName, err)

--- a/worker.go
+++ b/worker.go
@@ -4,6 +4,7 @@ package frankenphp
 import "C"
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -74,7 +75,11 @@ func getWorkerKey(name string, filename string) string {
 }
 
 func newWorker(o workerOpt) (*worker, error) {
-	absFileName, err := fastabs.FastAbs(o.fileName)
+	absFileName, err := filepath.EvalSymlinks(o.fileName)
+	if err != nil {
+		return nil, fmt.Errorf("worker filename is invalid %q: %w", o.fileName, err)
+	}
+	absFileName, err = fastabs.FastAbs(absFileName)
 	if err != nil {
 		return nil, fmt.Errorf("worker filename is invalid %q: %w", o.fileName, err)
 	}


### PR DESCRIPTION
This one is interesting — though I’m not sure the best way to provide a test. I will have to look into maybe an integration test because it is a careful dance between how we resolve paths in the Caddy module vs. workers. I looked into making a proper change (literally using the same logic everywhere), but I think it is best to wait until #1646 is merged.

But anyway, this change deals with some interesting edge cases. I will use gherkin to describe them:

```gherkin
Feature: FrankenPHP symlinked edge cases
  Background: 
    Given a `test` folder
    And a `public` folder linked to `test`
    And a worker script located at `test/index.php`
    And a `test/nested` folder
    And a worker script located at `test/nested/index.php`
  Scenario: neighboring worker script
    Given frankenphp located in the test folder
    When I execute `frankenphp php-server --listen localhost:8080 -w index.php` from `public`
    Then I expect to see the worker script executed successfully
  Scenario: nested worker script
    Given frankenphp located in the test folder
    When I execute `frankenphp --listen localhost:8080 -w nested/index.php` from `public`
    Then I expect to see the worker script executed successfully
  Scenario: outside the symlinked folder
    Given frankenphp located in the root folder
    When I execute `frankenphp --listen localhost:8080 -w public/index.php` from the root folder
    Then I expect to see the worker script executed successfully
  Scenario: specified root directory
    Given frankenphp located in the root folder
    When I execute `frankenphp --listen localhost:8080 -w public/index.php -r public` from the root folder
    Then I expect to see the worker script executed successfully    
```

Trying to write that out in regular English would be more complex IMHO.

These scenarios should all pass now with this PR.