### PR TITLE
chore: remove SPC_PHP_DEFAULT_OPTIMIZE_CFLAGS which doesn't exist annymore

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -90,10 +90,6 @@ fi
 if [ "${os}" = "linux" ] && { [[ "${arch}" =~ "aarch" ]] || [[ "${arch}" =~ "arm" ]]; }; then
 	fpic="-fPIC"
 	fpie="-fPIE"
-
-	if [ -z "${DEBUG_SYMBOLS}" ]; then
-		export SPC_PHP_DEFAULT_OPTIMIZE_CFLAGS="-g -fstack-protector-strong -fPIC -fPIE -Os -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-	fi
 else
 	fpic="-fpic"
 	fpie="-fpie"

--- a/build-static.sh
+++ b/build-static.sh
@@ -90,6 +90,9 @@ fi
 if [ "${os}" = "linux" ] && { [[ "${arch}" =~ "aarch" ]] || [[ "${arch}" =~ "arm" ]]; }; then
 	fpic="-fPIC"
 	fpie="-fPIE"
+
+	# FIXME: temporary workaround because pre-built poackages aren't compiled wiht -fPIC yet
+  SPC_OPT_DOWNLOAD_ARGS="--ignore-cache-sources=php-src --retry 5"
 else
 	fpic="-fpic"
 	fpie="-fpie"

--- a/build-static.sh
+++ b/build-static.sh
@@ -92,7 +92,7 @@ if [ "${os}" = "linux" ] && { [[ "${arch}" =~ "aarch" ]] || [[ "${arch}" =~ "arm
 	fpie="-fPIE"
 
 	# FIXME: temporary workaround because pre-built poackages aren't compiled wiht -fPIC yet
-  SPC_OPT_DOWNLOAD_ARGS="--ignore-cache-sources=php-src --retry 5"
+	SPC_OPT_DOWNLOAD_ARGS="--ignore-cache-sources=php-src --retry 5"
 else
 	fpic="-fpic"
 	fpie="-fpie"


### PR DESCRIPTION
This env var has been removed from SPC.