### PR TITLE
fix: dev docker image build

### DIFF
--- a/dev-alpine.Dockerfile
+++ b/dev-alpine.Dockerfile
@@ -79,7 +79,9 @@ WORKDIR /go/src/app
 COPY . .
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN go build
+RUN export CGO_CFLAGS="$(php-config --includes)" && \
+	export CGO_LDFLAGS="$(php-config --ldflags)" && \
+	go build
 
 WORKDIR /go/src/app
 CMD [ "zsh" ]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -83,7 +83,9 @@ WORKDIR /go/src/app
 COPY --link . ./
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN ../../go.sh build -buildvcs=false
+RUN export CGO_CFLAGS="$(php-config --includes)" && \
+	export CGO_LDFLAGS="$(php-config --ldflags)" && \
+	 ../../go.sh build -buildvcs=false
 
 WORKDIR /go/src/app
 CMD [ "zsh" ]


### PR DESCRIPTION
This fixes the dev docker images according to https://frankenphp.dev/docs/compile/#using-xcaddy (the env vars are now required when building since 1.9)