### PR TITLE
bring back note for php_server -> root

### DIFF
--- a/docs/cn/config.md
+++ b/docs/cn/config.md
@@ -86,13 +86,15 @@ localhost {
 
 ```caddyfile
 app.example.com {
+	root /path/to/app/public
 	php_server {
-		root /path/to/app/public
+		root /path/to/app/public # 允许更好的缓存
 		worker index.php <num>
 	}
 }
 
 other.example.com {
+	root /path/to/other/public
 	php_server {
 		root /path/to/other/public
 		worker index.php <num>

--- a/docs/config.md
+++ b/docs/config.md
@@ -95,13 +95,15 @@ You can also define multiple workers if you serve multiple apps on the same serv
 
 ```caddyfile
 app.example.com {
+    root /path/to/app/public
 	php_server {
-		root /path/to/app/public
+		root /path/to/app/public # allows for better caching
 		worker index.php <num>
 	}
 }
 
 other.example.com {
+    root /path/to/other/public
 	php_server {
 		root /path/to/other/public
 		worker index.php <num>

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -94,13 +94,15 @@ Vous pouvez aussi définir plusieurs workers si vous servez plusieurs applicatio
 
 ```caddyfile
 app.example.com {
+    root /path/to/app/public
     php_server {
-        root /path/to/app/public
+        root /path/to/app/public # permet une meilleure mise en cache
         worker index.php <num>
     }
 }
 
 other.example.com {
+    root /path/to/other/public
     php_server {
         root /path/to/other/public
         worker index.php <num>

--- a/docs/ru/config.md
+++ b/docs/ru/config.md
@@ -89,13 +89,15 @@ localhost {
 
 ```caddyfile
 app.example.com {
+	root /path/to/app/public
 	php_server {
-		root /path/to/app/public
+		root /path/to/app/public # позволяет лучше кэшировать
 		worker index.php <num>
 	}
 }
 
 other.example.com {
+	root /path/to/other/public
 	php_server {
 		root /path/to/other/public
 		worker index.php <num>

--- a/docs/tr/config.md
+++ b/docs/tr/config.md
@@ -88,13 +88,15 @@ Aynı sunucuda birden fazla uygulamaya hizmet veriyorsanız birden fazla işçi 
 
 ```caddyfile
 app.example.com {
+	root /path/to/app/public
 	php_server {
-		root /path/to/app/public
+		root /path/to/app/public # daha iyi önbelleğe almayı sağlar
 		worker index.php <num>
 	}
 }
 
 other.example.com {
+	root /path/to/other/public
 	php_server {
 		root /path/to/other/public
 		worker index.php <num>


### PR DESCRIPTION
I think we either lost it somewhere along the way, or it was in a different place. probably a good idea to include the root directive in both, though.