### PR TITLE
feat: frankenphp_info

### DIFF
--- a/debugstate.go
+++ b/debugstate.go
@@ -1,5 +1,11 @@
 package frankenphp
 
+// #include "frankenphp.h"
+import "C"
+import (
+	"unsafe"
+)
+
 // EXPERIMENTAL: ThreadDebugState prints the state of a single PHP thread - debugging purposes only
 type ThreadDebugState struct {
 	Index                    int
@@ -43,4 +49,23 @@ func threadDebugState(thread *phpThread) ThreadDebugState {
 		IsBusy:                   !thread.state.isInWaitingState(),
 		WaitingSinceMilliseconds: thread.state.waitTime(),
 	}
+}
+
+// EXPERIMENTAL: Expose the current thread's information to PHP
+//
+//export go_frankenphp_info
+func go_frankenphp_info(threadIndex C.uintptr_t) unsafe.Pointer {
+	thread := phpThreads[threadIndex]
+	return PHPArray(&Array{
+		keys: []PHPKey{
+			PHPKey{Type: PHPStringKey, Str: "thread_name"},
+			PHPKey{Type: PHPStringKey, Str: "thread_index"},
+			PHPKey{Type: PHPStringKey, Str: "is_worker"},
+		},
+		values: []interface{}{
+			thread.name(),
+			int(threadIndex),
+			thread.handler.(*workerThread) != nil,
+		},
+	})
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1221,9 +1221,5 @@ PHP_FUNCTION(frankenphp_info) {
   }
 
   zend_array *result = go_frankenphp_info(thread_index);
-  if (result) {
-    RETURN_ARR(result);
-  }
-
-  RETURN_EMPTY_ARRAY();
+  RETURN_ARR(result);
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1213,3 +1213,18 @@ void register_extensions(zend_module_entry *m, int len) {
       php_register_internal_extensions_func;
   php_register_internal_extensions_func = register_internal_extensions;
 }
+
+/* EXPERIMENTAL */
+PHP_FUNCTION(frankenphp_info)
+{
+	if (zend_parse_parameters_none() == FAILURE) {
+        RETURN_THROWS();
+    }
+
+	zend_array *result = go_frankenphp_info(thread_index);
+    if (result) {
+        RETURN_ARR(result);
+    }
+
+    RETURN_EMPTY_ARRAY();
+}

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1215,16 +1215,15 @@ void register_extensions(zend_module_entry *m, int len) {
 }
 
 /* EXPERIMENTAL */
-PHP_FUNCTION(frankenphp_info)
-{
-	if (zend_parse_parameters_none() == FAILURE) {
-        RETURN_THROWS();
-    }
+PHP_FUNCTION(frankenphp_info) {
+  if (zend_parse_parameters_none() == FAILURE) {
+    RETURN_THROWS();
+  }
 
-	zend_array *result = go_frankenphp_info(thread_index);
-    if (result) {
-        RETURN_ARR(result);
-    }
+  zend_array *result = go_frankenphp_info(thread_index);
+  if (result) {
+    RETURN_ARR(result);
+  }
 
-    RETURN_EMPTY_ARRAY();
+  RETURN_EMPTY_ARRAY();
 }

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -32,3 +32,4 @@ function frankenphp_response_headers(): array|bool {}
  */
 function apache_response_headers(): array|bool {}
 
+function frankenphp_info(): array {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -30,8 +30,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_apache_response_headers arginfo_frankenphp_response_headers
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_info, 0, 0,
-                                        IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_info, 0, 0, IS_ARRAY,
+                                        0)
 ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(frankenphp_handle_request);

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -30,11 +30,16 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_apache_response_headers arginfo_frankenphp_response_headers
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_info, 0, 0,
+                                        IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(headers_send);
 ZEND_FUNCTION(frankenphp_finish_request);
 ZEND_FUNCTION(frankenphp_request_headers);
 ZEND_FUNCTION(frankenphp_response_headers);
+ZEND_FUNCTION(frankenphp_info);
 
 // clang-format off
 static const zend_function_entry ext_functions[] = {
@@ -47,6 +52,7 @@ static const zend_function_entry ext_functions[] = {
   ZEND_FALIAS(getallheaders, frankenphp_request_headers, arginfo_getallheaders)
   ZEND_FE(frankenphp_response_headers, arginfo_frankenphp_response_headers)
   ZEND_FALIAS(apache_response_headers, frankenphp_response_headers, arginfo_apache_response_headers)
+  ZEND_FE(frankenphp_info, arginfo_frankenphp_info)
   ZEND_FE_END
 };
 // clang-format on


### PR DESCRIPTION
This PR is inspired by some discussions like #1743. It's currently often not trivial to determine if a PHP request is running in worker mode or to generally access info about FrankenPHP from the PHP side.

This PR adds a `frankenphp_info()` function to retrieve debug info as an array from the PHP side. Still not sure about all the information that could be relevant.

The extension generator definitely helped building this function 👍 (assuming `PHPArray` can be safely used already)