### PR TITLE
Add modular threads

### DIFF
--- a/context.go
+++ b/context.go
@@ -28,7 +28,9 @@ type frankenPHPContext struct {
 	// Whether the request is already closed by us
 	isDone bool
 
-	responseWriter http.ResponseWriter
+	responseWriter    http.ResponseWriter
+	handlerParameters any
+	handlerReturn     any
 
 	done      chan any
 	startedAt time.Time

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -456,7 +456,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
   fci.size = sizeof fci;
   fci.retval = &retval;
   fci.params = result.r1;
-  fci.param_count = result.r1 != NULL ? 1 : 0;
+  fci.param_count = result.r1 == NULL ? 0 : 1;
 
   if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
     callback_ret = &retval;

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -475,7 +475,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
   frankenphp_worker_request_shutdown();
   go_frankenphp_finish_worker_request(thread_index, callback_ret);
   if (result.r1 != NULL) {
-  	zval_ptr_dtor(result.r1);
+    zval_ptr_dtor(result.r1);
   }
   if (callback_ret != NULL) {
     zval_ptr_dtor(&retval);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -456,7 +456,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
   fci.size = sizeof fci;
   fci.retval = &retval;
   fci.params = result.r1;
-  fci.param_count = 1;
+  fci.param_count = result.r1 != NULL ? 1 : 0;
 
   if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
     callback_ret = &retval;

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -432,10 +432,11 @@ PHP_FUNCTION(frankenphp_handle_request) {
   zend_unset_timeout();
 #endif
 
-  bool has_request = go_frankenphp_worker_handle_request_start(thread_index);
+  struct go_frankenphp_worker_handle_request_start_return result =
+      go_frankenphp_worker_handle_request_start(thread_index);
   if (frankenphp_worker_request_startup() == FAILURE
       /* Shutting down */
-      || !has_request) {
+      || !result.r0) {
     RETURN_FALSE;
   }
 
@@ -450,10 +451,15 @@ PHP_FUNCTION(frankenphp_handle_request) {
 
   /* Call the PHP func passed to frankenphp_handle_request() */
   zval retval = {0};
+  zval *callback_ret = NULL;
+
   fci.size = sizeof fci;
   fci.retval = &retval;
-  if (zend_call_function(&fci, &fcc) == SUCCESS) {
-    zval_ptr_dtor(&retval);
+  fci.params = result.r1;
+  fci.param_count = 1;
+
+  if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+    callback_ret = &retval;
   }
 
   /*
@@ -467,7 +473,13 @@ PHP_FUNCTION(frankenphp_handle_request) {
   }
 
   frankenphp_worker_request_shutdown();
-  go_frankenphp_finish_worker_request(thread_index);
+  go_frankenphp_finish_worker_request(thread_index, callback_ret);
+  if (result.r1 != NULL) {
+  	zval_ptr_dtor(result.r1);
+  }
+  if (callback_ret != NULL) {
+    zval_ptr_dtor(&retval);
+  }
 
   RETURN_TRUE;
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -302,7 +302,6 @@ func Shutdown() {
 
 	drainWatcher()
 	drainAutoScaling()
-	drainExternalWorkerPipes()
 	drainPHPThreads()
 
 	metrics.Shutdown()

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -214,6 +214,11 @@ func Init(options ...Option) error {
 
 	registerExtensions()
 
+	// add registered external workers
+	for _, ew := range externalWorkers {
+		options = append(options, WithWorkers(ew.Name(), ew.FileName(), ew.GetMinThreads(), WithWorkerEnv(ew.Env())))
+	}
+
 	opt := &opt{}
 	for _, o := range options {
 		if err := o(opt); err != nil {

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -302,6 +302,7 @@ func Shutdown() {
 
 	drainWatcher()
 	drainAutoScaling()
+	drainExternalWorkerPipes()
 	drainPHPThreads()
 
 	metrics.Shutdown()

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -33,7 +33,7 @@ type WorkerExtension interface {
 	ThreadActivatedNotification(threadId int)
 	ThreadDrainNotification(threadId int)
 	ThreadDeactivatedNotification(threadId int)
-	ProvideRequest() <-chan *WorkerRequest
+	ProvideRequest() *WorkerRequest
 }
 
 type WorkerRequest struct {

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -40,7 +40,9 @@ type WorkerExtension interface {
 }
 
 type WorkerRequest struct {
-	Request  *http.Request
+	// The request for your worker script to handle
+	Request *http.Request
+	// Response is a response writer that provides the output of the provided request
 	Response http.ResponseWriter
 	// Done is an optional channel that will be closed when the request processing is complete
 	Done chan struct{}
@@ -48,7 +50,6 @@ type WorkerRequest struct {
 
 var externalWorkers = make(map[string]WorkerExtension)
 var externalWorkerMutex sync.Mutex
-
 
 func RegisterExternalWorker(worker WorkerExtension) {
 	externalWorkerMutex.Lock()
@@ -105,4 +106,3 @@ func startExternalWorkerPipe(w *worker, externalWorker WorkerExtension, thread *
 		}
 	}()
 }
-

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -25,8 +25,7 @@ import (
 //
 // Note: External workers receive the lowest priority when determining thread allocations. If GetMinThreads cannot be
 // allocated, then frankenphp will panic and provide this information to the user (who will need to allocation more
-// total threads). Don't be greedy. Use ProvideBackPressure to indicate when you receive a request to trigger
-// autoscaling.
+// total threads). Don't be greedy.
 type WorkerExtension interface {
 	Name() string
 	FileName() string

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -60,49 +60,34 @@ func RegisterExternalWorker(worker WorkerExtension) {
 
 // startExternalWorkerPipe creates a pipe from an external worker to the main worker.
 func startExternalWorkerPipe(w *worker, externalWorker WorkerExtension, thread *phpThread) {
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.LogAttrs(context.Background(), slog.LevelError, "external worker pipe panicked", slog.String("worker", w.name), slog.Any("panic", r))
-			}
-		}()
+	for {
+		rq := externalWorker.ProvideRequest()
 
-		for {
-			var rq *WorkerRequest
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						logger.LogAttrs(context.Background(), slog.LevelError, "ProvideRequest panicked", slog.String("worker", w.name), slog.Any("panic", r))
-						rq = nil
-					}
+		if rq == nil || rq.Request == nil {
+			logger.LogAttrs(context.Background(), slog.LevelWarn, "external worker provided nil request", slog.String("worker", w.name), slog.Int("thread", thread.threadIndex))
+			continue
+		}
+
+		r := rq.Request
+		fr, err := NewRequestWithContext(r, WithOriginalRequest(r), WithWorkerName(w.name))
+		if err != nil {
+			logger.LogAttrs(context.Background(), slog.LevelError, "error creating request for external worker", slog.String("worker", w.name), slog.Int("thread", thread.threadIndex), slog.Any("error", err))
+			continue
+		}
+
+		if fc, ok := fromContext(fr.Context()); ok {
+			fc.responseWriter = rq.Response
+
+			// Queue the request and wait for completion if Done channel was provided
+			logger.LogAttrs(context.Background(), slog.LevelInfo, "queue the external worker request", slog.String("worker", w.name), slog.Int("thread", thread.threadIndex))
+
+			w.requestChan <- fc
+			if rq.Done != nil {
+				go func() {
+					<-fc.done
+					close(rq.Done)
 				}()
-				rq = externalWorker.ProvideRequest()
-			}()
-
-			if rq == nil || rq.Request == nil {
-				logger.LogAttrs(context.Background(), slog.LevelWarn, "external worker provided nil request", slog.String("worker", w.name))
-				continue
-			}
-
-			r := rq.Request
-			fr, err := NewRequestWithContext(r, WithOriginalRequest(r), WithWorkerName(w.name))
-			if err != nil {
-				logger.LogAttrs(context.Background(), slog.LevelError, "error creating request for external worker", slog.String("worker", w.name), slog.Any("error", err))
-				continue
-			}
-
-			if fc, ok := fromContext(fr.Context()); ok {
-				fc.responseWriter = rq.Response
-
-				// Queue the request and wait for completion if Done channel was provided
-				w.requestChan <- fc
-				if rq.Done != nil {
-					go func() {
-						<-fc.done
-						close(rq.Done)
-					}()
-				}
 			}
 		}
-	}()
+	}
 }

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -12,8 +12,7 @@ import (
 // A worker script with the provided Name and FileName will be registered, along with the provided
 // configuration. You can also provide any environment variables that you want through Env. GetMinThreads allows you to
 // reserve a minimum number of threads from the frankenphp thread pool. This number must be positive.
-// ProvideBackPressure allows you to autoscale your threads from the free threads in frankenphp's thread pool. These
-// methods are only called once at startup, so register them in an init() function.
+// These methods are only called once at startup, so register them in an init() function.
 //
 // When a thread is activated and nearly ready, ThreadActivatedNotification will be called with an opaque threadId;
 // this is a time for setting up any per-thread resources. When a thread is about to be returned to the thread pool,

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -35,7 +35,12 @@ type WorkerExtension interface {
 	ThreadActivatedNotification(threadId int)
 	ThreadDrainNotification(threadId int)
 	ThreadDeactivatedNotification(threadId int)
-	ProvideRequest() <-chan *http.Request
+	ProvideRequest() <-chan *WorkerRequest
+}
+
+type WorkerRequest struct {
+	Request  *http.Request
+	Response http.ResponseWriter
 }
 
 var externalWorkers = make(map[string]WorkerExtension)

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -1,6 +1,8 @@
 package frankenphp
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"sync"
 )
@@ -20,10 +22,11 @@ import (
 // After the thread is returned to the thread pool, ThreadDeactivatedNotification will be called.
 //
 // Once you have at least one thread activated, you will receive calls to ProvideRequest where you should respond with
-// a request.
+// a request. FrankenPHP will automatically pipe these requests to the worker script and handle the response.
+// The piping process is designed to run indefinitely and will be gracefully shut down when FrankenPHP shuts down.
 //
 // Note: External workers receive the lowest priority when determining thread allocations. If GetMinThreads cannot be
-// allocated, then frankenphp will panic and provide this information to the user (who will need to allocation more
+// allocated, then frankenphp will panic and provide this information to the user (who will need to allocate more
 // total threads). Don't be greedy.
 type WorkerExtension interface {
 	Name() string
@@ -44,9 +47,93 @@ type WorkerRequest struct {
 var externalWorkers = make(map[string]WorkerExtension)
 var externalWorkerMutex sync.Mutex
 
+var externalWorkerPipes = make(map[string]context.CancelFunc)
+var externalWorkerPipesMutex sync.Mutex
+
 func RegisterExternalWorker(worker WorkerExtension) {
 	externalWorkerMutex.Lock()
 	defer externalWorkerMutex.Unlock()
 
 	externalWorkers[worker.Name()] = worker
+}
+
+// startExternalWorkerPipe creates a pipe from an external worker to the main worker.
+func startExternalWorkerPipe(w *worker, externalWorker WorkerExtension, thread *phpThread) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Register the cancel function for shutdown
+	externalWorkerPipesMutex.Lock()
+	externalWorkerPipes[w.name] = cancel
+	externalWorkerPipesMutex.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.LogAttrs(context.Background(), slog.LevelError, "external worker pipe panicked", slog.String("worker", w.name), slog.Any("panic", r))
+			}
+			externalWorkerPipesMutex.Lock()
+			delete(externalWorkerPipes, w.name)
+			externalWorkerPipesMutex.Unlock()
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				logger.LogAttrs(context.Background(), slog.LevelDebug, "external worker pipe shutting down", slog.String("worker", w.name))
+				return
+			default:
+			}
+
+			var rq *WorkerRequest
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						logger.LogAttrs(context.Background(), slog.LevelError, "ProvideRequest panicked", slog.String("worker", w.name), slog.Any("panic", r))
+						rq = nil
+					}
+				}()
+				rq = externalWorker.ProvideRequest()
+			}()
+
+			if rq == nil || rq.Request == nil {
+				logger.LogAttrs(context.Background(), slog.LevelWarn, "external worker provided nil request", slog.String("worker", w.name))
+				continue
+			}
+
+			r := rq.Request
+			fr, err := NewRequestWithContext(r, WithOriginalRequest(r), WithWorkerName(w.name))
+			if err != nil {
+				logger.LogAttrs(context.Background(), slog.LevelError, "error creating request for external worker", slog.String("worker", w.name), slog.Any("error", err))
+				continue
+			}
+
+			if fc, ok := fromContext(fr.Context()); ok {
+				fc.responseWriter = rq.Response
+
+				select {
+				case w.requestChan <- fc:
+					// Request successfully queued
+				case <-ctx.Done():
+					fc.reject(503, "Service Unavailable")
+					return
+				}
+			}
+		}
+	}()
+}
+
+// drainExternalWorkerPipes shuts down all external worker pipes gracefully
+func drainExternalWorkerPipes() {
+	externalWorkerPipesMutex.Lock()
+	defer externalWorkerPipesMutex.Unlock()
+
+	logger.LogAttrs(context.Background(), slog.LevelDebug, "shutting down external worker pipes", slog.Int("count", len(externalWorkerPipes)))
+
+	for workerName, cancel := range externalWorkerPipes {
+		logger.LogAttrs(context.Background(), slog.LevelDebug, "shutting down external worker pipe", slog.String("worker", workerName))
+		cancel()
+	}
+
+	// Clear the map
+	externalWorkerPipes = make(map[string]context.CancelFunc)
 }

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -1,0 +1,49 @@
+package frankenphp
+
+import (
+	"net/http"
+	"sync"
+)
+
+// WorkerExtension allows you to register an external worker where instead of calling frankenphp handlers on
+// frankenphp_handle_request(), the ProvideRequest method is called. You are responsible for providing a standard
+// http.Request that will be conferred to the underlying worker script.
+//
+// A worker script with the provided Name and FileName will be registered, along with the provided
+// configuration. You can also provide any environment variables that you want through Env. GetMinThreads allows you to
+// reserve a minimum number of threads from the frankenphp thread pool. This number must be positive.
+// ProvideBackPressure allows you to autoscale your threads from the free threads in frankenphp's thread pool. These
+// methods are only called once at startup, so register them in an init() function.
+//
+// When a thread is activated and nearly ready, ThreadActivatedNotification will be called with an opaque threadId;
+// this is a time for setting up any per-thread resources. When a thread is about to be returned to the thread pool,
+// you will receive a call to ThreadDrainNotification that will inform you of the threadId.
+// After the thread is returned to the thread pool, ThreadDeactivatedNotification will be called.
+//
+// Once you have at least one thread activated, you will receive calls to ProvideRequest where you should respond with
+// a request.
+//
+// Note: External workers receive the lowest priority when determining thread allocations. If GetMinThreads cannot be
+// allocated, then frankenphp will panic and provide this information to the user (who will need to allocation more
+// total threads). Don't be greedy. Use ProvideBackPressure to indicate when you receive a request to trigger
+// autoscaling.
+type WorkerExtension interface {
+	Name() string
+	FileName() string
+	Env() PreparedEnv
+	GetMinThreads() int
+	ThreadActivatedNotification(threadId int)
+	ThreadDrainNotification(threadId int)
+	ThreadDeactivatedNotification(threadId int)
+	ProvideRequest() <-chan *http.Request
+}
+
+var externalWorkers = make(map[string]WorkerExtension)
+var externalWorkerMutex sync.Mutex
+
+func RegisterExternalWorker(worker WorkerExtension) {
+	externalWorkerMutex.Lock()
+	defer externalWorkerMutex.Unlock()
+
+	externalWorkers[worker.Name()] = worker
+}

--- a/threadFramework_test.go
+++ b/threadFramework_test.go
@@ -1,0 +1,1 @@
+package frankenphp

--- a/threadFramework_test.go
+++ b/threadFramework_test.go
@@ -1,1 +1,0 @@
-package frankenphp

--- a/threadFramework_test.go
+++ b/threadFramework_test.go
@@ -1,0 +1,126 @@
+package frankenphp_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWorkerExtension implements the frankenphp.WorkerExtension interface
+type mockWorkerExtension struct {
+	name             string
+	fileName         string
+	env              frankenphp.PreparedEnv
+	minThreads       int
+	requestChan      chan *frankenphp.WorkerRequest
+	activatedCount   int
+	drainCount       int
+	deactivatedCount int
+	mu               sync.Mutex
+}
+
+func newMockWorkerExtension(name, fileName string, minThreads int) *mockWorkerExtension {
+	return &mockWorkerExtension{
+		name:        name,
+		fileName:    fileName,
+		env:         make(frankenphp.PreparedEnv),
+		minThreads:  minThreads,
+		requestChan: make(chan *frankenphp.WorkerRequest, 10), // Buffer to avoid blocking
+	}
+}
+
+func (m *mockWorkerExtension) Name() string {
+	return m.name
+}
+
+func (m *mockWorkerExtension) FileName() string {
+	return m.fileName
+}
+
+func (m *mockWorkerExtension) Env() frankenphp.PreparedEnv {
+	return m.env
+}
+
+func (m *mockWorkerExtension) GetMinThreads() int {
+	return m.minThreads
+}
+
+func (m *mockWorkerExtension) ThreadActivatedNotification(threadId int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.activatedCount++
+}
+
+func (m *mockWorkerExtension) ThreadDrainNotification(threadId int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.drainCount++
+}
+
+func (m *mockWorkerExtension) ThreadDeactivatedNotification(threadId int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deactivatedCount++
+}
+
+func (m *mockWorkerExtension) ProvideRequest() *frankenphp.WorkerRequest {
+	return <-m.requestChan
+}
+
+func (m *mockWorkerExtension) InjectRequest(r *frankenphp.WorkerRequest) {
+	m.requestChan <- r
+}
+
+func (m *mockWorkerExtension) GetActivatedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.activatedCount
+}
+
+func TestWorkerExtension(t *testing.T) {
+	// Create a mock extension
+	mockExt := newMockWorkerExtension("mockWorker", "testdata/worker.php", 1)
+
+	// Register the mock extension
+	frankenphp.RegisterExternalWorker(mockExt)
+
+	// Initialize FrankenPHP with a worker that has a different name than our extension
+	err := frankenphp.Init()
+	require.NoError(t, err)
+	defer frankenphp.Shutdown()
+
+	// Wait a bit for the worker to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify that the extension's thread was activated
+	assert.GreaterOrEqual(t, mockExt.GetActivatedCount(), 1, "Thread should have been activated")
+
+	// Create a test request
+	req := httptest.NewRequest("GET", "http://example.com/test/?foo=bar", nil)
+	req.Header.Set("X-Test-Header", "test-value")
+
+	w := httptest.NewRecorder()
+
+	// Inject the request into the worker through the extension
+	mockExt.InjectRequest(&frankenphp.WorkerRequest{
+		Request:  req,
+		Response: w,
+	})
+
+	// Wait a bit for the request to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Check the response
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	// The worker.php script should output information about the request
+	// We're just checking that we got a response, not the specific content
+	assert.NotEmpty(t, body, "Response body should not be empty")
+}

--- a/threadworker.go
+++ b/threadworker.go
@@ -232,7 +232,9 @@ func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) (C.bool,
 func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t, retval *C.zval) {
 	thread := phpThreads[threadIndex]
 	fc := thread.getRequestContext()
-	fc.handlerReturn = GoValue(unsafe.Pointer(retval))
+	if retval != nil {
+		fc.handlerReturn = GoValue(unsafe.Pointer(retval))
+	}
 
 	fc.closeContext()
 	thread.handler.(*workerThread).workerContext = nil

--- a/threadworker.go
+++ b/threadworker.go
@@ -24,7 +24,7 @@ type workerThread struct {
 }
 
 func convertToWorkerThread(thread *phpThread, worker *worker) {
-	externalWorker, _ := externalWorkers[worker.name]
+	externalWorker := externalWorkers[worker.name]
 
 	thread.setHandler(&workerThread{
 		state:  thread.state,

--- a/threadworker.go
+++ b/threadworker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"time"
+	"unsafe"
 )
 
 // representation of a thread assigned to a worker script
@@ -159,7 +160,7 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 }
 
 // waitForWorkerRequest is called during frankenphp_handle_request in the php worker script.
-func (handler *workerThread) waitForWorkerRequest() bool {
+func (handler *workerThread) waitForWorkerRequest() (bool, any) {
 	// unpin any memory left over from previous requests
 	handler.thread.Unpin()
 
@@ -195,7 +196,7 @@ func (handler *workerThread) waitForWorkerRequest() bool {
 			C.frankenphp_reset_opcache()
 		}
 
-		return false
+		return false, nil
 	case fc = <-handler.thread.requestChan:
 	case fc = <-handler.worker.requestChan:
 	}
@@ -205,23 +206,33 @@ func (handler *workerThread) waitForWorkerRequest() bool {
 
 	logger.LogAttrs(ctx, slog.LevelDebug, "request handling started", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex), slog.String("url", fc.request.RequestURI))
 
-	return true
+	return true, fc.handlerParameters
 }
 
 // go_frankenphp_worker_handle_request_start is called at the start of every php request served.
 //
 //export go_frankenphp_worker_handle_request_start
-func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) C.bool {
+func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) (C.bool, unsafe.Pointer) {
 	handler := phpThreads[threadIndex].handler.(*workerThread)
-	return C.bool(handler.waitForWorkerRequest())
+	hasRequest, parameters := handler.waitForWorkerRequest()
+
+	if parameters != nil {
+		p := PHPValue(parameters)
+		handler.thread.Pin(p)
+
+		return C.bool(hasRequest), p
+	}
+
+	return C.bool(hasRequest), nil
 }
 
 // go_frankenphp_finish_worker_request is called at the end of every php request served.
 //
 //export go_frankenphp_finish_worker_request
-func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t) {
+func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t, retval *C.zval) {
 	thread := phpThreads[threadIndex]
 	fc := thread.getRequestContext()
+	fc.handlerReturn = GoValue(unsafe.Pointer(retval))
 
 	fc.closeContext()
 	thread.handler.(*workerThread).workerContext = nil

--- a/worker.go
+++ b/worker.go
@@ -60,7 +60,7 @@ func initWorkers(opt []workerOpt) error {
 					go func(w *worker, externalWorker WorkerExtension) {
 						for {
 							// todo: handle shutdown
-							rq := <-externalWorker.ProvideRequest()
+							rq := externalWorker.ProvideRequest()
 							r := rq.Request
 							fr, err := NewRequestWithContext(r, WithOriginalRequest(r), WithWorkerName(w.name))
 							if err != nil {

--- a/worker.go
+++ b/worker.go
@@ -60,13 +60,15 @@ func initWorkers(opt []workerOpt) error {
 					go func(w *worker, externalWorker WorkerExtension) {
 						for {
 							// todo: handle shutdown
-							r := <-externalWorker.ProvideRequest()
+							rq := <-externalWorker.ProvideRequest()
+							r := rq.Request
 							fr, err := NewRequestWithContext(r, WithOriginalRequest(r), WithWorkerName(w.name))
 							if err != nil {
 								logger.LogAttrs(context.Background(), slog.LevelError, "error creating request for external worker", slog.String("worker", w.name), slog.Any("error", err))
 								continue
 							}
 							if fc, ok := fromContext(fr.Context()); ok {
+								fc.responseWriter = rq.Response
 								w.requestChan <- fc
 							}
 						}

--- a/worker.go
+++ b/worker.go
@@ -55,7 +55,7 @@ func initWorkers(opt []workerOpt) error {
 				// create a pipe from the external worker to the main worker
 				// note: this is locked to the initial thread size the external worker requested
 				if workerThread, ok := thread.handler.(*workerThread); ok && workerThread.externalWorker != nil {
-					startExternalWorkerPipe(w, workerThread.externalWorker, thread)
+					go startExternalWorkerPipe(w, workerThread.externalWorker, thread)
 				}
 				workersReady.Done()
 			}()


### PR DESCRIPTION
This allows for extensions to register as external workers. For example, someone could create an in-process, multi-threaded queue that can be used as a Symfony Messenger:

```go
package simple_messenger

import "C"
import (
	"bytes"
	"io"
	"net/http"
	"unsafe"

	"github.com/dunglas/frankenphp"
)

type messenger struct {
	messages chan *string
}

func (m *messenger) Name() string {
	return "m#Messenger"
}

func (m *messenger) FileName() string {
	return "vendor/somewhere/MessengerWorker.php"
}

func (m *messenger) GetMinThreads() int {
	return 4
}

func (m *messenger) ThreadActivatedNotification(threadId int)   {}
func (m *messenger) ThreadDrainNotification(threadId int)       {}
func (m *messenger) ThreadDeactivatedNotification(threadId int) {}
func (m *messenger) Env() frankenphp.PreparedEnv {
	return frankenphp.PreparedEnv{}
}

func (m *messenger) ProvideRequest() *frankenphp.WorkerRequest {
	msg := <-m.messages
	body := bytes.NewBufferString(*msg)
	return &frankenphp.WorkerRequest{
		Request: &http.Request{
			Body: io.NopCloser(body),
		},
	}
}

var m = &messenger{
	messages: make(chan *string),
}

// export_php:function sendMessage(string $message): void
func sendMessage(msgStr C.zend_string) {
	msg := frankenphp.GoString(unsafe.Pointer(msgStr))
	m.messages <- &msg
}

func init() {
	frankenphp.RegisterExternalWorker(m)
}
```

The external worker may then send "requests" to the registered PHP file that can package them up as whatever object is required. Any responses are sent back to the extension if a ResponseWriter is provided, otherwise it is sent to stdout.