### PR TITLE
chore(ci): only trigger time consuming steps when relevant

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,8 +7,14 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
+    paths:
+      - "*.c"
+      - "*.h"
+      - "*.stub.php"
+      - "*Dockerfile"
+      - "docker-bake.hcl"
+      - "*.sh"
+      - ".github/workflows/docker.yaml"
   push:
     branches:
       - main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,8 @@
 ---
 name: Lint Code Base
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
     branches:

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -1,5 +1,8 @@
 ---
 name: Sanitizers
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
     branches:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -7,8 +7,14 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
+    paths:
+      - "*.c"
+      - "*.h"
+      - "*.stub.php"
+      - "*Dockerfile"
+      - "docker-bake.hcl"
+      - "*.sh"
+      - ".github/workflows/static.yaml"
   push:
     branches:
       - main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,8 @@
 ---
 name: Tests
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Because of the numerous platforms FrankenPHP supports, dozens of Docker images are built every time we push something in a branch. This leads to bottlenecks when multiple pushes are performed in a short amount of time (from 1 to 15 minutes). It can then happens several hours before jobs are picked up by Github runners.

I propose to keep linters, sanitizers and tests for every push. They are quick to run and give immediate feedback on PR health.

Building static bin and dozens of Docker images is the real pain point, therefore I propose to only run them at merge on main and when some specific files are edited. I added a list of glob patterns, feel free to comment which you think should also be added.