### PR TITLE
remove system include locations from frankenphp.go

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -14,15 +14,15 @@ package frankenphp
 
 // #cgo nocallback frankenphp_update_server_context
 // #cgo noescape frankenphp_update_server_context
-// #cgo !nosysinc darwin pkg-config: libxml-2.0
+// #cgo !nosys darwin pkg-config: libxml-2.0
 // #cgo CFLAGS: -Wall -Werror
-// #cgo !nosysinc CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
+// #cgo !nosys CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
 // #cgo linux CFLAGS: -D_GNU_SOURCE
-// #cgo !nosysinc darwin CFLAGS: -I/opt/homebrew/include
-// #cgo !nosysinc LDFLAGS: -L/usr/local/lib -L/usr/lib
+// #cgo !nosys darwin CFLAGS: -I/opt/homebrew/include
+// #cgo !nosys LDFLAGS: -L/usr/local/lib -L/usr/lib
 // #cgo LDFLAGS: -lphp -lm -lutil
 // #cgo linux LDFLAGS: -ldl -lresolv
-// #cgo !nosysinc darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
+// #cgo !nosys darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
 // #cgo darwin LDFLAGS: -liconv -ldl
 // #include <stdlib.h>
 // #include <stdint.h>

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -14,14 +14,16 @@ package frankenphp
 
 // #cgo nocallback frankenphp_update_server_context
 // #cgo noescape frankenphp_update_server_context
-// #cgo darwin pkg-config: libxml-2.0
+// #cgo !nosys darwin pkg-config: libxml-2.0
 // #cgo CFLAGS: -Wall -Werror
-// #cgo CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
+// #cgo !nosys CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
 // #cgo linux CFLAGS: -D_GNU_SOURCE
-// #cgo darwin CFLAGS: -I/opt/homebrew/include
-// #cgo LDFLAGS: -L/usr/local/lib -L/usr/lib -lphp -lm -lutil
+// #cgo !nosys darwin CFLAGS: -I/opt/homebrew/include
+// #cgo !nosys LDFLAGS: -L/usr/local/lib -L/usr/lib
+// #cgo LDFLAGS: -lphp -lm -lutil
 // #cgo linux LDFLAGS: -ldl -lresolv
-// #cgo darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib -liconv -ldl
+// #cgo !nosys darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
+// #cgo darwin LDFLAGS: -liconv -ldl
 // #include <stdlib.h>
 // #include <stdint.h>
 // #include <php_variables.h>

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -19,7 +19,7 @@ package frankenphp
 // #cgo linux CFLAGS: -D_GNU_SOURCE
 // #cgo LDFLAGS: -lphp -lm -lutil
 // #cgo linux LDFLAGS: -ldl -lresolv
-// #cgo darwin LDFLAGS: -liconv -ldl
+// #cgo darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -liconv -ldl
 // #include <stdlib.h>
 // #include <stdint.h>
 // #include <php_variables.h>

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -14,15 +14,15 @@ package frankenphp
 
 // #cgo nocallback frankenphp_update_server_context
 // #cgo noescape frankenphp_update_server_context
-// #cgo !nosys darwin pkg-config: libxml-2.0
+// #cgo !nosysinc darwin pkg-config: libxml-2.0
 // #cgo CFLAGS: -Wall -Werror
-// #cgo !nosys CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
+// #cgo !nosysinc CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
 // #cgo linux CFLAGS: -D_GNU_SOURCE
-// #cgo !nosys darwin CFLAGS: -I/opt/homebrew/include
-// #cgo !nosys LDFLAGS: -L/usr/local/lib -L/usr/lib
+// #cgo !nosysinc darwin CFLAGS: -I/opt/homebrew/include
+// #cgo !nosysinc LDFLAGS: -L/usr/local/lib -L/usr/lib
 // #cgo LDFLAGS: -lphp -lm -lutil
 // #cgo linux LDFLAGS: -ldl -lresolv
-// #cgo !nosys darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
+// #cgo !nosysinc darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
 // #cgo darwin LDFLAGS: -liconv -ldl
 // #include <stdlib.h>
 // #include <stdint.h>

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -14,15 +14,11 @@ package frankenphp
 
 // #cgo nocallback frankenphp_update_server_context
 // #cgo noescape frankenphp_update_server_context
-// #cgo !nosys darwin pkg-config: libxml-2.0
+// #cgo darwin pkg-config: libxml-2.0
 // #cgo CFLAGS: -Wall -Werror
-// #cgo !nosys CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
 // #cgo linux CFLAGS: -D_GNU_SOURCE
-// #cgo !nosys darwin CFLAGS: -I/opt/homebrew/include
-// #cgo !nosys LDFLAGS: -L/usr/local/lib -L/usr/lib
 // #cgo LDFLAGS: -lphp -lm -lutil
 // #cgo linux LDFLAGS: -ldl -lresolv
-// #cgo !nosys darwin LDFLAGS: -Wl,-rpath,/usr/local/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/libiconv/lib
 // #cgo darwin LDFLAGS: -liconv -ldl
 // #include <stdlib.h>
 // #include <stdint.h>


### PR DESCRIPTION
closes #https://github.com/php/frankenphp/issues/1727

Edit: explanation: adds an arbitrarily named "nosys" tag. When passed as a tag, it means that the frankenphp.go source code does not define include paths to /usr/include and ldflag path to /usr/lib.

When the tag isn't passed, as to not break people's builds, nothing changes.