### PR TITLE
[fix segfault] ensure environment trackvars are setup

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -7,6 +7,7 @@ package frankenphp
 // #cgo noescape frankenphp_register_bulk
 // #cgo noescape frankenphp_register_variables_from_request_info
 // #cgo noescape frankenphp_register_variable_safe
+// #cgo noescape frankenphp_register_env_safe
 // #cgo noescape frankenphp_register_single
 // #include <php_variables.h>
 // #include "frankenphp.h"
@@ -195,6 +196,7 @@ func addHeadersToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
 func addPreparedEnvToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
 	for k, v := range fc.env {
 		C.frankenphp_register_variable_safe(toUnsafeChar(k), toUnsafeChar(v), C.size_t(len(v)), trackVarsArray)
+		C.frankenphp_register_env_safe(toUnsafeChar(k), toUnsafeChar(v), C.size_t(len(v)))
 	}
 	fc.env = nil
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -764,6 +764,9 @@ static void frankenphp_register_variables(zval *track_vars_array) {
    * variables.
    */
 
+   zval_ptr_dtor_nogc(&PG(http_globals)[TRACK_VARS_ENV]);
+   array_init(&PG(http_globals)[TRACK_VARS_ENV]);
+
   /* in non-worker mode we import the os environment regularly */
   if (!is_worker_thread) {
     get_full_env(track_vars_array);

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -71,6 +71,8 @@ void frankenphp_register_variables_from_request_info(
     zend_string *auth_user, zend_string *request_method);
 void frankenphp_register_variable_safe(char *key, char *var, size_t val_len,
                                        zval *track_vars_array);
+
+void frankenphp_register_env_safe(char *key, char *var, size_t val_len);
 zend_string *frankenphp_init_persistent_string(const char *string, size_t len);
 int frankenphp_reset_opcache(void);
 int frankenphp_get_current_memory_limit();


### PR DESCRIPTION
I’ve been chasing down this issue for MONTHS. I finally managed to figure out the issue.

In workers, $_ENV works EXTREMELY weird sometimes, depending on where you access it from. If you accessed in the global scope, you could get different values than if you access it in a function or method.

Well... I checked `PG(http_globals)[TRACK_VARS_ENV]` in an extension (expecting to get the real env) and caused a segfault because it isn’t set until after the first request (and it is always empty).

This PR fixes the issue by making sure the http_globals array stays in sync with the environment.

potentially related PRs: 
- #1504
- #1061
- #1395