### PR TITLE
ci(docker): authenticate GitHub API calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,16 +81,23 @@ RUN apt-get update && \
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN curl -s https://api.github.com/repos/e-dant/watcher/releases/latest | \
-		grep tarball_url | \
-		awk '{ print $2 }' | \
-		sed 's/,$//' | \
-		sed 's/"//g' | \
-		xargs curl -L | \
+RUN --mount=type=secret,id=github-token \
+    if [ -f /run/secrets/github-token ] && [ -s /run/secrets/github-token ]; then \
+        echo "Using authenticated GitHub API request"; \
+        curl -s -H "Authorization: Bearer $(cat /run/secrets/github-token)" https://api.github.com/repos/e-dant/watcher/releases/latest; \
+    else \
+        echo "Using unauthenticated GitHub API request"; \
+        curl -s https://api.github.com/repos/e-dant/watcher/releases/latest; \
+    fi | \
+    grep tarball_url | \
+    awk '{ print $2 }' | \
+    sed 's/,$//' | \
+    sed 's/"//g' | \
+    xargs curl -L | \
     tar xz --strip-components 1 && \
     cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-	cmake --build build && \
-	cmake --install build && \
+    cmake --build build && \
+    cmake --install build && \
     ldconfig
 
 WORKDIR /go/src/app

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -88,16 +88,23 @@ RUN apk add --no-cache --virtual .build-deps \
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN curl -s https://api.github.com/repos/e-dant/watcher/releases/latest | \
-		grep tarball_url | \
-		awk '{ print $2 }' | \
-		sed 's/,$//' | \
-		sed 's/"//g' | \
-		xargs curl -L | \
+RUN --mount=type=secret,id=github-token \
+    if [ -f /run/secrets/github-token ] && [ -s /run/secrets/github-token ]; then \
+        echo "Using authenticated GitHub API request"; \
+        curl -s -H "Authorization: Bearer $(cat /run/secrets/github-token)" https://api.github.com/repos/e-dant/watcher/releases/latest; \
+    else \
+        echo "Using unauthenticated GitHub API request"; \
+        curl -s https://api.github.com/repos/e-dant/watcher/releases/latest; \
+    fi | \
+    grep tarball_url | \
+    awk '{ print $2 }' | \
+    sed 's/,$//' | \
+    sed 's/"//g' | \
+    xargs curl -L | \
     tar xz --strip-components 1 && \
     cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-	cmake --build build && \
-	cmake --install build
+    cmake --build build && \
+    cmake --install build
 
 WORKDIR /go/src/app
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -116,6 +116,7 @@ target "default" {
     args = {
         FRANKENPHP_VERSION = VERSION
     }
+    secret = ["id=github-token,env=GITHUB_TOKEN"]
 }
 
 target "static-builder-musl" {


### PR DESCRIPTION
There are some jobs failing times to times because an invalid URL is provided to curl. Github API only allows 60 requests per hour, which could be not that much given the number of jobs.

I suggest we add the authentication with the repo GH token so the limit is way higher. [This draft](https://github.com/php/frankenphp/pull/1677) is green with the change.