### PR TITLE
fix: forwards php_server root to try_files

### DIFF
--- a/caddy/module.go
+++ b/caddy/module.go
@@ -464,6 +464,7 @@ func parsePhpServer(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 			redirMatcherSet := caddy.ModuleMap{
 				"file": h.JSON(fileserver.MatchFile{
 					TryFiles: []string{dirIndex},
+					Root:     phpsrv.Root,
 				}),
 				"not": h.JSON(caddyhttp.MatchNot{
 					MatcherSetsRaw: []caddy.ModuleMap{
@@ -491,6 +492,7 @@ func parsePhpServer(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigValue, error)
 				TryFiles:  tryFiles,
 				TryPolicy: tryPolicy,
 				SplitPath: extensions,
+				Root:      phpsrv.Root,
 			}),
 		}
 		rewriteHandler := rewrite.Rewrite{

--- a/caddy/module_test.go
+++ b/caddy/module_test.go
@@ -1,0 +1,40 @@
+package caddy_test
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestRootBehavesTheSameOutsideAndInsidePhpServer(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	testPortNum, _ := strconv.Atoi(testPort)
+	testPortTwo := strconv.Itoa(testPortNum + 1)
+	expectedFileResponse, _ := os.ReadFile("../testdata/files/static.txt")
+	tester.InitServer(`
+		{
+			skip_install_trust
+			admin localhost:2999
+		}
+
+		http://localhost:`+testPort+` {
+			root ../testdata/files
+			php_server
+		}
+
+		http://localhost:`+testPortTwo+` {
+            php_server {
+                root ../testdata/files
+            }
+        }
+		`, "caddyfile")
+
+	// serve the file with root outside of php_server
+	tester.AssertGetResponse("http://localhost:"+testPort+"/static.txt", http.StatusOK, string(expectedFileResponse))
+
+	// serve the file with root within php_server
+	tester.AssertGetResponse("http://localhost:"+testPortTwo+"/static.txt", http.StatusOK, string(expectedFileResponse))
+}


### PR DESCRIPTION
Should fix #1723

The root defined in `php_server` was never really forwarded to `try_files`, which led to potentially confusing behavior where the `file_server`  root (coming from php_server) and the `try_files` root (coming from the caddy route) would differ.