### PR TITLE
feat(worker): make maximum consecutive failures configurable

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -33,7 +33,7 @@ func (e *exponentialBackoff) recordFailure() bool {
 	e.backoff = min(e.backoff*2, e.maxBackoff)
 
 	e.mu.Unlock()
-	return e.failureCount >= e.maxConsecutiveFailures
+	return e.maxConsecutiveFailures != -1 && e.failureCount >= e.maxConsecutiveFailures
 }
 
 // wait sleeps for the backoff duration if failureCount is non-zero.

--- a/caddy/app.go
+++ b/caddy/app.go
@@ -114,7 +114,13 @@ func (f *FrankenPHPApp) Start() error {
 		frankenphp.WithMaxWaitTime(f.MaxWaitTime),
 	}
 	for _, w := range append(f.Workers) {
-		opts = append(opts, frankenphp.WithWorkers(w.Name, repl.ReplaceKnown(w.FileName, ""), w.Num, w.Env, w.Watch))
+		workerOpts := []frankenphp.WorkerOption{
+			frankenphp.WithWorkerEnv(w.Env),
+			frankenphp.WithWorkerWatchMode(w.Watch),
+			frankenphp.WithWorkerMaxFailures(w.MaxConsecutiveFailures),
+		}
+
+		opts = append(opts, frankenphp.WithWorkers(w.Name, repl.ReplaceKnown(w.FileName, ""), w.Num, workerOpts...))
 	}
 
 	frankenphp.Shutdown()

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,6 +71,7 @@ The `frankenphp` [global option](https://caddyserver.com/docs/caddyfile/concepts
 			env <key> <value> # Sets an extra environment variable to the given value. Can be specified more than once for multiple environment variables.
 			watch <path> # Sets the path to watch for file changes. Can be specified more than once for multiple paths.
 			name <name> # Sets the name of the worker, used in logs and metrics. Default: absolute path of worker file
+			max_consecutive_failures <num> # Sets the maximum number of consecutive failures before the worker is considered unhealthy, -1 means the worker will always restart. Default: 6.
 		}
 	}
 }

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -70,6 +70,7 @@ L'[option globale](https://caddyserver.com/docs/caddyfile/concepts#global-option
             env <key> <value> # Définit une variable d'environnement supplémentaire avec la valeur donnée. Peut être spécifié plusieurs fois pour régler plusieurs variables d'environnement.
             watch <path> # Définit le chemin d'accès à surveiller pour les modifications de fichiers. Peut être spécifié plusieurs fois pour plusieurs chemins.
             name <name> # Définit le nom du worker, utilisé dans les journaux et les métriques. Défaut : chemin absolu du fichier du worker
+            max_consecutive_failures <num> # Définit le nombre maximum d'échecs consécutifs avant que le worker ne soit considéré comme défaillant, -1 signifie que le worker redémarre toujours. Par défaut : 6.
         }
     }
 }

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -150,6 +150,17 @@ Si le script worker reste en place plus longtemps que le dernier backoff \* 2, F
 Toutefois, si le script de worker continue d'échouer avec un code de sortie non nul dans un court laps de temps
 (par exemple, une faute de frappe dans un script), FrankenPHP plantera avec l'erreur : `too many consecutive failures` (trop d'échecs consécutifs).
 
+Le nombre d'échecs consécutifs peut être configuré dans votre [Caddyfile](config.md#configuration-du-caddyfile) avec l'option `max_consecutive_failures` :
+
+```caddyfile
+frankenphp {
+    worker {
+        # ...
+        max_consecutive_failures 10
+    }
+}
+```
+
 ## Comportement des superglobales
 
 [Les superglobales PHP](https://www.php.net/manual/fr/language.variables.superglobals.php) (`$_SERVER`, `$_ENV`, `$_GET`...)

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -146,6 +146,19 @@ it will not penalize the worker script and restart it again.
 However, if the worker script continues to fail with a non-zero exit code in a short period of time
 (for example, having a typo in a script), FrankenPHP will crash with the error: `too many consecutive failures`.
 
+The number of consecutive failures can be configured in your [Caddyfile](config.md#caddyfile-config) with the `max_consecutive_failures` option:
+
+```caddyfile
+frankenphp {
+    worker {
+        # ...
+        max_consecutive_failures 10
+    }
+}
+```
+
+```caddyfile
+
 ## Superglobals Behavior
 
 [PHP superglobals](https://www.php.net/manual/en/language.variables.superglobals.php) (`$_SERVER`, `$_ENV`, `$_GET`...)

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -66,7 +66,11 @@ func runTest(t *testing.T, test func(func(http.ResponseWriter, *http.Request), *
 
 	initOpts := []frankenphp.Option{frankenphp.WithLogger(opts.logger)}
 	if opts.workerScript != "" {
-		initOpts = append(initOpts, frankenphp.WithWorkers("workerName", testDataDir+opts.workerScript, opts.nbWorkers, opts.env, opts.watch))
+		workerOpts := []frankenphp.WorkerOption{
+			frankenphp.WithWorkerEnv(opts.env),
+			frankenphp.WithWorkerWatchMode(opts.watch),
+		}
+		initOpts = append(initOpts, frankenphp.WithWorkers("workerName", testDataDir+opts.workerScript, opts.nbWorkers, workerOpts...))
 	}
 	initOpts = append(initOpts, opts.initOpts...)
 	if opts.phpIni != nil {

--- a/scaling_test.go
+++ b/scaling_test.go
@@ -37,7 +37,11 @@ func TestScaleAWorkerThreadUpAndDown(t *testing.T) {
 	assert.NoError(t, Init(
 		WithNumThreads(2),
 		WithMaxThreads(3),
-		WithWorkers(workerName, workerPath, 1, map[string]string{}, []string{}),
+		WithWorkers(workerName, workerPath, 1,
+			WithWorkerEnv(map[string]string{}),
+			WithWorkerWatchMode([]string{}),
+			WithWorkerMaxFailures(0),
+		),
 		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 	))
 

--- a/threadworker.go
+++ b/threadworker.go
@@ -30,7 +30,7 @@ func convertToWorkerThread(thread *phpThread, worker *worker) {
 		backoff: &exponentialBackoff{
 			maxBackoff:             1 * time.Second,
 			minBackoff:             100 * time.Millisecond,
-			maxConsecutiveFailures: 6,
+			maxConsecutiveFailures: worker.maxConsecutiveFailures,
 		},
 	})
 	worker.attachThread(thread)
@@ -116,7 +116,6 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 
 	// on exit status 0 we just run the worker script again
 	if exitStatus == 0 && !handler.isBootingScript {
-		// TODO: make the max restart configurable
 		metrics.StopWorker(worker.name, StopReasonRestart)
 		handler.backoff.recordSuccess()
 		logger.LogAttrs(ctx, slog.LevelDebug, "restarting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))

--- a/worker.go
+++ b/worker.go
@@ -14,13 +14,14 @@ import (
 
 // represents a worker script and can have many threads assigned to it
 type worker struct {
-	name        string
-	fileName    string
-	num         int
-	env         PreparedEnv
-	requestChan chan *frankenPHPContext
-	threads     []*phpThread
-	threadMutex sync.RWMutex
+	name                   string
+	fileName               string
+	num                    int
+	env                    PreparedEnv
+	requestChan            chan *frankenPHPContext
+	threads                []*phpThread
+	threadMutex            sync.RWMutex
+	maxConsecutiveFailures int
 }
 
 var (
@@ -99,12 +100,13 @@ func newWorker(o workerOpt) (*worker, error) {
 
 	o.env["FRANKENPHP_WORKER\x00"] = "1"
 	w := &worker{
-		name:        o.name,
-		fileName:    absFileName,
-		num:         o.num,
-		env:         o.env,
-		requestChan: make(chan *frankenPHPContext),
-		threads:     make([]*phpThread, 0, o.num),
+		name:                   o.name,
+		fileName:               absFileName,
+		num:                    o.num,
+		env:                    o.env,
+		requestChan:            make(chan *frankenPHPContext),
+		threads:                make([]*phpThread, 0, o.num),
+		maxConsecutiveFailures: o.maxConsecutiveFailures,
 	}
 	workers[key] = w
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -121,8 +121,16 @@ func TestWorkerGetOpt(t *testing.T) {
 
 func ExampleServeHTTP_workers() {
 	if err := frankenphp.Init(
-		frankenphp.WithWorkers("worker1", "worker1.php", 4, map[string]string{"ENV1": "foo"}, []string{}),
-		frankenphp.WithWorkers("worker2", "worker2.php", 2, map[string]string{"ENV2": "bar"}, []string{}),
+		frankenphp.WithWorkers("worker1", "worker1.php", 4,
+			frankenphp.WithWorkerEnv(map[string]string{"ENV1": "foo"}),
+			frankenphp.WithWorkerWatchMode([]string{}),
+			frankenphp.WithWorkerMaxFailures(0),
+		),
+		frankenphp.WithWorkers("worker2", "worker2.php", 2,
+			frankenphp.WithWorkerEnv(map[string]string{"ENV2": "bar"}),
+			frankenphp.WithWorkerWatchMode([]string{}),
+			frankenphp.WithWorkerMaxFailures(0),
+		),
 	); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds a new configuration key to configure max consecutive failures for workers:

```caddyfile
frankenphp {
    worker {
        # ...
        max_consecutive_failures 10
    }
}
```