### PR TITLE
register extensions in cli mode

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -635,6 +635,9 @@ func go_is_context_done(threadIndex C.uintptr_t) C.bool {
 // ExecuteScriptCLI executes the PHP script passed as parameter.
 // It returns the exit status code of the script.
 func ExecuteScriptCLI(script string, args []string) int {
+	// Ensure extensions are registered before CLI execution
+	registerExtensions()
+
 	cScript := C.CString(script)
 	defer C.free(unsafe.Pointer(cScript))
 
@@ -645,6 +648,9 @@ func ExecuteScriptCLI(script string, args []string) int {
 }
 
 func ExecutePHPCode(phpCode string) int {
+	// Ensure extensions are registered before CLI execution
+	registerExtensions()
+
 	cCode := C.CString(phpCode)
 	defer C.free(unsafe.Pointer(cCode))
 	return int(C.frankenphp_execute_script_cli(cCode, 0, nil, true))


### PR DESCRIPTION
Currently, no frankenphp extensions are registered in cli mode. This fixes that.