### PR TITLE
feat(extgen): add support for callable in parameters

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -81,24 +81,75 @@ While the first point speaks for itself, the second may be harder to apprehend. 
 
 While some variable types have the same memory representation between C/PHP and Go, some types require more logic to be directly used. This is maybe the hardest part when it comes to writing extensions because it requires understanding internals of the Zend Engine and how variables are stored internally in PHP. This table summarizes what you need to know:
 
-| PHP type           | Go type          | Direct conversion | C to Go helper        | Go to C helper         | Class Methods Support |
-|--------------------|------------------|-------------------|-----------------------|------------------------|-----------------------|
-| `int`              | `int64`          | ✅                 | -                     | -                      | ✅                     |
-| `?int`             | `*int64`         | ✅                 | -                     | -                      | ✅                     |
-| `float`            | `float64`        | ✅                 | -                     | -                      | ✅                     |
-| `?float`           | `*float64`       | ✅                 | -                     | -                      | ✅                     |
-| `bool`             | `bool`           | ✅                 | -                     | -                      | ✅                     |
-| `?bool`            | `*bool`          | ✅                 | -                     | -                      | ✅                     |
-| `string`/`?string` | `*C.zend_string` | ❌                 | frankenphp.GoString() | frankenphp.PHPString() | ✅                     |
-| `array`            | `slice`/`map`    | ❌                 | _Not yet implemented_ | _Not yet implemented_  | ❌                     |
-| `object`           | `struct`         | ❌                 | _Not yet implemented_ | _Not yet implemented_  | ❌                     |
+| PHP type           | Go type             | Direct conversion | C to Go helper        | Go to C helper         | Class Methods Support |
+|--------------------|---------------------|-------------------|-----------------------|------------------------|-----------------------|
+| `int`              | `int64`             | ✅                 | -                     | -                      | ✅                     |
+| `?int`             | `*int64`            | ✅                 | -                     | -                      | ✅                     |
+| `float`            | `float64`           | ✅                 | -                     | -                      | ✅                     |
+| `?float`           | `*float64`          | ✅                 | -                     | -                      | ✅                     |
+| `bool`             | `bool`              | ✅                 | -                     | -                      | ✅                     |
+| `?bool`            | `*bool`             | ✅                 | -                     | -                      | ✅                     |
+| `string`/`?string` | `*C.zend_string`    | ❌                 | frankenphp.GoString() | frankenphp.PHPString() | ✅                     |
+| `array`            | `*frankenphp.Array` | ❌                 | frankenphp.GoArray()  | frankenphp.PHPArray()  | ✅                     |
+| `object`           | `struct`            | ❌                 | _Not yet implemented_ | _Not yet implemented_  | ❌                     |
 
 > [!NOTE]
 > This table is not exhaustive yet and will be completed as the FrankenPHP types API gets more complete.
 >
-> For class methods specifically, only primitive types are currently supported. Arrays and objects cannot be used as method parameters or return types yet.
+> For class methods specifically, primitive types and arrays are currently supported. Objects cannot be used as method parameters or return types yet.
 
 If you refer to the code snippet of the previous section, you can see that helpers are used to convert the first parameter and the return value. The second and third parameter of our `repeat_this()` function don't need to be converted as memory representation of the underlying types are the same for both C and Go.
+
+#### Working with Arrays
+
+FrankenPHP provides native support for PHP arrays through the `frankenphp.Array` type. This type represents both PHP indexed arrays (lists) and associative arrays (hashmaps) with ordered key-value pairs.
+
+**Creating and manipulating arrays in Go:**
+
+```go
+//export_php:function process_data(array $input): array
+func process_data(arr *C.zval) unsafe.Pointer {
+    // Convert PHP array to Go
+    goArray := frankenphp.GoArray(unsafe.Pointer(arr))
+	
+	result := &frankenphp.Array{}
+    
+    result.SetInt(0, "first")
+    result.SetInt(1, "second")
+    result.Append("third") // Automatically assigns next integer key
+    
+    result.SetString("name", "John")
+    result.SetString("age", int64(30))
+    
+    for i := uint32(0); i < goArray.Len(); i++ {
+        key, value := goArray.At(i)
+        if key.Type == frankenphp.PHPStringKey {
+            result.SetString("processed_"+key.Str, value)
+        } else {
+            result.SetInt(key.Int+100, value)
+        }
+    }
+    
+    // Convert back to PHP array
+    return frankenphp.PHPArray(result)
+}
+```
+
+**Key features of `frankenphp.Array`:**
+
+* **Ordered key-value pairs** - Maintains insertion order like PHP arrays
+* **Mixed key types** - Supports both integer and string keys in the same array
+* **Type safety** - The `PHPKey` type ensures proper key handling
+* **Automatic list detection** - When converting to PHP, automatically detects if array should be a packed list or hashmap
+
+**Available methods:**
+
+* `SetInt(key int64, value interface{})` - Set value with integer key
+* `SetString(key string, value interface{})` - Set value with string key  
+* `Append(value interface{})` - Add value with next available integer key
+* `Len() uint32` - Get number of elements
+* `At(index uint32) (PHPKey, interface{})` - Get key-value pair at index
+* `frankenphp.PHPArray(arr *frankenphp.Array) unsafe.Pointer` - Convert to PHP array
 
 ### Declaring a Native PHP Class
 
@@ -188,7 +239,7 @@ func (us *UserStruct) UpdateInfo(name *C.zend_string, age *int64, active *bool) 
 * **PHP `null` becomes Go `nil`** - when PHP passes `null`, your Go function receives a `nil` pointer
 
 > [!WARNING]
-> Currently, class methods have the following limitations. **Arrays and objects are not supported** as parameter types or return types. Only scalar types are supported: `string`, `int`, `float`, `bool` and `void` (for return type). **Nullable parameter types are fully supported** for all scalar types (`?string`, `?int`, `?float`, `?bool`).
+> Currently, class methods have the following limitations. **Objects are not supported** as parameter types or return types. **Arrays are fully supported** for both parameters and return types. Supported types: `string`, `int`, `float`, `bool`, `array`, and `void` (for return type). **Nullable parameter types are fully supported** for all scalar types (`?string`, `?int`, `?float`, `?bool`).
 
 After generating the extension, you will be allowed to use the class and its methods in PHP. Note that you **cannot access properties directly**:
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -81,17 +81,18 @@ While the first point speaks for itself, the second may be harder to apprehend. 
 
 While some variable types have the same memory representation between C/PHP and Go, some types require more logic to be directly used. This is maybe the hardest part when it comes to writing extensions because it requires understanding internals of the Zend Engine and how variables are stored internally in PHP. This table summarizes what you need to know:
 
-| PHP type           | Go type             | Direct conversion | C to Go helper        | Go to C helper         | Class Methods Support |
-|--------------------|---------------------|-------------------|-----------------------|------------------------|-----------------------|
-| `int`              | `int64`             | ✅                 | -                     | -                      | ✅                     |
-| `?int`             | `*int64`            | ✅                 | -                     | -                      | ✅                     |
-| `float`            | `float64`           | ✅                 | -                     | -                      | ✅                     |
-| `?float`           | `*float64`          | ✅                 | -                     | -                      | ✅                     |
-| `bool`             | `bool`              | ✅                 | -                     | -                      | ✅                     |
-| `?bool`            | `*bool`             | ✅                 | -                     | -                      | ✅                     |
-| `string`/`?string` | `*C.zend_string`    | ❌                 | frankenphp.GoString() | frankenphp.PHPString() | ✅                     |
-| `array`            | `*frankenphp.Array` | ❌                 | frankenphp.GoArray()  | frankenphp.PHPArray()  | ✅                     |
-| `object`           | `struct`            | ❌                 | _Not yet implemented_ | _Not yet implemented_  | ❌                     |
+| PHP type           | Go type             | Direct conversion | C to Go helper        | Go to C helper               | Class Methods Support |
+|--------------------|---------------------|-------------------|-----------------------|------------------------------|-----------------------|
+| `int`              | `int64`             | ✅                 | -                     | -                            | ✅                     |
+| `?int`             | `*int64`            | ✅                 | -                     | -                            | ✅                     |
+| `float`            | `float64`           | ✅                 | -                     | -                            | ✅                     |
+| `?float`           | `*float64`          | ✅                 | -                     | -                            | ✅                     |
+| `bool`             | `bool`              | ✅                 | -                     | -                            | ✅                     |
+| `?bool`            | `*bool`             | ✅                 | -                     | -                            | ✅                     |
+| `string`/`?string` | `*C.zend_string`    | ❌                 | frankenphp.GoString() | frankenphp.PHPString()       | ✅                     |
+| `array`            | `*frankenphp.Array` | ❌                 | frankenphp.GoArray()  | frankenphp.PHPArray()        | ✅                     |
+| `callable`         | `*C.zval`           | ❌                 | -                     | frankenphp.CallPHPCallable() | ❌                     |
+| `object`           | -                   | ❌                 | _Not yet implemented_ | _Not yet implemented_        | ❌                     |
 
 > [!NOTE]
 > This table is not exhaustive yet and will be completed as the FrankenPHP types API gets more complete.
@@ -150,6 +151,54 @@ func process_data(arr *C.zval) unsafe.Pointer {
 * `Len() uint32` - Get number of elements
 * `At(index uint32) (PHPKey, interface{})` - Get key-value pair at index
 * `frankenphp.PHPArray(arr *frankenphp.Array) unsafe.Pointer` - Convert to PHP array
+
+### Working with Callables
+
+FrankenPHP provides a way to work with PHP callables using the `frankenphp.CallPHPCallable` helper. This allows you to call PHP functions or methods from Go code.
+
+To showcase this, let's create our own `array_map()` function that takes a callable and an array, applies the callable to each element of the array, and returns a new array with the results:
+
+```go
+// export_php:function my_array_map(array $data, callable $callback): array
+func my_array_map(arr *C.zval, callback *C.zval) unsafe.Pointer {
+	goArr := frankenphp.GoArray(unsafe.Pointer(arr))
+	result := &frankenphp.Array{}
+
+	for i := uint32(0); i < goArr.Len(); i++ {
+		key, value := goArr.At(i)
+
+		callbackResult := frankenphp.CallPHPCallable(unsafe.Pointer(callback), []interface{}{value})
+
+		if key.Type == frankenphp.PHPIntKey {
+			result.SetInt(key.Int, callbackResult)
+		} else {
+			result.SetString(key.Str, callbackResult)
+		}
+	}
+
+	return frankenphp.PHPArray(result)
+}
+```
+
+Notice how we use `frankenphp.CallPHPCallable()` to call the PHP callable passed as a parameter. This function takes a pointer to the callable and an array of arguments, and it returns the result of the callable execution. You can use the callable syntax you're used to:
+
+```php
+<?php
+
+$strArray = ['a' => 'hello', 'b' => 'world', 'c' => 'php'];
+$result = my_array_map($strArray, 'strtoupper'); // $result will be ['a' => 'HELLO', 'b' => 'WORLD', 'c' => 'PHP']
+
+$arr = [1, 2, 3, 4, [5, 6]];
+$result = my_array_map($arr, function($item) {
+    if (\is_array($item)) {
+        return my_array_map($item, function($subItem) {
+            return $subItem * 2;
+        });
+    }
+
+    return $item * 3;
+}); // $result will be [3, 6, 9, 12, [10, 12]]
+```
 
 ### Declaring a Native PHP Class
 

--- a/docs/fr/extensions.md
+++ b/docs/fr/extensions.md
@@ -81,24 +81,75 @@ Alors que le premier point parle de lui-même, le second peut être plus diffici
 
 Bien que certains types de variables aient la même représentation mémoire entre C/PHP et Go, certains types nécessitent plus de logique pour être directement utilisés. C'est peut-être la partie la plus difficile quand il s'agit d'écrire des extensions car cela nécessite de comprendre les fonctionnements internes du moteur Zend et comment les variables sont stockées dans le moteur de PHP. Ce tableau résume ce que vous devez savoir :
 
-| Type PHP           | Type Go          | Conversion directe | Assistant C vers Go     | Assistant Go vers C     | Support des Méthodes de Classe |
-|--------------------|------------------|--------------------|-------------------------|-------------------------|--------------------------------|
-| `int`              | `int64`          | ✅                  | -                       | -                       | ✅                              |
-| `?int`             | `*int64`         | ✅                  | -                       | -                       | ✅                              |
-| `float`            | `float64`        | ✅                  | -                       | -                       | ✅                              |
-| `?float`           | `*float64`       | ✅                  | -                       | -                       | ✅                              |
-| `bool`             | `bool`           | ✅                  | -                       | -                       | ✅                              |
-| `?bool`            | `*bool`          | ✅                  | -                       | -                       | ✅                              |
-| `string`/`?string` | `*C.zend_string` | ❌                  | frankenphp.GoString()   | frankenphp.PHPString()  | ✅                              |
-| `array`            | `slice`/`map`    | ❌                  | _Pas encore implémenté_ | _Pas encore implémenté_ | ❌                              |
-| `object`           | `struct`         | ❌                  | _Pas encore implémenté_ | _Pas encore implémenté_ | ❌                              |
+| Type PHP           | Type Go             | Conversion directe | Assistant C vers Go     | Assistant Go vers C     | Support des Méthodes de Classe |
+|--------------------|---------------------|--------------------|-------------------------|-------------------------|--------------------------------|
+| `int`              | `int64`             | ✅                  | -                       | -                       | ✅                              |
+| `?int`             | `*int64`            | ✅                  | -                       | -                       | ✅                              |
+| `float`            | `float64`           | ✅                  | -                       | -                       | ✅                              |
+| `?float`           | `*float64`          | ✅                  | -                       | -                       | ✅                              |
+| `bool`             | `bool`              | ✅                  | -                       | -                       | ✅                              |
+| `?bool`            | `*bool`             | ✅                  | -                       | -                       | ✅                              |
+| `string`/`?string` | `*C.zend_string`    | ❌                  | frankenphp.GoString()   | frankenphp.PHPString()  | ✅                              |
+| `array`            | `*frankenphp.Array` | ❌                  | frankenphp.GoArray()    | frankenphp.PHPArray()   | ✅                              |
+| `object`           | `struct`            | ❌                  | _Pas encore implémenté_ | _Pas encore implémenté_ | ❌                              |
 
 > [!NOTE]
 > Ce tableau n'est pas encore exhaustif et sera complété au fur et à mesure que l'API de types FrankenPHP deviendra plus complète.
 >
-> Pour les méthodes de classe spécifiquement, seuls les types primitifs sont actuellement supportés. Les tableaux et objets ne peuvent pas encore être utilisés comme paramètres de méthode ou types de retour.
+> Pour les méthodes de classe spécifiquement, les types primitifs et les tableaux sont supportés. Les objets ne peuvent pas encore être utilisés comme paramètres de méthode ou types de retour.
 
 Si vous vous référez à l'extrait de code de la section précédente, vous pouvez voir que des assistants sont utilisés pour convertir le premier paramètre et la valeur de retour. Les deuxième et troisième paramètres de notre fonction `repeat_this()` n'ont pas besoin d'être convertis car la représentation mémoire des types sous-jacents est la même pour C et Go.
+
+#### Travailler avec les Tableaux
+
+FrankenPHP fournit un support natif pour les tableaux PHP à travers le type `frankenphp.Array`. Ce type représente à la fois les tableaux indexés PHP (listes) et les tableaux associatifs (hashmaps) avec des paires clé-valeur ordonnées.
+
+**Créer et manipuler des tableaux en Go :**
+
+```go
+//export_php:function process_data(array $input): array
+func process_data(arr *C.zval) unsafe.Pointer {
+    // Convertir le tableau PHP vers Go
+    goArray := frankenphp.GoArray(unsafe.Pointer(arr))
+    
+    result := &frankenphp.Array{}
+    
+    result.SetInt(0, "first")
+    result.SetInt(1, "second")
+    result.Append("third") // Assigne automatiquement la prochaine clé entière
+    
+    result.SetString("name", "John")
+    result.SetString("age", int64(30))
+    
+    for i := uint32(0); i < goArray.Len(); i++ {
+        key, value := goArray.At(i)
+        if key.Type == frankenphp.PHPStringKey {
+            result.SetString("processed_"+key.Str, value)
+        } else {
+            result.SetInt(key.Int+100, value)
+        }
+    }
+    
+    // Reconvertir vers un tableau PHP
+    return frankenphp.PHPArray(result)
+}
+```
+
+**Fonctionnalités clés de `frankenphp.Array` :**
+
+* **Paires clé-valeur ordonnées** - Maintient l'ordre d'insertion comme les tableaux PHP
+* **Types de clés mixtes** - Supporte les clés entières et chaînes dans le même tableau
+* **Sécurité de type** - Le type `PHPKey` assure une gestion appropriée des clés
+* **Détection automatique de liste** - Lors de la conversion vers PHP, détecte automatiquement si le tableau doit être une liste compacte ou un hashmap
+
+**Méthodes disponibles :**
+
+* `SetInt(key int64, value interface{})` - Définir une valeur avec une clé entière
+* `SetString(key string, value interface{})` - Définir une valeur avec une clé chaîne
+* `Append(value interface{})` - Ajouter une valeur avec la prochaine clé entière disponible
+* `Len() uint32` - Obtenir le nombre d'éléments
+* `At(index uint32) (PHPKey, interface{})` - Obtenir la paire clé-valeur à l'index
+* `frankenphp.PHPArray(arr *frankenphp.Array) unsafe.Pointer` - Convertir vers un tableau PHP
 
 ### Déclarer une Classe PHP Native
 
@@ -188,7 +239,7 @@ func (us *UserStruct) UpdateInfo(name *C.zend_string, age *int64, active *bool) 
 * **PHP `null` devient Go `nil`** - quand PHP passe `null`, votre fonction Go reçoit un pointeur `nil`
 
 > [!WARNING]
-> Actuellement, les méthodes de classe ont les limitations suivantes. **Les tableaux et objets ne sont pas supportés** comme types de paramètres ou types de retour. Seuls les types scalaires sont supportés : `string`, `int`, `float`, `bool` et `void` (pour le type de retour). **Les types de paramètres nullables sont entièrement supportés** pour tous les types scalaires (`?string`, `?int`, `?float`, `?bool`).
+> Actuellement, les méthodes de classe ont les limitations suivantes. **Les objets ne sont pas supportés** comme types de paramètres ou types de retour. **Les tableaux sont entièrement supportés** pour les paramètres et types de retour. Types supportés : `string`, `int`, `float`, `bool`, `array`, et `void` (pour le type de retour). **Les types de paramètres nullables sont entièrement supportés** pour tous les types scalaires (`?string`, `?int`, `?float`, `?bool`).
 
 Après avoir généré l'extension, vous serez autorisé à utiliser la classe et ses méthodes en PHP. Notez que vous **ne pouvez pas accéder aux propriétés directement** :
 

--- a/docs/fr/extensions.md
+++ b/docs/fr/extensions.md
@@ -151,6 +151,54 @@ func process_data(arr *C.zval) unsafe.Pointer {
 * `At(index uint32) (PHPKey, interface{})` - Obtenir la paire clé-valeur à l'index
 * `frankenphp.PHPArray(arr *frankenphp.Array) unsafe.Pointer` - Convertir vers un tableau PHP
 
+### Travailler avec des Callables
+
+FrankenPHP propose un moyen de travailler avec les _callables_ PHP grâce au helper `frankenphp.CallPHPCallable()`. Cela permet d’appeler des fonctions ou des méthodes PHP depuis du code Go.
+
+Pour illustrer cela, créons notre propre fonction `array_map()` qui prend un _callable_ et un tableau, applique le _callable_ à chaque élément du tableau, et retourne un nouveau tableau avec les résultats :
+
+```go
+// export_php:function my_array_map(array $data, callable $callback): array
+func my_array_map(arr *C.zval, callback *C.zval) unsafe.Pointer {
+	goArr := frankenphp.GoArray(unsafe.Pointer(arr))
+	result := &frankenphp.Array{}
+
+	for i := uint32(0); i < goArr.Len(); i++ {
+		key, value := goArr.At(i)
+
+		callbackResult := frankenphp.CallPHPCallable(unsafe.Pointer(callback), []interface{}{value})
+
+		if key.Type == frankenphp.PHPIntKey {
+			result.SetInt(key.Int, callbackResult)
+		} else {
+			result.SetString(key.Str, callbackResult)
+		}
+	}
+
+	return frankenphp.PHPArray(result)
+}
+```
+
+Remarquez comment nous utilisons `frankenphp.CallPHPCallable()` pour appeler le _callable_ PHP passé en paramètre. Cette fonction prend un pointeur vers le _callable_ et un tableau d’arguments, et elle retourne le résultat de l’exécution du _callable_. Vous pouvez utiliser la syntaxe habituelle des _callables_ :
+
+```php
+<?php
+
+$strArray = ['a' => 'hello', 'b' => 'world', 'c' => 'php'];
+$result = my_array_map($strArray, 'strtoupper'); // $result vaudra ['a' => 'HELLO', 'b' => 'WORLD', 'c' => 'PHP']
+
+$arr = [1, 2, 3, 4, [5, 6]];
+$result = my_array_map($arr, function($item) {
+    if (\is_array($item)) {
+        return my_array_map($item, function($subItem) {
+            return $subItem * 2;
+        });
+    }
+
+    return $item * 3;
+}); // $result vaudra [3, 6, 9, 12, [10, 12]]
+```
+
 ### Déclarer une Classe PHP Native
 
 Le générateur prend en charge la déclaration de **classes opaques** comme structures Go, qui peuvent être utilisées pour créer des objets PHP. Vous pouvez utiliser la directive `//export_php:class` pour définir une classe PHP. Par exemple :

--- a/internal/extgen/gofile_test.go
+++ b/internal/extgen/gofile_test.go
@@ -501,6 +501,176 @@ func (ts *TestStruct) ProcessData(name string, count *int64, enabled *bool) stri
 	assert.Contains(t, content, exportDirective, "Generated content should contain export directive: %s", exportDirective)
 }
 
+func TestGoFileGenerator_MethodWrapperWithArrayParams(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sourceContent := `package main
+
+import "fmt"
+
+//export_php:class ArrayClass
+type ArrayStruct struct {
+	data []interface{}
+}
+
+//export_php:method ArrayClass::processArray(array $items): array
+func (as *ArrayStruct) ProcessArray(items *frankenphp.Array) *frankenphp.Array {
+	result := &frankenphp.Array{}
+	for i := uint32(0); i < items.Len(); i++ {
+		key, value := items.At(i)
+		result.SetString(fmt.Sprintf("processed_%d", i), value)
+	}
+	return result
+}
+
+//export_php:method ArrayClass::filterData(array $data, string $filter): array
+func (as *ArrayStruct) FilterData(data *frankenphp.Array, filter string) *frankenphp.Array {
+	result := &frankenphp.Array{}
+	// Filter logic here
+	return result
+}`
+
+	sourceFile := filepath.Join(tmpDir, "test.go")
+	require.NoError(t, os.WriteFile(sourceFile, []byte(sourceContent), 0644))
+
+	methods := []phpClassMethod{
+		{
+			Name:       "ProcessArray",
+			PhpName:    "processArray",
+			ClassName:  "ArrayClass",
+			Signature:  "processArray(array $items): array",
+			ReturnType: "array",
+			Params: []phpParameter{
+				{Name: "items", PhpType: "array", IsNullable: false},
+			},
+			GoFunction: `func (as *ArrayStruct) ProcessArray(items *frankenphp.Array) *frankenphp.Array {
+	result := &frankenphp.Array{}
+	for i := uint32(0); i < items.Len(); i++ {
+		key, value := items.At(i)
+		result.SetString(fmt.Sprintf("processed_%d", i), value)
+	}
+	return result
+}`,
+		},
+		{
+			Name:       "FilterData",
+			PhpName:    "filterData",
+			ClassName:  "ArrayClass",
+			Signature:  "filterData(array $data, string $filter): array",
+			ReturnType: "array",
+			Params: []phpParameter{
+				{Name: "data", PhpType: "array", IsNullable: false},
+				{Name: "filter", PhpType: "string", IsNullable: false},
+			},
+			GoFunction: `func (as *ArrayStruct) FilterData(data *frankenphp.Array, filter string) *frankenphp.Array {
+	result := &frankenphp.Array{}
+	return result
+}`,
+		},
+	}
+
+	classes := []phpClass{
+		{
+			Name:     "ArrayClass",
+			GoStruct: "ArrayStruct",
+			Methods:  methods,
+		},
+	}
+
+	generator := &Generator{
+		BaseName:   "array_test",
+		SourceFile: sourceFile,
+		Classes:    classes,
+		BuildDir:   tmpDir,
+	}
+
+	goGen := GoFileGenerator{generator}
+	content, err := goGen.buildContent()
+	require.NoError(t, err)
+
+	expectedArrayWrapperSignature := "func ProcessArray_wrapper(handle C.uintptr_t, items *C.zval) unsafe.Pointer"
+	assert.Contains(t, content, expectedArrayWrapperSignature, "Generated content should contain array wrapper signature: %s", expectedArrayWrapperSignature)
+
+	expectedMixedWrapperSignature := "func FilterData_wrapper(handle C.uintptr_t, data *C.zval, filter *C.zend_string) unsafe.Pointer"
+	assert.Contains(t, content, expectedMixedWrapperSignature, "Generated content should contain mixed wrapper signature: %s", expectedMixedWrapperSignature)
+
+	expectedArrayCall := "structObj.ProcessArray(items)"
+	assert.Contains(t, content, expectedArrayCall, "Generated content should contain array method call: %s", expectedArrayCall)
+
+	expectedMixedCall := "structObj.FilterData(data, filter)"
+	assert.Contains(t, content, expectedMixedCall, "Generated content should contain mixed method call: %s", expectedMixedCall)
+
+	assert.Contains(t, content, "//export ProcessArray_wrapper", "Generated content should contain ProcessArray export directive")
+	assert.Contains(t, content, "//export FilterData_wrapper", "Generated content should contain FilterData export directive")
+}
+
+func TestGoFileGenerator_MethodWrapperWithNullableArrayParams(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sourceContent := `package main
+
+//export_php:class NullableArrayClass
+type NullableArrayStruct struct{}
+
+//export_php:method NullableArrayClass::processOptionalArray(?array $items, string $name): string
+func (nas *NullableArrayStruct) ProcessOptionalArray(items *frankenphp.Array, name string) string {
+	if items == nil {
+		return "No items: " + name
+	}
+	return fmt.Sprintf("Processing %d items for %s", items.Len(), name)
+}`
+
+	sourceFile := filepath.Join(tmpDir, "test.go")
+	require.NoError(t, os.WriteFile(sourceFile, []byte(sourceContent), 0644))
+
+	methods := []phpClassMethod{
+		{
+			Name:       "ProcessOptionalArray",
+			PhpName:    "processOptionalArray",
+			ClassName:  "NullableArrayClass",
+			Signature:  "processOptionalArray(?array $items, string $name): string",
+			ReturnType: "string",
+			Params: []phpParameter{
+				{Name: "items", PhpType: "array", IsNullable: true},
+				{Name: "name", PhpType: "string", IsNullable: false},
+			},
+			GoFunction: `func (nas *NullableArrayStruct) ProcessOptionalArray(items *frankenphp.Array, name string) string {
+	if items == nil {
+		return "No items: " + name
+	}
+	return fmt.Sprintf("Processing %d items for %s", items.Len(), name)
+}`,
+		},
+	}
+
+	classes := []phpClass{
+		{
+			Name:     "NullableArrayClass",
+			GoStruct: "NullableArrayStruct",
+			Methods:  methods,
+		},
+	}
+
+	generator := &Generator{
+		BaseName:   "nullable_array_test",
+		SourceFile: sourceFile,
+		Classes:    classes,
+		BuildDir:   tmpDir,
+	}
+
+	goGen := GoFileGenerator{generator}
+	content, err := goGen.buildContent()
+	require.NoError(t, err)
+
+	expectedWrapperSignature := "func ProcessOptionalArray_wrapper(handle C.uintptr_t, items *C.zval, name *C.zend_string) unsafe.Pointer"
+	assert.Contains(t, content, expectedWrapperSignature, "Generated content should contain nullable array wrapper signature: %s", expectedWrapperSignature)
+
+	expectedCall := "structObj.ProcessOptionalArray(items, name)"
+	assert.Contains(t, content, expectedCall, "Generated content should contain method call: %s", expectedCall)
+
+	assert.Contains(t, content, "//export ProcessOptionalArray_wrapper", "Generated content should contain export directive")
+}
+
 func createTempSourceFile(t *testing.T, content string) string {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "source.go")

--- a/internal/extgen/paramparser.go
+++ b/internal/extgen/paramparser.go
@@ -68,6 +68,8 @@ func (pp *ParameterParser) generateSingleParamDeclaration(param phpParameter) []
 		if param.IsNullable {
 			decls = append(decls, fmt.Sprintf("zend_bool %s_is_null = 0;", param.Name))
 		}
+	case "array":
+		decls = append(decls, fmt.Sprintf("zval *%s = NULL;", param.Name))
 	}
 
 	return decls
@@ -115,6 +117,8 @@ func (pp *ParameterParser) generateParamParsingMacro(param phpParameter) string 
 			return fmt.Sprintf("\n        Z_PARAM_DOUBLE_OR_NULL(%s, %s_is_null)", param.Name, param.Name)
 		case "bool":
 			return fmt.Sprintf("\n        Z_PARAM_BOOL_OR_NULL(%s, %s_is_null)", param.Name, param.Name)
+		case "array":
+			return fmt.Sprintf("\n        Z_PARAM_ARRAY_OR_NULL(%s)", param.Name)
 		default:
 			return ""
 		}
@@ -128,6 +132,8 @@ func (pp *ParameterParser) generateParamParsingMacro(param phpParameter) string 
 			return fmt.Sprintf("\n        Z_PARAM_DOUBLE(%s)", param.Name)
 		case "bool":
 			return fmt.Sprintf("\n        Z_PARAM_BOOL(%s)", param.Name)
+		case "array":
+			return fmt.Sprintf("\n        Z_PARAM_ARRAY(%s)", param.Name)
 		default:
 			return ""
 		}
@@ -158,6 +164,8 @@ func (pp *ParameterParser) generateSingleGoCallParam(param phpParameter) string 
 			return fmt.Sprintf("%s_is_null ? NULL : &%s", param.Name, param.Name)
 		case "bool":
 			return fmt.Sprintf("%s_is_null ? NULL : &%s", param.Name, param.Name)
+		case "array":
+			return param.Name
 		default:
 			return param.Name
 		}
@@ -171,6 +179,8 @@ func (pp *ParameterParser) generateSingleGoCallParam(param phpParameter) string 
 			return fmt.Sprintf("(double) %s", param.Name)
 		case "bool":
 			return fmt.Sprintf("(int) %s", param.Name)
+		case "array":
+			return param.Name
 		default:
 			return param.Name
 		}

--- a/internal/extgen/paramparser.go
+++ b/internal/extgen/paramparser.go
@@ -70,6 +70,8 @@ func (pp *ParameterParser) generateSingleParamDeclaration(param phpParameter) []
 		}
 	case "array":
 		decls = append(decls, fmt.Sprintf("zval *%s = NULL;", param.Name))
+	case "callable":
+		decls = append(decls, fmt.Sprintf("zval *%s_callback;", param.Name))
 	}
 
 	return decls
@@ -119,6 +121,8 @@ func (pp *ParameterParser) generateParamParsingMacro(param phpParameter) string 
 			return fmt.Sprintf("\n        Z_PARAM_BOOL_OR_NULL(%s, %s_is_null)", param.Name, param.Name)
 		case "array":
 			return fmt.Sprintf("\n        Z_PARAM_ARRAY_OR_NULL(%s)", param.Name)
+		case "callable":
+			return fmt.Sprintf("\n        Z_PARAM_ZVAL_OR_NULL(%s_callback)", param.Name)
 		default:
 			return ""
 		}
@@ -134,6 +138,8 @@ func (pp *ParameterParser) generateParamParsingMacro(param phpParameter) string 
 			return fmt.Sprintf("\n        Z_PARAM_BOOL(%s)", param.Name)
 		case "array":
 			return fmt.Sprintf("\n        Z_PARAM_ARRAY(%s)", param.Name)
+		case "callable":
+			return fmt.Sprintf("\n        Z_PARAM_ZVAL(%s_callback)", param.Name)
 		default:
 			return ""
 		}
@@ -166,6 +172,8 @@ func (pp *ParameterParser) generateSingleGoCallParam(param phpParameter) string 
 			return fmt.Sprintf("%s_is_null ? NULL : &%s", param.Name, param.Name)
 		case "array":
 			return param.Name
+		case "callable":
+			return fmt.Sprintf("%s_callback", param.Name)
 		default:
 			return param.Name
 		}
@@ -181,6 +189,8 @@ func (pp *ParameterParser) generateSingleGoCallParam(param phpParameter) string 
 			return fmt.Sprintf("(int) %s", param.Name)
 		case "array":
 			return param.Name
+		case "callable":
+			return fmt.Sprintf("%s_callback", param.Name)
 		default:
 			return param.Name
 		}

--- a/internal/extgen/paramparser_test.go
+++ b/internal/extgen/paramparser_test.go
@@ -140,6 +140,29 @@ func TestParameterParser_GenerateParamDeclarations(t *testing.T) {
 			},
 			expected: "    zend_string *name = NULL;\n    zend_long count = 0;\n    zend_bool count_is_null = 0;",
 		},
+		{
+			name: "array parameter",
+			params: []phpParameter{
+				{Name: "items", PhpType: "array", HasDefault: false},
+			},
+			expected: "    zval *items = NULL;",
+		},
+		{
+			name: "nullable array parameter",
+			params: []phpParameter{
+				{Name: "items", PhpType: "array", HasDefault: false, IsNullable: true},
+			},
+			expected: "    zval *items = NULL;",
+		},
+		{
+			name: "mixed types with array",
+			params: []phpParameter{
+				{Name: "name", PhpType: "string", HasDefault: false},
+				{Name: "items", PhpType: "array", HasDefault: false},
+				{Name: "count", PhpType: "int", HasDefault: true, DefaultValue: "5"},
+			},
+			expected: "    zend_string *name = NULL;\n    zval *items = NULL;\n    zend_long count = 5;",
+		},
 	}
 
 	for _, tt := range tests {
@@ -232,6 +255,29 @@ func TestParameterParser_GenerateGoCallParams(t *testing.T) {
 			},
 			expected: "name, (long) count, (double) ratio, (int) enabled",
 		},
+		{
+			name: "array parameter",
+			params: []phpParameter{
+				{Name: "items", PhpType: "array"},
+			},
+			expected: "items",
+		},
+		{
+			name: "nullable array parameter",
+			params: []phpParameter{
+				{Name: "items", PhpType: "array", IsNullable: true},
+			},
+			expected: "items",
+		},
+		{
+			name: "mixed parameters with array",
+			params: []phpParameter{
+				{Name: "name", PhpType: "string"},
+				{Name: "items", PhpType: "array"},
+				{Name: "count", PhpType: "int"},
+			},
+			expected: "name, items, (long) count",
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +335,16 @@ func TestParameterParser_GenerateParamParsingMacro(t *testing.T) {
 			name:     "nullable bool parameter",
 			param:    phpParameter{Name: "enabled", PhpType: "bool", IsNullable: true},
 			expected: "\n        Z_PARAM_BOOL_OR_NULL(enabled, enabled_is_null)",
+		},
+		{
+			name:     "array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array"},
+			expected: "\n        Z_PARAM_ARRAY(items)",
+		},
+		{
+			name:     "nullable array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array", IsNullable: true},
+			expected: "\n        Z_PARAM_ARRAY_OR_NULL(items)",
 		},
 		{
 			name:     "unknown type",
@@ -391,6 +447,16 @@ func TestParameterParser_GenerateSingleGoCallParam(t *testing.T) {
 			expected: "enabled_is_null ? NULL : &enabled",
 		},
 		{
+			name:     "array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array"},
+			expected: "items",
+		},
+		{
+			name:     "nullable array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array", IsNullable: true},
+			expected: "items",
+		},
+		{
 			name:     "unknown type",
 			param:    phpParameter{Name: "unknown", PhpType: "unknown"},
 			expected: "unknown",
@@ -457,6 +523,16 @@ func TestParameterParser_GenerateSingleParamDeclaration(t *testing.T) {
 			name:     "nullable float parameter",
 			param:    phpParameter{Name: "ratio", PhpType: "float", HasDefault: false, IsNullable: true},
 			expected: []string{"double ratio = 0.0;", "zend_bool ratio_is_null = 0;"},
+		},
+		{
+			name:     "array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array", HasDefault: false},
+			expected: []string{"zval *items = NULL;"},
+		},
+		{
+			name:     "nullable array parameter",
+			param:    phpParameter{Name: "items", PhpType: "array", HasDefault: false, IsNullable: true},
+			expected: []string{"zval *items = NULL;"},
 		},
 	}
 

--- a/internal/extgen/paramparser_test.go
+++ b/internal/extgen/paramparser_test.go
@@ -163,6 +163,29 @@ func TestParameterParser_GenerateParamDeclarations(t *testing.T) {
 			},
 			expected: "    zend_string *name = NULL;\n    zval *items = NULL;\n    zend_long count = 5;",
 		},
+		{
+			name: "callable parameter",
+			params: []phpParameter{
+				{Name: "callback", PhpType: "callable", HasDefault: false},
+			},
+			expected: "    zval *callback_callback;",
+		},
+		{
+			name: "nullable callable parameter",
+			params: []phpParameter{
+				{Name: "callback", PhpType: "callable", HasDefault: false, IsNullable: true},
+			},
+			expected: "    zval *callback_callback;",
+		},
+		{
+			name: "mixed types with callable",
+			params: []phpParameter{
+				{Name: "data", PhpType: "array", HasDefault: false},
+				{Name: "callback", PhpType: "callable", HasDefault: false},
+				{Name: "options", PhpType: "int", HasDefault: true, DefaultValue: "0"},
+			},
+			expected: "    zval *data = NULL;\n    zval *callback_callback;\n    zend_long options = 0;",
+		},
 	}
 
 	for _, tt := range tests {
@@ -278,6 +301,29 @@ func TestParameterParser_GenerateGoCallParams(t *testing.T) {
 			},
 			expected: "name, items, (long) count",
 		},
+		{
+			name: "callable parameter",
+			params: []phpParameter{
+				{Name: "callback", PhpType: "callable"},
+			},
+			expected: "callback_callback",
+		},
+		{
+			name: "nullable callable parameter",
+			params: []phpParameter{
+				{Name: "callback", PhpType: "callable", IsNullable: true},
+			},
+			expected: "callback_callback",
+		},
+		{
+			name: "mixed parameters with callable",
+			params: []phpParameter{
+				{Name: "data", PhpType: "array"},
+				{Name: "callback", PhpType: "callable"},
+				{Name: "limit", PhpType: "int"},
+			},
+			expected: "data, callback_callback, (long) limit",
+		},
 	}
 
 	for _, tt := range tests {
@@ -345,6 +391,16 @@ func TestParameterParser_GenerateParamParsingMacro(t *testing.T) {
 			name:     "nullable array parameter",
 			param:    phpParameter{Name: "items", PhpType: "array", IsNullable: true},
 			expected: "\n        Z_PARAM_ARRAY_OR_NULL(items)",
+		},
+		{
+			name:     "callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable"},
+			expected: "\n        Z_PARAM_ZVAL(callback_callback)",
+		},
+		{
+			name:     "nullable callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable", IsNullable: true},
+			expected: "\n        Z_PARAM_ZVAL_OR_NULL(callback_callback)",
 		},
 		{
 			name:     "unknown type",
@@ -457,6 +513,16 @@ func TestParameterParser_GenerateSingleGoCallParam(t *testing.T) {
 			expected: "items",
 		},
 		{
+			name:     "callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable"},
+			expected: "callback_callback",
+		},
+		{
+			name:     "nullable callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable", IsNullable: true},
+			expected: "callback_callback",
+		},
+		{
 			name:     "unknown type",
 			param:    phpParameter{Name: "unknown", PhpType: "unknown"},
 			expected: "unknown",
@@ -533,6 +599,16 @@ func TestParameterParser_GenerateSingleParamDeclaration(t *testing.T) {
 			name:     "nullable array parameter",
 			param:    phpParameter{Name: "items", PhpType: "array", HasDefault: false, IsNullable: true},
 			expected: []string{"zval *items = NULL;"},
+		},
+		{
+			name:     "callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable", HasDefault: false},
+			expected: []string{"zval *callback_callback;"},
+		},
+		{
+			name:     "nullable callable parameter",
+			param:    phpParameter{Name: "callback", PhpType: "callable", HasDefault: false, IsNullable: true},
+			expected: []string{"zval *callback_callback;"},
 		},
 	}
 

--- a/internal/extgen/phpfunc.go
+++ b/internal/extgen/phpfunc.go
@@ -44,6 +44,10 @@ func (pfg *PHPFuncGenerator) generateGoCall(fn phpFunction) string {
 		return fmt.Sprintf("    zend_string *result = %s(%s);", fn.Name, callParams)
 	}
 
+	if fn.ReturnType == "array" {
+		return fmt.Sprintf("    zend_array *result = %s(%s);", fn.Name, callParams)
+	}
+
 	return fmt.Sprintf("    %s result = %s(%s);", pfg.getCReturnType(fn.ReturnType), fn.Name, callParams)
 }
 
@@ -57,6 +61,8 @@ func (pfg *PHPFuncGenerator) getCReturnType(returnType string) string {
 		return "double"
 	case "bool":
 		return "int"
+	case "array":
+		return "zend_array*"
 	default:
 		return "void"
 	}
@@ -76,6 +82,12 @@ func (pfg *PHPFuncGenerator) generateReturnCode(returnType string) string {
 		return `    RETURN_DOUBLE(result);`
 	case "bool":
 		return `    RETURN_BOOL(result);`
+	case "array":
+		return `    if (result) {
+        RETURN_ARR(result);
+    } else {
+        array_init(return_value);
+    }`
 	default:
 		return ""
 	}

--- a/internal/extgen/phpfunc_test.go
+++ b/internal/extgen/phpfunc_test.go
@@ -96,6 +96,46 @@ func TestPHPFunctionGenerator_Generate(t *testing.T) {
 				"RETURN_DOUBLE(result)",
 			},
 		},
+		{
+			name: "array function with array parameter",
+			function: phpFunction{
+				Name:       "process_array",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "input", PhpType: "array"},
+				},
+			},
+			contains: []string{
+				"PHP_FUNCTION(process_array)",
+				"zval *input = NULL;",
+				"Z_PARAM_ARRAY(input)",
+				"zend_array *result = process_array(input);",
+				"RETURN_ARR(result)",
+			},
+		},
+		{
+			name: "array function with mixed parameters",
+			function: phpFunction{
+				Name:       "filter_array",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "data", PhpType: "array"},
+					{Name: "key", PhpType: "string"},
+					{Name: "limit", PhpType: "int", HasDefault: true, DefaultValue: "10"},
+				},
+			},
+			contains: []string{
+				"PHP_FUNCTION(filter_array)",
+				"zval *data = NULL;",
+				"zend_string *key = NULL;",
+				"zend_long limit = 10;",
+				"Z_PARAM_ARRAY(data)",
+				"Z_PARAM_STR(key)",
+				"Z_PARAM_LONG(limit)",
+				"ZEND_PARSE_PARAMETERS_START(2, 3)",
+				"Z_PARAM_OPTIONAL",
+			},
+		},
 	}
 
 	generator := PHPFuncGenerator{}
@@ -155,6 +195,28 @@ func TestPHPFunctionGenerator_GenerateParamDeclarations(t *testing.T) {
 				"double rate = 1.5;",
 			},
 		},
+		{
+			name: "array parameter",
+			params: []phpParameter{
+				{Name: "items", PhpType: "array"},
+			},
+			contains: []string{
+				"zval *items = NULL;",
+			},
+		},
+		{
+			name: "mixed types with array",
+			params: []phpParameter{
+				{Name: "name", PhpType: "string"},
+				{Name: "data", PhpType: "array"},
+				{Name: "count", PhpType: "int"},
+			},
+			contains: []string{
+				"zend_string *name = NULL;",
+				"zval *data = NULL;",
+				"zend_long count = 0;",
+			},
+		},
 	}
 
 	parser := ParameterParser{}
@@ -202,6 +264,14 @@ func TestPHPFunctionGenerator_GenerateReturnCode(t *testing.T) {
 			returnType: "float",
 			contains: []string{
 				"RETURN_DOUBLE(result)",
+			},
+		},
+		{
+			name:       "array return",
+			returnType: "array",
+			contains: []string{
+				"RETURN_ARR(result)",
+				"array_init(return_value)",
 			},
 		},
 		{
@@ -268,6 +338,22 @@ func TestPHPFunctionGenerator_GenerateGoCallParams(t *testing.T) {
 				{Name: "rate", PhpType: "float"},
 			},
 			expected: "(int) enabled, (double) rate",
+		},
+		{
+			name: "array parameter",
+			params: []phpParameter{
+				{Name: "data", PhpType: "array"},
+			},
+			expected: "data",
+		},
+		{
+			name: "mixed parameters with array",
+			params: []phpParameter{
+				{Name: "name", PhpType: "string"},
+				{Name: "items", PhpType: "array"},
+				{Name: "count", PhpType: "int"},
+			},
+			expected: "name, items, (long) count",
 		},
 	}
 

--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -96,6 +96,8 @@ PHP_METHOD({{.ClassName}}, {{.PhpName}}) {
     zend_bool {{$param.Name}}_is_null = 0;{{end}}
     {{- else if eq $param.PhpType "array"}}
     zval *{{$param.Name}} = NULL;
+    {{- else if eq $param.PhpType "callable"}}
+    zval *{{$param.Name}}_callback;
     {{- end}}
     {{- end}}
     
@@ -104,7 +106,7 @@ PHP_METHOD({{.ClassName}}, {{.PhpName}}) {
         {{$optionalStarted := false}}{{range .Params}}{{if .HasDefault}}{{if not $optionalStarted -}}
         Z_PARAM_OPTIONAL
         {{$optionalStarted = true}}{{end}}{{end -}}
-        {{if .IsNullable}}{{if eq .PhpType "string"}}Z_PARAM_STR_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "int"}}Z_PARAM_LONG_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "float"}}Z_PARAM_DOUBLE_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "bool"}}Z_PARAM_BOOL_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "array"}}Z_PARAM_ARRAY_OR_NULL({{.Name}}){{end}}{{else}}{{if eq .PhpType "string"}}Z_PARAM_STR({{.Name}}){{else if eq .PhpType "int"}}Z_PARAM_LONG({{.Name}}){{else if eq .PhpType "float"}}Z_PARAM_DOUBLE({{.Name}}){{else if eq .PhpType "bool"}}Z_PARAM_BOOL({{.Name}}){{else if eq .PhpType "array"}}Z_PARAM_ARRAY({{.Name}}){{end}}{{end}}
+        {{if .IsNullable}}{{if eq .PhpType "string"}}Z_PARAM_STR_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "int"}}Z_PARAM_LONG_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "float"}}Z_PARAM_DOUBLE_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "bool"}}Z_PARAM_BOOL_OR_NULL({{.Name}}, {{.Name}}_is_null){{else if eq .PhpType "array"}}Z_PARAM_ARRAY_OR_NULL({{.Name}}){{else if eq .PhpType "callable"}}Z_PARAM_ZVAL_OR_NULL({{.Name}}_callback){{end}}{{else}}{{if eq .PhpType "string"}}Z_PARAM_STR({{.Name}}){{else if eq .PhpType "int"}}Z_PARAM_LONG({{.Name}}){{else if eq .PhpType "float"}}Z_PARAM_DOUBLE({{.Name}}){{else if eq .PhpType "bool"}}Z_PARAM_BOOL({{.Name}}){{else if eq .PhpType "array"}}Z_PARAM_ARRAY({{.Name}}){{else if eq .PhpType "callable"}}Z_PARAM_ZVAL({{.Name}}_callback){{end}}{{end}}
         {{end -}}
     ZEND_PARSE_PARAMETERS_END();
     {{else}}
@@ -113,19 +115,19 @@ PHP_METHOD({{.ClassName}}, {{.PhpName}}) {
     
     {{- if ne .ReturnType "void"}}
     {{- if eq .ReturnType "string"}}
-    zend_string* result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{.Name}}{{end}}{{end}}{{end}});
+    zend_string* result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}{{.Name}}_callback{{end}}{{else}}{{if eq .PhpType "callable"}}{{.Name}}_callback{{else}}{{.Name}}{{end}}{{end}}{{end}}{{end}});
     RETURN_STR(result);
     {{- else if eq .ReturnType "int"}}
-    zend_long result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else}}(long){{.Name}}{{end}}{{end}}{{end}}{{end}});
+    zend_long result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}ZEND_FCI_INITIALIZED({{.Name}}_fci) ? &{{.Name}}_fci : NULL{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}&{{.Name}}_fci{{else}}(long){{.Name}}{{end}}{{end}}{{end}}{{end}});
     RETURN_LONG(result);
     {{- else if eq .ReturnType "float"}}
-    double result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else}}(double){{.Name}}{{end}}{{end}}{{end}}{{end}});
+    double result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}ZEND_FCI_INITIALIZED({{.Name}}_fci) ? &{{.Name}}_fci : NULL{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}&{{.Name}}_fci{{else}}(double){{.Name}}{{end}}{{end}}{{end}}{{end}});
     RETURN_DOUBLE(result);
     {{- else if eq .ReturnType "bool"}}
-    int result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else}}(int){{.Name}}{{end}}{{end}}{{end}}{{end}});
+    int result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}ZEND_FCI_INITIALIZED({{.Name}}_fci) ? &{{.Name}}_fci : NULL{{end}}{{else}}{{if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}&{{.Name}}_fci{{else}}(int){{.Name}}{{end}}{{end}}{{end}}{{end}});
     RETURN_BOOL(result);
     {{- else if eq .ReturnType "array"}}
-    void* result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{.Name}}{{end}}{{end}}{{end}});
+    void* result = {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}ZEND_FCI_INITIALIZED({{.Name}}_fci) ? &{{.Name}}_fci : NULL{{end}}{{else}}{{if eq .PhpType "callable"}}&{{.Name}}_fci{{else}}{{.Name}}{{end}}{{end}}{{end}}{{end}});
     if (result != NULL) {
         HashTable *ht = (HashTable*)result;
         RETURN_ARR(ht);
@@ -134,7 +136,7 @@ PHP_METHOD({{.ClassName}}, {{.PhpName}}) {
     }
     {{- end}}
     {{- else}}
-    {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{else}}{{if eq .PhpType "string"}}{{.Name}}{{else if eq .PhpType "int"}}(long){{.Name}}{{else if eq .PhpType "float"}}(double){{.Name}}{{else if eq .PhpType "bool"}}(int){{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{end}}{{end}}{{end}}{{end}});
+    {{.Name}}_wrapper(intern->go_handle{{if .Params}}{{range .Params}}, {{if .IsNullable}}{{if eq .PhpType "string"}}{{.Name}}_is_null ? NULL : {{.Name}}{{else if eq .PhpType "int"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "float"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "bool"}}{{.Name}}_is_null ? NULL : &{{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}ZEND_FCI_INITIALIZED({{.Name}}_fci) ? &{{.Name}}_fci : NULL{{end}}{{else}}{{if eq .PhpType "string"}}{{.Name}}{{else if eq .PhpType "int"}}(long){{.Name}}{{else if eq .PhpType "float"}}(double){{.Name}}{{else if eq .PhpType "bool"}}(int){{.Name}}{{else if eq .PhpType "array"}}{{.Name}}{{else if eq .PhpType "callable"}}&{{.Name}}_fci{{end}}{{end}}{{end}}{{end}});
     {{- end}}
 }
 {{end}}{{end}}

--- a/internal/extgen/validator.go
+++ b/internal/extgen/validator.go
@@ -47,7 +47,7 @@ func (v *Validator) validateParameter(param phpParameter) error {
 		return fmt.Errorf("invalid parameter name: %s", param.Name)
 	}
 
-	validTypes := []string{"string", "int", "float", "bool", "array", "object", "mixed"}
+	validTypes := []string{"string", "int", "float", "bool", "array", "object", "mixed", "callable"}
 	if !v.isValidType(param.PhpType, validTypes) {
 		return fmt.Errorf("invalid parameter type: %s", param.PhpType)
 	}
@@ -90,7 +90,7 @@ func (v *Validator) validateClassProperty(prop phpClassProperty) error {
 		return fmt.Errorf("invalid property name: %s", prop.Name)
 	}
 
-	validTypes := []string{"string", "int", "float", "bool", "array", "object", "mixed"}
+	validTypes := []string{"string", "int", "float", "bool", "array", "object", "mixed", "callable"}
 	if !v.isValidType(prop.PhpType, validTypes) {
 		return fmt.Errorf("invalid property type: %s", prop.PhpType)
 	}
@@ -109,16 +109,16 @@ func (v *Validator) isValidType(typeStr string, validTypes []string) bool {
 
 // validateScalarTypes checks if PHP signature contains only supported scalar types
 func (v *Validator) validateScalarTypes(fn phpFunction) error {
-	supportedTypes := []string{"string", "int", "float", "bool", "array"}
+	supportedTypes := []string{"string", "int", "float", "bool", "array", "callable"}
 
 	for i, param := range fn.Params {
 		if !v.isScalarType(param.PhpType, supportedTypes) {
-			return fmt.Errorf("parameter %d (%s) has unsupported type '%s'. Only scalar types (string, int, float, bool, array) and their nullable variants are supported", i+1, param.Name, param.PhpType)
+			return fmt.Errorf("parameter %d (%s) has unsupported type '%s'. Only scalar types (string, int, float, bool, array, callable) and their nullable variants are supported", i+1, param.Name, param.PhpType)
 		}
 	}
 
 	if fn.ReturnType != "void" && !v.isScalarType(fn.ReturnType, supportedTypes) {
-		return fmt.Errorf("return type '%s' is not supported. Only scalar types (string, int, float, bool, array), void, and their nullable variants are supported", fn.ReturnType)
+		return fmt.Errorf("return type '%s' is not supported. Only scalar types (string, int, float, bool, array, callable), void, and their nullable variants are supported", fn.ReturnType)
 	}
 
 	return nil
@@ -175,8 +175,10 @@ func (v *Validator) validateGoFunctionSignatureWithOptions(phpFunc phpFunction, 
 		effectiveGoParamCount = goParamCount - 1
 	}
 
-	if len(phpFunc.Params) != effectiveGoParamCount {
-		return fmt.Errorf("parameter count mismatch: PHP function has %d parameters but Go function has %d", len(phpFunc.Params), effectiveGoParamCount)
+	expectedGoParams := len(phpFunc.Params)
+
+	if expectedGoParams != effectiveGoParamCount {
+		return fmt.Errorf("parameter count mismatch: PHP function has %d parameters (expecting %d Go parameters) but Go function has %d", len(phpFunc.Params), expectedGoParams, effectiveGoParamCount)
 	}
 
 	if goFunc.Type.Params != nil && len(phpFunc.Params) > 0 {
@@ -220,11 +222,13 @@ func (v *Validator) phpTypeToGoType(phpType string, isNullable bool) string {
 		baseType = "bool"
 	case "array":
 		baseType = "*C.zval"
+	case "callable":
+		baseType = "*C.zval"
 	default:
 		baseType = "interface{}"
 	}
 
-	if isNullable && phpType != "string" && phpType != "array" {
+	if isNullable && phpType != "string" && phpType != "array" && phpType != "callable" {
 		return "*" + baseType
 	}
 

--- a/internal/extgen/validator_test.go
+++ b/internal/extgen/validator_test.go
@@ -61,6 +61,29 @@ func TestValidateFunction(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid function with callable parameter",
+			function: phpFunction{
+				Name:       "callableFunction",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "data", PhpType: "array"},
+					{Name: "callback", PhpType: "callable"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid function with nullable callable parameter",
+			function: phpFunction{
+				Name:       "nullableCallableFunction",
+				ReturnType: "string",
+				Params: []phpParameter{
+					{Name: "callback", PhpType: "callable", IsNullable: true},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "empty function name",
 			function: phpFunction{
 				Name:       "",
@@ -305,6 +328,23 @@ func TestValidateParameter(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid callable parameter",
+			param: phpParameter{
+				Name:    "callbackParam",
+				PhpType: "callable",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid nullable callable parameter",
+			param: phpParameter{
+				Name:       "nullableCallbackParam",
+				PhpType:    "callable",
+				IsNullable: true,
+			},
+			expectError: false,
+		},
+		{
 			name: "empty parameter name",
 			param: phpParameter{
 				Name:    "",
@@ -485,6 +525,28 @@ func TestValidateScalarTypes(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid callable parameter",
+			function: phpFunction{
+				Name:       "callableFunction",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "callbackParam", PhpType: "callable"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid nullable callable parameter",
+			function: phpFunction{
+				Name:       "nullableCallableFunction",
+				ReturnType: "string",
+				Params: []phpParameter{
+					{Name: "callbackParam", PhpType: "callable", IsNullable: true},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "invalid object parameter",
 			function: phpFunction{
 				Name:       "objectFunction",
@@ -612,7 +674,7 @@ func TestValidateGoFunctionSignature(t *testing.T) {
 }`,
 			},
 			expectError: true,
-			errorMsg:    "parameter count mismatch: PHP function has 2 parameters but Go function has 1",
+			errorMsg:    "parameter count mismatch: PHP function has 2 parameters (expecting 2 Go parameters) but Go function has 1",
 		},
 		{
 			name: "parameter type mismatch",
@@ -718,6 +780,50 @@ func TestValidateGoFunctionSignature(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "valid callable parameter",
+			phpFunc: phpFunction{
+				Name:       "callableFunc",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "callback", PhpType: "callable"},
+				},
+				GoFunction: `func callableFunc(callback *C.zval) unsafe.Pointer {
+	return nil
+}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid nullable callable parameter",
+			phpFunc: phpFunction{
+				Name:       "nullableCallableFunc",
+				ReturnType: "string",
+				Params: []phpParameter{
+					{Name: "callback", PhpType: "callable", IsNullable: true},
+				},
+				GoFunction: `func nullableCallableFunc(callback *C.zval) unsafe.Pointer {
+	return nil
+}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "mixed callable and other parameters",
+			phpFunc: phpFunction{
+				Name:       "mixedCallableFunc",
+				ReturnType: "array",
+				Params: []phpParameter{
+					{Name: "data", PhpType: "array"},
+					{Name: "callback", PhpType: "callable"},
+					{Name: "options", PhpType: "int"},
+				},
+				GoFunction: `func mixedCallableFunc(data *C.zval, callback *C.zval, options int64) unsafe.Pointer {
+	return nil
+}`,
+			},
+			expectError: false,
+		},
 	}
 
 	validator := Validator{}
@@ -751,6 +857,8 @@ func TestPhpTypeToGoType(t *testing.T) {
 		{"bool", true, "*bool"},
 		{"array", false, "*C.zval"},
 		{"array", true, "*C.zval"},
+		{"callable", false, "*C.zval"},
+		{"callable", true, "*C.zval"},
 		{"unknown", false, "interface{}"},
 	}
 

--- a/types.c
+++ b/types.c
@@ -13,3 +13,30 @@ Bucket *get_ht_bucket_data(HashTable *ht, uint32_t index) {
   }
   return NULL;
 }
+
+void *__emalloc__(size_t size) { return emalloc(size); }
+
+void __efree__(void *ptr) { efree(ptr); }
+
+void __zend_hash_init__(HashTable *ht, uint32_t nSize, dtor_func_t pDestructor,
+                        bool persistent) {
+  zend_hash_init(ht, nSize, null, pDestructor, persistent);
+}
+
+int __zend_is_callable__(zval *cb) { return zend_is_callable(cb, 0, NULL); }
+
+int __call_user_function__(zval *function_name, zval *retval,
+                           uint32_t param_count, zval params[]) {
+  return call_user_function(CG(function_table), NULL, function_name, retval,
+                            param_count, params);
+}
+
+void __zval_long__(zval *z, zend_long l) { ZVAL_LONG(z, l); }
+
+void __zval_double__(zval *z, double d) { ZVAL_DOUBLE(z, d); }
+
+void __zval_string__(zval *z, const char *s) { ZVAL_STRING(z, s); }
+
+void __zval_bool__(zval *z, bool b) { ZVAL_BOOL(z, b); }
+
+void __zval_null__(zval *z) { ZVAL_NULL(z); }

--- a/types.c
+++ b/types.c
@@ -1,0 +1,15 @@
+#include "types.h"
+
+zval *get_ht_packed_data(HashTable *ht, uint32_t index) {
+  if (ht->u.flags & HASH_FLAG_PACKED) {
+    return &ht->arPacked[index];
+  }
+  return NULL;
+}
+
+Bucket *get_ht_bucket_data(HashTable *ht, uint32_t index) {
+  if (!(ht->u.flags & HASH_FLAG_PACKED)) {
+    return &ht->arData[index];
+  }
+  return NULL;
+}

--- a/types.go
+++ b/types.go
@@ -2,14 +2,6 @@ package frankenphp
 
 /*
 #include "types.h"
-
-static inline void* __emalloc(size_t size) {
-    return emalloc(size);
-}
-
-static inline void __zend_hash_init(HashTable *ht, uint32_t nSize, dtor_func_t pDestructor, bool persistent) {
-    zend_hash_init(ht, nSize, null, pDestructor, persistent);
-}
 */
 import "C"
 import "unsafe"
@@ -189,6 +181,43 @@ func PHPArray(arr *Array) unsafe.Pointer {
 	return unsafe.Pointer(zendArray)
 }
 
+// EXPERIMENTAL: CallPHPCallable executes a PHP callable with the given parameters.
+// Returns the result of the callable as a Go interface{}, or nil if the call failed.
+func CallPHPCallable(cb unsafe.Pointer, params []interface{}) interface{} {
+	if cb == nil {
+		return nil
+	}
+
+	callback := (*C.zval)(cb)
+	if callback == nil {
+		return nil
+	}
+
+	if C.__zend_is_callable__(callback) == 0 {
+		return nil
+	}
+
+	paramCount := len(params)
+	var paramStorage *C.zval
+	if paramCount > 0 {
+		paramStorage = (*C.zval)(C.__emalloc__(C.size_t(paramCount) * C.size_t(unsafe.Sizeof(C.zval{}))))
+		defer C.__efree__(unsafe.Pointer(paramStorage))
+
+		for i, param := range params {
+			setGoValueToZval((*C.zval)(unsafe.Pointer(uintptr(unsafe.Pointer(paramStorage))+uintptr(i)*unsafe.Sizeof(C.zval{}))), param)
+		}
+	}
+
+	var retval C.zval
+
+	result := C.__call_user_function__(callback, &retval, C.uint32_t(paramCount), paramStorage)
+	if result != C.SUCCESS {
+		return nil
+	}
+
+	return convertZvalToGo(&retval)
+}
+
 // convertZvalToGo converts a PHP zval to a Go interface{}
 func convertZvalToGo(zval *C.zval) interface{} {
 	t := C.zval_get_type(zval)
@@ -224,47 +253,44 @@ func convertZvalToGo(zval *C.zval) interface{} {
 	}
 }
 
-// convertGoToZval converts a Go interface{} to a PHP zval
-func convertGoToZval(value interface{}) *C.zval {
-	zval := (*C.zval)(C.__emalloc(C.size_t(unsafe.Sizeof(C.zval{}))))
-	u1 := (*C.uint8_t)(unsafe.Pointer(&zval.u1[0]))
-	v0 := unsafe.Pointer(&zval.value[0])
-
+// setGoValueToZval sets a Go value to an existing zval using PHP macros
+func setGoValueToZval(zval *C.zval, value interface{}) {
 	switch v := value.(type) {
 	case nil:
-		*u1 = C.IS_NULL
+		C.__zval_null__(zval)
 	case bool:
-		if v {
-			*u1 = C.IS_TRUE
-		} else {
-			*u1 = C.IS_FALSE
-		}
+		C.__zval_bool__(zval, C._Bool(v))
 	case int:
-		*u1 = C.IS_LONG
-		*(*C.zend_long)(v0) = C.zend_long(v)
+		C.__zval_long__(zval, C.zend_long(v))
 	case int64:
-		*u1 = C.IS_LONG
-		*(*C.zend_long)(v0) = C.zend_long(v)
+		C.__zval_long__(zval, C.zend_long(v))
 	case float64:
-		*u1 = C.IS_DOUBLE
-		*(*C.double)(v0) = C.double(v)
+		C.__zval_double__(zval, C.double(v))
 	case string:
-		*u1 = C.IS_STRING
-		*(**C.zend_string)(v0) = (*C.zend_string)(PHPString(v, false))
+		cstr := C.CString(v)
+		defer C.free(unsafe.Pointer(cstr))
+		C.__zval_string__(zval, cstr)
 	case *Array:
+		u1 := (*C.uint8_t)(unsafe.Pointer(&zval.u1[0]))
+		v0 := unsafe.Pointer(&zval.value[0])
 		*u1 = C.IS_ARRAY
 		*(**C.zend_array)(v0) = (*C.zend_array)(PHPArray(v))
 	default:
-		*u1 = C.IS_NULL
+		C.__zval_null__(zval)
 	}
+}
 
+// convertGoToZval converts a Go interface{} to a PHP zval (allocates memory)
+func convertGoToZval(value interface{}) *C.zval {
+	zval := (*C.zval)(C.__emalloc__(C.size_t(unsafe.Sizeof(C.zval{}))))
+	setGoValueToZval(zval, value)
 	return zval
 }
 
 // createNewArray creates a new zend_array with the specified size.
 func createNewArray(size uint32) *C.HashTable {
-	ht := C.__emalloc(C.size_t(unsafe.Sizeof(C.HashTable{})))
-	C.__zend_hash_init((*C.struct__zend_array)(ht), C.uint32_t(size), nil, C._Bool(false))
+	ht := C.__emalloc__(C.size_t(unsafe.Sizeof(C.HashTable{})))
+	C.__zend_hash_init__((*C.struct__zend_array)(ht), C.uint32_t(size), nil, C._Bool(false))
 
 	return (*C.HashTable)(ht)
 }

--- a/types.go
+++ b/types.go
@@ -1,6 +1,16 @@
 package frankenphp
 
-//#include <zend.h>
+/*
+#include "types.h"
+
+static inline void* __emalloc(size_t size) {
+    return emalloc(size);
+}
+
+static inline void __zend_hash_init(HashTable *ht, uint32_t nSize, dtor_func_t pDestructor, bool persistent) {
+    zend_hash_init(ht, nSize, null, pDestructor, persistent);
+}
+*/
 import "C"
 import "unsafe"
 
@@ -30,4 +40,260 @@ func PHPString(s string, persistent bool) unsafe.Pointer {
 	)
 
 	return unsafe.Pointer(zendStr)
+}
+
+// PHPKeyType represents the type of PHP hashmap key
+type PHPKeyType int
+
+const (
+	PHPIntKey PHPKeyType = iota
+	PHPStringKey
+)
+
+type PHPKey struct {
+	Type PHPKeyType
+	Str  string
+	Int  int64
+}
+
+// Array represents a PHP array with ordered key-value pairs
+type Array struct {
+	keys   []PHPKey
+	values []interface{}
+}
+
+// SetInt sets a value with an integer key
+func (arr *Array) SetInt(key int64, value interface{}) {
+	arr.keys = append(arr.keys, PHPKey{Type: PHPIntKey, Int: key})
+	arr.values = append(arr.values, value)
+}
+
+// SetString sets a value with a string key
+func (arr *Array) SetString(key string, value interface{}) {
+	arr.keys = append(arr.keys, PHPKey{Type: PHPStringKey, Str: key})
+	arr.values = append(arr.values, value)
+}
+
+// Append adds a value to the end of the array with the next available integer key
+func (arr *Array) Append(value interface{}) {
+	nextKey := arr.getNextIntKey()
+	arr.SetInt(nextKey, value)
+}
+
+// getNextIntKey finds the next available integer key
+func (arr *Array) getNextIntKey() int64 {
+	maxKey := int64(-1)
+	for _, key := range arr.keys {
+		if key.Type == PHPIntKey && key.Int > maxKey {
+			maxKey = key.Int
+		}
+	}
+
+	return maxKey + 1
+}
+
+// Len returns the number of elements in the array
+func (arr *Array) Len() uint32 {
+	return uint32(len(arr.keys))
+}
+
+// At returns the key and value at the given index
+func (arr *Array) At(index uint32) (PHPKey, interface{}) {
+	if index >= uint32(len(arr.keys)) {
+		return PHPKey{}, nil
+	}
+	return arr.keys[index], arr.values[index]
+}
+
+// EXPERIMENTAL: GoArray converts a zend_array to a Go Array
+func GoArray(arr unsafe.Pointer) *Array {
+	result := &Array{
+		keys:   make([]PHPKey, 0),
+		values: make([]interface{}, 0),
+	}
+
+	if arr == nil {
+		return result
+	}
+
+	zval := (*C.zval)(arr)
+	hashTable := (*C.HashTable)(castZval(zval, C.IS_ARRAY))
+
+	if hashTable == nil {
+		return result
+	}
+
+	used := hashTable.nNumUsed
+	if htIsPacked(hashTable) {
+		for i := C.uint32_t(0); i < used; i++ {
+			v := C.get_ht_packed_data(hashTable, i)
+			if v != nil && C.zval_get_type(v) != C.IS_UNDEF {
+				value := convertZvalToGo(v)
+				result.SetInt(int64(i), value)
+			}
+		}
+	} else {
+		for i := C.uint32_t(0); i < used; i++ {
+			bucket := C.get_ht_bucket_data(hashTable, i)
+			if bucket != nil && C.zval_get_type(&bucket.val) != C.IS_UNDEF {
+				v := convertZvalToGo(&bucket.val)
+
+				if bucket.key != nil {
+					keyStr := GoString(unsafe.Pointer(bucket.key))
+					result.SetString(keyStr, v)
+				} else {
+					result.SetInt(int64(bucket.h), v)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// PHPArray converts a Go Array to a PHP zend_array.
+func PHPArray(arr *Array) unsafe.Pointer {
+	if arr == nil || arr.Len() == 0 {
+		return unsafe.Pointer(createNewArray(0))
+	}
+
+	isList := true
+	for i, k := range arr.keys {
+		if k.Type != PHPIntKey || k.Int != int64(i) {
+			isList = false
+			break
+		}
+	}
+
+	var zendArray *C.HashTable
+	if isList {
+		zendArray = createNewArray(arr.Len())
+		for _, v := range arr.values {
+			zval := convertGoToZval(v)
+			C.zend_hash_next_index_insert(zendArray, zval)
+		}
+	} else {
+		zendArray = createNewArray(arr.Len())
+		for i, k := range arr.keys {
+			zval := convertGoToZval(arr.values[i])
+
+			if k.Type == PHPStringKey {
+				keyStr := PHPString(k.Str, false)
+				C.zend_hash_update(zendArray, (*C.zend_string)(keyStr), zval)
+			} else {
+				C.zend_hash_index_update(zendArray, C.zend_ulong(k.Int), zval)
+			}
+		}
+	}
+
+	return unsafe.Pointer(zendArray)
+}
+
+// convertZvalToGo converts a PHP zval to a Go interface{}
+func convertZvalToGo(zval *C.zval) interface{} {
+	t := C.zval_get_type(zval)
+	switch t {
+	case C.IS_NULL:
+		return nil
+	case C.IS_FALSE:
+		return false
+	case C.IS_TRUE:
+		return true
+	case C.IS_LONG:
+		longPtr := (*C.zend_long)(castZval(zval, C.IS_LONG))
+		if longPtr != nil {
+			return int64(*longPtr)
+		}
+		return int64(0)
+	case C.IS_DOUBLE:
+		doublePtr := (*C.double)(castZval(zval, C.IS_DOUBLE))
+		if doublePtr != nil {
+			return float64(*doublePtr)
+		}
+		return float64(0)
+	case C.IS_STRING:
+		str := (*C.zend_string)(castZval(zval, C.IS_STRING))
+		if str != nil {
+			return GoString(unsafe.Pointer(str))
+		}
+		return ""
+	case C.IS_ARRAY:
+		return GoArray(unsafe.Pointer(zval))
+	default:
+		return nil
+	}
+}
+
+// convertGoToZval converts a Go interface{} to a PHP zval
+func convertGoToZval(value interface{}) *C.zval {
+	zval := (*C.zval)(C.__emalloc(C.size_t(unsafe.Sizeof(C.zval{}))))
+	u1 := (*C.uint8_t)(unsafe.Pointer(&zval.u1[0]))
+	v0 := unsafe.Pointer(&zval.value[0])
+
+	switch v := value.(type) {
+	case nil:
+		*u1 = C.IS_NULL
+	case bool:
+		if v {
+			*u1 = C.IS_TRUE
+		} else {
+			*u1 = C.IS_FALSE
+		}
+	case int:
+		*u1 = C.IS_LONG
+		*(*C.zend_long)(v0) = C.zend_long(v)
+	case int64:
+		*u1 = C.IS_LONG
+		*(*C.zend_long)(v0) = C.zend_long(v)
+	case float64:
+		*u1 = C.IS_DOUBLE
+		*(*C.double)(v0) = C.double(v)
+	case string:
+		*u1 = C.IS_STRING
+		*(**C.zend_string)(v0) = (*C.zend_string)(PHPString(v, false))
+	case *Array:
+		*u1 = C.IS_ARRAY
+		*(**C.zend_array)(v0) = (*C.zend_array)(PHPArray(v))
+	default:
+		*u1 = C.IS_NULL
+	}
+
+	return zval
+}
+
+// createNewArray creates a new zend_array with the specified size.
+func createNewArray(size uint32) *C.HashTable {
+	ht := C.__emalloc(C.size_t(unsafe.Sizeof(C.HashTable{})))
+	C.__zend_hash_init((*C.struct__zend_array)(ht), C.uint32_t(size), nil, C._Bool(false))
+
+	return (*C.HashTable)(ht)
+}
+
+// htIsPacked checks if a HashTable is a list (packed) or hashmap (not packed).
+func htIsPacked(ht *C.HashTable) bool {
+	flags := *(*C.uint32_t)(unsafe.Pointer(&ht.u[0]))
+
+	return (flags & C.HASH_FLAG_PACKED) != 0
+}
+
+// castZval casts a zval to the expected type and returns a pointer to the value
+func castZval(zval *C.zval, expectedType C.uint8_t) unsafe.Pointer {
+	if zval == nil || C.zval_get_type(zval) != expectedType {
+		return nil
+	}
+
+	v := unsafe.Pointer(&zval.value[0])
+
+	switch expectedType {
+	case C.IS_LONG:
+		return v
+	case C.IS_DOUBLE:
+		return v
+	case C.IS_STRING:
+		return unsafe.Pointer(*(**C.zend_string)(v))
+	case C.IS_ARRAY:
+		return unsafe.Pointer(*(**C.zend_array)(v))
+	default:
+		return nil
+	}
 }

--- a/types.h
+++ b/types.h
@@ -1,0 +1,13 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <zend.h>
+#include <zend_API.h>
+#include <zend_alloc.h>
+#include <zend_hash.h>
+#include <zend_types.h>
+
+zval *get_ht_packed_data(HashTable *, uint32_t index);
+Bucket *get_ht_bucket_data(HashTable *, uint32_t index);
+
+#endif

--- a/types.h
+++ b/types.h
@@ -10,4 +10,19 @@
 zval *get_ht_packed_data(HashTable *, uint32_t index);
 Bucket *get_ht_bucket_data(HashTable *, uint32_t index);
 
+void *__emalloc__(size_t size);
+void __efree__(void *ptr);
+void __zend_hash_init__(HashTable *ht, uint32_t nSize, dtor_func_t pDestructor,
+                        bool persistent);
+
+int __zend_is_callable__(zval *cb);
+int __call_user_function__(zval *function_name, zval *retval,
+                           uint32_t param_count, zval params[]);
+
+void __zval_long__(zval *z, zend_long l);
+void __zval_double__(zval *z, double d);
+void __zval_string__(zval *z, const char *s);
+void __zval_bool__(zval *z, bool b);
+void __zval_null__(zval *z);
+
 #endif


### PR DESCRIPTION
Depends on https://github.com/php/frankenphp/pull/1724

Allows to write such code:

```go
// export_php:function my_array_map(array $data, callable $callback): array
func my_array_map(arr *C.zval, callback *C.zval) unsafe.Pointer {
	goArr := frankenphp.GoArray(unsafe.Pointer(arr))
	result := &frankenphp.Array{}

	for i := uint32(0); i < goArr.Len(); i++ {
		key, value := goArr.At(i)

		callbackResult := frankenphp.CallPHPCallable(unsafe.Pointer(callback), []interface{}{value})

		if key.Type == frankenphp.PHPIntKey {
			result.SetInt(key.Int, callbackResult)
		} else {
			result.SetString(key.Str, callbackResult)
		}
	}

	return frankenphp.PHPArray(result)
}
```

```php
$strArray = ['a' => 'hello', 'b' => 'world', 'c' => 'php'];
var_dump(my_array_map($strArray, 'strtoupper'));

$arr = [1, 2, 3, 4, [5, 6]];
var_dump(my_array_map($arr, function($item) {
    if (is_array($item)) {
        return my_array_map($item, function($subItem) {
            return $subItem * 2;
        });
    }

    return $item * 3;
}));

/*
Output:

array(3) {
  ["a"]=>
  string(5) "HELLO"
  ["b"]=>
  string(5) "WORLD"
  ["c"]=>
  string(3) "PHP"
}
array(5) {
  [0]=>
  int(3)
  [1]=>
  int(6)
  [2]=>
  int(9)
  [3]=>
  int(12)
  [4]=>
  array(2) {
    [0]=>
    int(10)
    [1]=>
    int(12)
  }
}
*/
```

TODO: fix support on methods