### PR TITLE
refactor: remove 'Max Threads'

### DIFF
--- a/caddy/admin_test.go
+++ b/caddy/admin_test.go
@@ -109,7 +109,7 @@ func TestAutoScaleWorkerThreads(t *testing.T) {
 
 	// spam an endpoint that simulates IO
 	endpoint := "http://localhost:" + testPort + "/?sleep=2&work=1000"
-	amountOfThreads := len(getDebugState(t, tester).ThreadDebugStates)
+	amountOfThreads := getNumThreads(t, tester)
 
 	// try to spawn the additional threads by spamming the server
 	for range maxTries {
@@ -122,7 +122,7 @@ func TestAutoScaleWorkerThreads(t *testing.T) {
 		}
 		wg.Wait()
 
-		amountOfThreads = len(getDebugState(t, tester).ThreadDebugStates)
+		amountOfThreads = getNumThreads(t, tester)
 		if amountOfThreads > 2 {
 			break
 		}
@@ -161,7 +161,7 @@ func TestAutoScaleRegularThreadsOnAutomaticThreadLimit(t *testing.T) {
 
 	// spam an endpoint that simulates IO
 	endpoint := "http://localhost:" + testPort + "/sleep.php?sleep=2&work=1000"
-	amountOfThreads := len(getDebugState(t, tester).ThreadDebugStates)
+	amountOfThreads := getNumThreads(t, tester)
 
 	// try to spawn the additional threads by spamming the server
 	for range maxTries {
@@ -174,7 +174,7 @@ func TestAutoScaleRegularThreadsOnAutomaticThreadLimit(t *testing.T) {
 		}
 		wg.Wait()
 
-		amountOfThreads = len(getDebugState(t, tester).ThreadDebugStates)
+		amountOfThreads = getNumThreads(t, tester)
 		if amountOfThreads > 1 {
 			break
 		}
@@ -208,6 +208,7 @@ func getAdminResponseBody(t *testing.T, tester *caddytest.Tester, method string,
 }
 
 func getDebugState(t *testing.T, tester *caddytest.Tester) frankenphp.FrankenPHPDebugState {
+	t.Helper()
 	threadStates := getAdminResponseBody(t, tester, "GET", "threads")
 
 	var debugStates frankenphp.FrankenPHPDebugState
@@ -215,6 +216,11 @@ func getDebugState(t *testing.T, tester *caddytest.Tester) frankenphp.FrankenPHP
 	assert.NoError(t, err)
 
 	return debugStates
+}
+
+func getNumThreads(t *testing.T, tester *caddytest.Tester) int {
+	t.Helper()
+	return len(getDebugState(t, tester).ThreadDebugStates)
 }
 
 func TestAddModuleWorkerViaAdminApi(t *testing.T) {

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddytest"
-	"github.com/dunglas/frankenphp"
 	"github.com/dunglas/frankenphp/internal/fastabs"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -475,7 +474,7 @@ func TestMetrics(t *testing.T) {
 	_, err = metrics.ReadFrom(resp.Body)
 	require.NoError(t, err, "failed to read metrics")
 
-	cpus := fmt.Sprintf("%d", frankenphp.MaxThreads)
+	cpus := strconv.Itoa(getNumThreads(t, tester))
 
 	// Check metrics
 	expectedMetrics := `
@@ -548,7 +547,7 @@ func TestWorkerMetrics(t *testing.T) {
 	_, err = metrics.ReadFrom(resp.Body)
 	require.NoError(t, err, "failed to read metrics")
 
-	cpus := fmt.Sprintf("%d", frankenphp.MaxThreads)
+	cpus := strconv.Itoa(getNumThreads(t, tester))
 
 	// Check metrics
 	expectedMetrics := `
@@ -640,7 +639,7 @@ func TestNamedWorkerMetrics(t *testing.T) {
 	_, err = metrics.ReadFrom(resp.Body)
 	require.NoError(t, err, "failed to read metrics")
 
-	cpus := fmt.Sprintf("%d", frankenphp.MaxThreads)
+	cpus := strconv.Itoa(getNumThreads(t, tester))
 
 	// Check metrics
 	expectedMetrics := `
@@ -731,8 +730,9 @@ func TestAutoWorkerConfig(t *testing.T) {
 	_, err = metrics.ReadFrom(resp.Body)
 	require.NoError(t, err, "failed to read metrics")
 
-	cpus := fmt.Sprintf("%d", frankenphp.MaxThreads)
-	workers := fmt.Sprintf("%d", frankenphp.MaxThreads-1)
+	numThreads := getNumThreads(t, tester)
+	cpus := strconv.Itoa(numThreads)
+	workers := strconv.Itoa(numThreads - 1)
 
 	// Check metrics
 	expectedMetrics := `
@@ -1093,7 +1093,7 @@ func TestMultiWorkersMetrics(t *testing.T) {
 	_, err = metrics.ReadFrom(resp.Body)
 	require.NoError(t, err, "failed to read metrics")
 
-	cpus := fmt.Sprintf("%d", frankenphp.MaxThreads)
+	cpus := strconv.Itoa(getNumThreads(t, tester))
 
 	// Check metrics
 	expectedMetrics := `

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -140,9 +140,6 @@ func Config() PHPConfig {
 	}
 }
 
-// MaxThreads is internally used during tests. It is written to, but never read and may go away in the future.
-var MaxThreads int
-
 func calculateMaxThreads(opt *opt) (int, int, int, error) {
 	maxProcs := runtime.GOMAXPROCS(0) * 2
 
@@ -253,7 +250,6 @@ func Init(options ...Option) error {
 	}
 
 	metrics.TotalThreads(totalThreadCount)
-	MaxThreads = totalThreadCount
 
 	config := Config()
 


### PR DESCRIPTION
This PR removes the exported 'Max Threads' variable (only used in tests) and uses the 'debug state' instead.