### PR TITLE
extgen: Add support for init/minit/mshutdown

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -272,25 +272,27 @@ This design ensures that your Go code has complete control over how the object's
 The generator supports defining module initialization and shutdown functions using the `//export_php:module` directive.
 This allows you to perform setup and cleanup operations when your extension is loaded and unloaded.
 
-```go
-//export_php:module init=initializeModule, shutdown=cleanupModule
-```
-
-The `init` parameter specifies a function that will be called when the module is initialized, and the `shutdown` parameter specifies a function that will be called when the module is shut down. Both parameters are optional; you can specify either one, both, or none.
-
-The specified functions should be defined in your Go code:
+To define an initialization function, tag it with `//export_php:module init`:
 
 ```go
+//export_php:module init
 func initializeModule() {
-// Perform initialization tasks
-// For example, set up global resources, initialize data structures, etc.
-}
-
-func cleanupModule() {
-// Perform cleanup tasks
-// For example, free resources, close connections, etc.
+    // Perform initialization tasks
+    // For example, set up global resources, initialize data structures, etc.
 }
 ```
+
+To define a shutdown function, tag it with `//export_php:module shutdown`:
+
+```go
+//export_php:module shutdown
+func cleanupModule() {
+    // Perform cleanup tasks
+    // For example, free resources, close connections, etc.
+}
+```
+
+You can define either one, both, or none of these functions. The initialization function will be called when the PHP module is loaded, and the shutdown function will be called when the PHP module is unloaded.
 
 ### Declaring Constants
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -267,6 +267,31 @@ $user->updateInfo(null, 25, null);          // Name and active are null
 
 This design ensures that your Go code has complete control over how the object's state is accessed and modified, providing better encapsulation and type safety.
 
+### Module Initialization and Shutdown
+
+The generator supports defining module initialization and shutdown functions using the `//export_php:module` directive.
+This allows you to perform setup and cleanup operations when your extension is loaded and unloaded.
+
+```go
+//export_php:module init=initializeModule, shutdown=cleanupModule
+```
+
+The `init` parameter specifies a function that will be called when the module is initialized, and the `shutdown` parameter specifies a function that will be called when the module is shut down. Both parameters are optional; you can specify either one, both, or none.
+
+The specified functions should be defined in your Go code:
+
+```go
+func initializeModule() {
+// Perform initialization tasks
+// For example, set up global resources, initialize data structures, etc.
+}
+
+func cleanupModule() {
+// Perform cleanup tasks
+// For example, free resources, close connections, etc.
+}
+```
+
 ### Declaring Constants
 
 The generator supports exporting Go constants to PHP using two directives: `//export_php:const` for global constants and `//export_php:classconstant` for class constants. This allows you to share configuration values, status codes, and other constants between Go and PHP code.

--- a/internal/extgen/cfile.go
+++ b/internal/extgen/cfile.go
@@ -23,6 +23,7 @@ type cTemplateData struct {
 	Classes   []phpClass
 	Constants []phpConstant
 	Namespace string
+	Module    *phpModule
 }
 
 func (cg *cFileGenerator) generate() error {
@@ -68,6 +69,7 @@ func (cg *cFileGenerator) getTemplateContent() (string, error) {
 		Classes:   cg.generator.Classes,
 		Constants: cg.generator.Constants,
 		Namespace: cg.generator.Namespace,
+		Module:    cg.generator.Module,
 	}); err != nil {
 		return "", err
 	}

--- a/internal/extgen/generator.go
+++ b/internal/extgen/generator.go
@@ -15,6 +15,7 @@ type Generator struct {
 	Classes    []phpClass
 	Constants  []phpConstant
 	Namespace  string
+	Module     *phpModule
 }
 
 // EXPERIMENTAL
@@ -85,6 +86,12 @@ func (g *Generator) parseSource() error {
 		return fmt.Errorf("parsing namespace: %w", err)
 	}
 	g.Namespace = ns
+
+	module, err := parser.ParseModule(g.SourceFile)
+	if err != nil {
+		return fmt.Errorf("parsing module: %w", err)
+	}
+	g.Module = module
 
 	return nil
 }

--- a/internal/extgen/gofile.go
+++ b/internal/extgen/gofile.go
@@ -25,6 +25,7 @@ type goTemplateData struct {
 	InternalFunctions []string
 	Functions         []phpFunction
 	Classes           []phpClass
+	Module            *phpModule
 }
 
 func (gg *GoFileGenerator) generate() error {
@@ -62,6 +63,7 @@ func (gg *GoFileGenerator) buildContent() (string, error) {
 		InternalFunctions: internalFunctions,
 		Functions:         gg.generator.Functions,
 		Classes:           classes,
+		Module:            gg.generator.Module,
 	})
 
 	if err != nil {

--- a/internal/extgen/gofile_test.go
+++ b/internal/extgen/gofile_test.go
@@ -103,7 +103,9 @@ func test() {
 				{
 					Name:       "test",
 					ReturnType: phpVoid,
-					GoFunction: "func test() {\n\t// simple function\n}",
+					GoFunction: `func test() {
+	// simple function
+}`,
 				},
 			},
 			contains: []string{
@@ -213,7 +215,9 @@ func TestGoFileGenerator_PackageNameSanitization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.baseName, func(t *testing.T) {
-			sourceFile := createTempSourceFile(t, "package main\n//export_php: test(): void\nfunc test() {}")
+			sourceFile := createTempSourceFile(t, `package main
+//export_php: test(): void
+func test() {}`)
 
 			generator := &Generator{
 				BaseName:   tt.baseName,
@@ -251,7 +255,8 @@ func TestGoFileGenerator_ErrorHandling(t *testing.T) {
 		},
 		{
 			name:       "valid file",
-			sourceFile: createTempSourceFile(t, "package main\nfunc test() {}"),
+			sourceFile: createTempSourceFile(t, `package main
+func test() {}`),
 			expectErr:  false,
 		},
 	}
@@ -756,7 +761,9 @@ func simpleFunc() {
 				{
 					Name:       "simpleFunc",
 					ReturnType: phpVoid,
-					GoFunction: "func simpleFunc() {\n\t// simple function\n}",
+					GoFunction: `func simpleFunc() {
+	// simple function
+}`,
 				},
 			},
 			classes:         nil,
@@ -790,7 +797,9 @@ func (ts *TestStruct) GetName() string {
 							Signature:  "getName(): string",
 							ReturnType: phpString,
 							Params:     []phpParameter{},
-							GoFunction: "func (ts *TestStruct) GetName() string {\n\treturn ts.name\n}",
+							GoFunction: `func (ts *TestStruct) GetName() string {
+	return ts.name
+}`,
 						},
 					},
 				},
@@ -821,7 +830,9 @@ func (ms *MixedStruct) GetValue() int {
 				{
 					Name:       "utilFunc",
 					ReturnType: phpString,
-					GoFunction: "func utilFunc() string {\n\treturn \"utility\"\n}",
+					GoFunction: `func utilFunc() string {
+	return "utility"
+}`,
 				},
 			},
 			classes: []phpClass{
@@ -836,7 +847,9 @@ func (ms *MixedStruct) GetValue() int {
 							Signature:  "getValue(): int",
 							ReturnType: phpInt,
 							Params:     []phpParameter{},
-							GoFunction: "func (ms *MixedStruct) GetValue() int {\n\treturn ms.value\n}",
+							GoFunction: `func (ms *MixedStruct) GetValue() int {
+	return ms.value
+}`,
 						},
 					},
 				},

--- a/internal/extgen/moduleParser.go
+++ b/internal/extgen/moduleParser.go
@@ -39,8 +39,10 @@ func (mp *ModuleParser) parse(filename string) (module *phpModule, err error) {
 
 	scanner := bufio.NewScanner(file)
 	module = &phpModule{}
-	var currentDirective string
-	var lineNumber int
+	var (
+		currentDirective string
+		lineNumber       int
+	)
 
 	for scanner.Scan() {
 		lineNumber++

--- a/internal/extgen/moduleParser.go
+++ b/internal/extgen/moduleParser.go
@@ -69,9 +69,15 @@ func (mp *ModuleParser) parse(filename string) (module *phpModule, err error) {
 
 			switch currentDirective {
 			case "init":
+				if module.InitFunc != "" {
+					return nil, fmt.Errorf("duplicate init directive found at line %d: init function '%s' already defined", lineNumber, module.InitFunc)
+				}
 				module.InitFunc = funcName
 				module.InitCode = funcCode
 			case "shutdown":
+				if module.ShutdownFunc != "" {
+					return nil, fmt.Errorf("duplicate shutdown directive found at line %d: shutdown function '%s' already defined", lineNumber, module.ShutdownFunc)
+				}
 				module.ShutdownFunc = funcName
 				module.ShutdownCode = funcCode
 			}

--- a/internal/extgen/moduleParser.go
+++ b/internal/extgen/moduleParser.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-var phpModuleParser = regexp.MustCompile(`//\s*export_php:module\s+(init|shutdown)`)
+var (
+	phpModuleParser = regexp.MustCompile(`//\s*export_php:module\s+(init|shutdown)`)
+	funcNameRegex   = regexp.MustCompile(`func\s+([a-zA-Z0-9_]+)`)
+)
 
 // phpModule represents a PHP module with optional init and shutdown functions
 type phpModule struct {
@@ -86,7 +89,6 @@ func (mp *ModuleParser) parse(filename string) (module *phpModule, err error) {
 // extractGoFunction extracts the function name and code from a function declaration
 func (mp *ModuleParser) extractGoFunction(scanner *bufio.Scanner, firstLine string) (string, string, error) {
 	// Extract function name from the first line
-	funcNameRegex := regexp.MustCompile(`func\s+([a-zA-Z0-9_]+)`)
 	matches := funcNameRegex.FindStringSubmatch(firstLine)
 	if len(matches) < 2 {
 		return "", "", fmt.Errorf("could not extract function name from line: %s", firstLine)

--- a/internal/extgen/moduleParser.go
+++ b/internal/extgen/moduleParser.go
@@ -1,0 +1,73 @@
+package extgen
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var phpModuleParser = regexp.MustCompile(`//\s*export_php:module\s*(.*)`)
+
+// phpModule represents a PHP module with optional init and shutdown functions
+type phpModule struct {
+	InitFunc     string // Name of the init function
+	ShutdownFunc string // Name of the shutdown function
+}
+
+// ModuleParser parses PHP module directives from Go source files
+type ModuleParser struct{}
+
+// parse parses the source file for PHP module directives
+func (mp *ModuleParser) parse(filename string) (*phpModule, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if matches := phpModuleParser.FindStringSubmatch(line); matches != nil {
+			moduleInfo := strings.TrimSpace(matches[1])
+			return mp.parseModuleInfo(moduleInfo)
+		}
+	}
+
+	// No module directive found
+	return nil, nil
+}
+
+// parseModuleInfo parses the module info string to extract init and shutdown function names
+func (mp *ModuleParser) parseModuleInfo(moduleInfo string) (*phpModule, error) {
+	module := &phpModule{}
+	
+	// Split the module info by commas
+	parts := strings.Split(moduleInfo, ",")
+	
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		
+		// Split each part by equals sign
+		keyValue := strings.SplitN(part, "=", 2)
+		if len(keyValue) != 2 {
+			continue
+		}
+		
+		key := strings.TrimSpace(keyValue[0])
+		value := strings.TrimSpace(keyValue[1])
+		
+		switch key {
+		case "init":
+			module.InitFunc = value
+		case "shutdown":
+			module.ShutdownFunc = value
+		}
+	}
+	
+	return module, nil
+}

--- a/internal/extgen/moduleParser_test.go
+++ b/internal/extgen/moduleParser_test.go
@@ -165,13 +165,13 @@ func regularFunction() {
 				assert.NotNil(t, module, "parse() should not return nil")
 				assert.Equal(t, tt.expected.InitFunc, module.InitFunc, "InitFunc mismatch")
 				assert.Equal(t, tt.expected.ShutdownFunc, module.ShutdownFunc, "ShutdownFunc mismatch")
-				
+
 				// Check that function code was extracted
 				if tt.expected.InitFunc != "" {
 					assert.Contains(t, module.InitCode, "func "+tt.expected.InitFunc, "InitCode should contain function declaration")
 					assert.True(t, strings.HasSuffix(module.InitCode, "}\n"), "InitCode should end with closing brace")
 				}
-				
+
 				if tt.expected.ShutdownFunc != "" {
 					assert.Contains(t, module.ShutdownCode, "func "+tt.expected.ShutdownFunc, "ShutdownCode should contain function declaration")
 					assert.True(t, strings.HasSuffix(module.ShutdownCode, "}\n"), "ShutdownCode should end with closing brace")
@@ -221,9 +221,9 @@ func TestExtractGoFunction(t *testing.T) {
 			parser := &ModuleParser{}
 			scanner := bufio.NewScanner(strings.NewReader(tt.input))
 			scanner.Scan() // Read the first line
-			
+
 			name, code, err := parser.extractGoFunction(scanner, tt.firstLine)
-			
+
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedName, name)
 			assert.True(t, strings.HasPrefix(code, tt.expectedPrefix), "Function code should start with the declaration")
@@ -234,7 +234,7 @@ func TestExtractGoFunction(t *testing.T) {
 
 func TestModuleParserFileErrors(t *testing.T) {
 	parser := &ModuleParser{}
-	
+
 	// Test with non-existent file
 	module, err := parser.parse("non_existent_file.go")
 	assert.Error(t, err, "parse() should return error for non-existent file")

--- a/internal/extgen/moduleParser_test.go
+++ b/internal/extgen/moduleParser_test.go
@@ -1,0 +1,265 @@
+package extgen
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModuleParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *phpModule
+	}{
+		{
+			name: "both init and shutdown",
+			input: `package main
+
+//export_php:module init=initializeModule, shutdown=cleanupModule
+func initializeModule() {
+	// Initialization code
+}
+
+func cleanupModule() {
+	// Cleanup code
+}`,
+			expected: &phpModule{
+				InitFunc:     "initializeModule",
+				ShutdownFunc: "cleanupModule",
+			},
+		},
+		{
+			name: "only init function",
+			input: `package main
+
+//export_php:module init=initializeModule
+func initializeModule() {
+	// Initialization code
+}`,
+			expected: &phpModule{
+				InitFunc:     "initializeModule",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "only shutdown function",
+			input: `package main
+
+//export_php:module shutdown=cleanupModule
+func cleanupModule() {
+	// Cleanup code
+}`,
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "cleanupModule",
+			},
+		},
+		{
+			name: "with extra whitespace",
+			input: `package main
+
+//export_php:module   init = initModule ,  shutdown = shutdownModule  
+func initModule() {
+	// Initialization code
+}
+
+func shutdownModule() {
+	// Cleanup code
+}`,
+			expected: &phpModule{
+				InitFunc:     "initModule",
+				ShutdownFunc: "shutdownModule",
+			},
+		},
+		{
+			name: "no module directive",
+			input: `package main
+
+func regularFunction() {
+	// Just a regular Go function
+}`,
+			expected: nil,
+		},
+		{
+			name: "empty module directive",
+			input: `package main
+
+//export_php:module
+func someFunction() {
+	// Some code
+}`,
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "invalid module directive format",
+			input: `package main
+
+//export_php:module init:initFunc, shutdown:shutdownFunc
+func initFunc() {
+	// Initialization code
+}
+
+func shutdownFunc() {
+	// Cleanup code
+}`,
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "unrecognized keys",
+			input: `package main
+
+//export_php:module start=startFunc, stop=stopFunc
+func startFunc() {
+	// Start code
+}
+
+func stopFunc() {
+	// Stop code
+}`,
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			fileName := filepath.Join(tmpDir, tt.name+".go")
+			require.NoError(t, os.WriteFile(fileName, []byte(tt.input), 0644))
+
+			parser := &ModuleParser{}
+			module, err := parser.parse(fileName)
+			require.NoError(t, err)
+
+			if tt.expected == nil {
+				assert.Nil(t, module, "parse() should return nil for no module directive")
+			} else {
+				assert.NotNil(t, module, "parse() should not return nil")
+				assert.Equal(t, tt.expected.InitFunc, module.InitFunc, "InitFunc mismatch")
+				assert.Equal(t, tt.expected.ShutdownFunc, module.ShutdownFunc, "ShutdownFunc mismatch")
+			}
+		})
+	}
+}
+
+func TestParseModuleInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     string
+		expected *phpModule
+	}{
+		{
+			name: "both init and shutdown",
+			info: "init=initializeModule, shutdown=cleanupModule",
+			expected: &phpModule{
+				InitFunc:     "initializeModule",
+				ShutdownFunc: "cleanupModule",
+			},
+		},
+		{
+			name: "only init",
+			info: "init=initializeModule",
+			expected: &phpModule{
+				InitFunc:     "initializeModule",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "only shutdown",
+			info: "shutdown=cleanupModule",
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "cleanupModule",
+			},
+		},
+		{
+			name: "with extra whitespace",
+			info: "  init = initModule ,  shutdown = shutdownModule  ",
+			expected: &phpModule{
+				InitFunc:     "initModule",
+				ShutdownFunc: "shutdownModule",
+			},
+		},
+		{
+			name: "empty string",
+			info: "",
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "invalid format - no equals sign",
+			info: "init initFunc, shutdown shutdownFunc",
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "invalid format - wrong separator",
+			info: "init=initFunc; shutdown=shutdownFunc",
+			expected: &phpModule{
+				InitFunc:     "initFunc",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "unrecognized keys",
+			info: "start=startFunc, stop=stopFunc",
+			expected: &phpModule{
+				InitFunc:     "",
+				ShutdownFunc: "",
+			},
+		},
+		{
+			name: "mixed valid and invalid",
+			info: "init=initFunc, invalid, shutdown=shutdownFunc",
+			expected: &phpModule{
+				InitFunc:     "initFunc",
+				ShutdownFunc: "shutdownFunc",
+			},
+		},
+		{
+			name: "reversed order",
+			info: "shutdown=shutdownFunc, init=initFunc",
+			expected: &phpModule{
+				InitFunc:     "initFunc",
+				ShutdownFunc: "shutdownFunc",
+			},
+		},
+	}
+
+	parser := &ModuleParser{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module, err := parser.parseModuleInfo(tt.info)
+			
+			assert.NoError(t, err, "parseModuleInfo() unexpected error")
+			assert.NotNil(t, module, "parseModuleInfo() should not return nil")
+			assert.Equal(t, tt.expected.InitFunc, module.InitFunc, "InitFunc mismatch")
+			assert.Equal(t, tt.expected.ShutdownFunc, module.ShutdownFunc, "ShutdownFunc mismatch")
+		})
+	}
+}
+
+func TestModuleParserFileErrors(t *testing.T) {
+	parser := &ModuleParser{}
+	
+	// Test with non-existent file
+	module, err := parser.parse("non_existent_file.go")
+	assert.Error(t, err, "parse() should return error for non-existent file")
+	assert.Nil(t, module, "parse() should return nil for non-existent file")
+}

--- a/internal/extgen/parser.go
+++ b/internal/extgen/parser.go
@@ -2,31 +2,26 @@ package extgen
 
 type SourceParser struct{}
 
-// EXPERIMENTAL
 func (p *SourceParser) ParseFunctions(filename string) ([]phpFunction, error) {
 	functionParser := &FuncParser{}
 	return functionParser.parse(filename)
 }
 
-// EXPERIMENTAL
 func (p *SourceParser) ParseClasses(filename string) ([]phpClass, error) {
 	classParser := classParser{}
 	return classParser.parse(filename)
 }
 
-// EXPERIMENTAL
 func (p *SourceParser) ParseConstants(filename string) ([]phpConstant, error) {
 	constantParser := &ConstantParser{}
 	return constantParser.parse(filename)
 }
 
-// EXPERIMENTAL
 func (p *SourceParser) ParseNamespace(filename string) (string, error) {
 	namespaceParser := NamespaceParser{}
 	return namespaceParser.parse(filename)
 }
 
-// EXPERIMENTAL
 func (p *SourceParser) ParseModule(filename string) (*phpModule, error) {
 	moduleParser := &ModuleParser{}
 	return moduleParser.parse(filename)

--- a/internal/extgen/parser.go
+++ b/internal/extgen/parser.go
@@ -25,3 +25,9 @@ func (p *SourceParser) ParseNamespace(filename string) (string, error) {
 	namespaceParser := NamespaceParser{}
 	return namespaceParser.parse(filename)
 }
+
+// EXPERIMENTAL
+func (p *SourceParser) ParseModule(filename string) (*phpModule, error) {
+	moduleParser := &ModuleParser{}
+	return moduleParser.parse(filename)
+}

--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -167,14 +167,28 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
     {{- end}}
     {{- end}}
     {{- end}}
+    
+    {{if and .Module .Module.InitFunc}}
+    {{.Module.InitFunc}}_wrapper();
+    {{end}}
+    
     return SUCCESS;
 }
+
+{{if .Module}}
+{{if .Module.ShutdownFunc}}
+PHP_MSHUTDOWN_FUNCTION({{.BaseName}}) {
+    {{.Module.ShutdownFunc}}_wrapper();
+    return SUCCESS;
+}
+{{end}}
+{{end}}
 
 zend_module_entry {{.BaseName}}_module_entry = {STANDARD_MODULE_HEADER,
                                          "{{.BaseName}}",
                                          ext_functions,             /* Functions */
                                          PHP_MINIT({{.BaseName}}),  /* MINIT */
-                                         NULL,                      /* MSHUTDOWN */
+                                         {{if and .Module .Module.ShutdownFunc}}PHP_MSHUTDOWN({{.BaseName}}),{{else}}NULL,{{end}}  /* MSHUTDOWN */
                                          NULL,                      /* RINIT */
                                          NULL,                      /* RSHUTDOWN */
                                          NULL,                      /* MINFO */

--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -169,7 +169,7 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
     {{- end}}
     
     {{if and .Module .Module.InitFunc}}
-    {{.Module.InitFunc}}_wrapper();
+    {{.Module.InitFunc}}();
     {{end}}
     
     return SUCCESS;
@@ -178,7 +178,7 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
 {{if .Module}}
 {{if .Module.ShutdownFunc}}
 PHP_MSHUTDOWN_FUNCTION({{.BaseName}}) {
-    {{.Module.ShutdownFunc}}_wrapper();
+    {{.Module.ShutdownFunc}}();
     return SUCCESS;
 }
 {{end}}

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -5,7 +5,6 @@ package {{.PackageName}}
 #include "{{.BaseName}}.h"
 */
 import "C"
-import "runtime/cgo"
 {{- range .Imports}}
 import {{.}}
 {{- end}}

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -10,9 +10,11 @@ import "runtime/cgo"
 import {{.}}
 {{- end}}
 
+{{if not .HasInitFunction}}
 func init() {
 	frankenphp.RegisterExtension(unsafe.Pointer(&C.ext_module_entry))
 }
+{{end}}
 {{range .Constants}}
 const {{.Name}} = {{.Value}}
 {{- end}}

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -20,6 +20,18 @@ const {{.Name}} = {{.Value}}
 {{.}}
 {{- end}}
 
+{{- if .Module}}
+{{- if .Module.InitFunc}}
+//export {{.Module.InitFunc}}
+{{.Module.InitCode}}
+{{- end}}
+
+{{- if .Module.ShutdownFunc}}
+//export {{.Module.ShutdownFunc}}
+{{.Module.ShutdownCode}}
+{{- end}}
+{{- end}}
+
 {{- range .Functions}}
 //export {{.Name}}
 {{.GoFunction}}

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -5,7 +5,9 @@ package {{.PackageName}}
 #include "{{.BaseName}}.h"
 */
 import "C"
+{{- if .Classes}}
 import "runtime/cgo"
+{{- end}}
 {{- range .Imports}}
 import {{.}}
 {{- end}}

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -5,6 +5,7 @@ package {{.PackageName}}
 #include "{{.BaseName}}.h"
 */
 import "C"
+import "runtime/cgo"
 {{- range .Imports}}
 import {{.}}
 {{- end}}


### PR DESCRIPTION
This PR adjusts extgen to handle:

- the case where the go code already contains an `init()` function.
- support for `//export_php:module init` to handle resource creation during module startup
- support for `//export_php:module shutdown` to handle resource cleanup during module shutdown