### PR TITLE
Fix: Missing shebang

### DIFF
--- a/testdata/load-test.js
+++ b/testdata/load-test.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import http from 'k6/http'
 import { check } from 'k6'
 


### PR DESCRIPTION
The javascript files lack a shebang at the top of the file. This means they can't be executed directly.

Fix:
--- a/testdata/load-test.js
+++ b/testdata/load-test.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import http from 'k6/http'
 import { check } from 'k6'