### PR TITLE
docs(worker): remove unnecessary ```caddyfile block causing markdown formatting issues

### DIFF
--- a/docs/worker.md
+++ b/docs/worker.md
@@ -157,8 +157,6 @@ frankenphp {
 }
 ```
 
-```caddyfile
-
 ## Superglobals Behavior
 
 [PHP superglobals](https://www.php.net/manual/en/language.variables.superglobals.php) (`$_SERVER`, `$_ENV`, `$_GET`...)


### PR DESCRIPTION
This pull request removes an unnecessary ```caddyfile block in the documentation that was causing incorrect formatting.
The misplaced code block delimiter broke the layout of the surrounding content.
This change restores the expected formatting and improves readability.