### PR TITLE
check if caddy http app fails to provision due to not configured or i…

### DIFF
--- a/caddy/app.go
+++ b/caddy/app.go
@@ -62,7 +62,12 @@ func (f *FrankenPHPApp) Provision(ctx caddy.Context) error {
 		}
 	} else {
 		// if the http module is not configured (this should never happen) then collect the metrics by default
-		f.metrics = frankenphp.NewPrometheusMetrics(ctx.GetMetricsRegistry())
+		if errors.Is(err, caddy.ErrNotConfigured) {
+			f.metrics = frankenphp.NewPrometheusMetrics(ctx.GetMetricsRegistry())
+		} else {
+			// the http module failed to provision due to invalid configuration
+			return fmt.Errorf("failed to provision caddy http: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
…nvalid configuration

Fix [801](https://github.com/dunglas/symfony-docker/issues/801).