### PR TITLE
Fix: Allows headers without whitespace after colon.

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -505,7 +505,7 @@ func splitRawHeader(rawHeader *C.char, length int) (string, string) {
 		return "", "" // No colon found, invalid header
 	}
 
-	key := C.GoStringN(rawHeader, C.int(i))
+	headerKey := C.GoStringN(rawHeader, C.int(i))
 
 	// skip whitespaces after the colon
 	j := i + 1
@@ -514,11 +514,10 @@ func splitRawHeader(rawHeader *C.char, length int) (string, string) {
 	}
 
 	// anything left is the header value
-	valueLen := length - j
 	valuePtr := (*C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(rawHeader)) + uintptr(j)))
-	value := C.GoStringN(valuePtr, C.int(valueLen))
+	headerValue := C.GoStringN(valuePtr, C.int(length-j))
 
-	return key, value
+	return headerKey, headerValue
 }
 
 //export go_write_headers

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -242,6 +242,7 @@ func testHeaders(t *testing.T, opts *testOptions) {
 		assert.Equal(t, 201, resp.StatusCode)
 		assert.Equal(t, "bar", resp.Header.Get("Foo"))
 		assert.Equal(t, "bar2", resp.Header.Get("Foo2"))
+		assert.Equal(t, "bar3", resp.Header.Get("Foo3"), "header without whitespace after colon")
 		assert.Empty(t, resp.Header.Get("Invalid"))
 		assert.Equal(t, fmt.Sprintf("%d", i), resp.Header.Get("I"))
 	}, opts)

--- a/testdata/headers.php
+++ b/testdata/headers.php
@@ -5,6 +5,7 @@ require_once __DIR__.'/_executor.php';
 return function () {
     header('Foo: bar');
     header('Foo2: bar2');
+    header('Foo3:bar3'); // no space after colon (also valid, not recommended)
     header('Invalid');
     header('I: ' . ($_GET['i'] ?? 'i not set'));
     http_response_code(201);


### PR DESCRIPTION
Fixes #1738

[rfc7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2) apparently doesn't explicitly disallow headers without a whitespace after the colon.

This PR allows both ways of calling the PHP ´header` function, since apparently FPM/nginx also allows them: 

```php
header('Content-Type: application/json'); # well formed, currently forwarded
header('Content-Type:application/json'); # not well formed, but still valid and currently not forwarded
```