### PR TITLE
chore: add support for GITHUB_TOKEN in static-builder-gnu

### DIFF
--- a/static-builder-gnu.Dockerfile
+++ b/static-builder-gnu.Dockerfile
@@ -160,8 +160,7 @@ COPY --link internal internal
 COPY --link package package
 
 RUN --mount=type=secret,id=github-token \
-	set -eux; \
-	./build-static.sh && \
+	GITHUB_TOKEN=$(cat /run/secrets/github-token) ./build-static.sh && \
 	if [ -n "${BUILD_PACKAGES}" ]; then \
 		./build-packages.sh; \
 	fi; \

--- a/static-builder-musl.Dockerfile
+++ b/static-builder-musl.Dockerfile
@@ -99,5 +99,6 @@ ENV SPC_OPT_BUILD_ARGS='--with-config-file-path=/etc/frankenphp --with-config-fi
 ENV SPC_REL_TYPE='binary'
 ENV EXTENSION_DIR='/usr/lib/frankenphp/modules'
 
-RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./build-static.sh && \
+RUN --mount=type=secret,id=github-token \
+	GITHUB_TOKEN=$(cat /run/secrets/github-token) ./build-static.sh && \
 	rm -Rf dist/static-php-cli/source/*


### PR DESCRIPTION
The token wasn't passed, causing some builds to fail because of GitHub's rate limiting.