### PR TITLE
fix: support filename other than `ext.go` and keep local vars on generation

### DIFF
--- a/internal/extgen/gofile.go
+++ b/internal/extgen/gofile.go
@@ -22,6 +22,7 @@ type goTemplateData struct {
 	BaseName          string
 	Imports           []string
 	Constants         []phpConstant
+	Variables         []string
 	InternalFunctions []string
 	Functions         []phpFunction
 	Classes           []phpClass
@@ -39,7 +40,7 @@ func (gg *GoFileGenerator) generate() error {
 
 func (gg *GoFileGenerator) buildContent() (string, error) {
 	sourceAnalyzer := SourceAnalyzer{}
-	imports, internalFunctions, err := sourceAnalyzer.analyze(gg.generator.SourceFile)
+	imports, variables, internalFunctions, err := sourceAnalyzer.analyze(gg.generator.SourceFile)
 	if err != nil {
 		return "", fmt.Errorf("analyzing source file: %w", err)
 	}
@@ -59,6 +60,7 @@ func (gg *GoFileGenerator) buildContent() (string, error) {
 		BaseName:          gg.generator.BaseName,
 		Imports:           filteredImports,
 		Constants:         gg.generator.Constants,
+		Variables:         variables,
 		InternalFunctions: internalFunctions,
 		Functions:         gg.generator.Functions,
 		Classes:           classes,

--- a/internal/extgen/hfile.go
+++ b/internal/extgen/hfile.go
@@ -17,6 +17,7 @@ type HeaderGenerator struct {
 }
 
 type TemplateData struct {
+	BaseName    string
 	HeaderGuard string
 	Constants   []phpConstant
 	Classes     []phpClass
@@ -50,6 +51,7 @@ func (hg *HeaderGenerator) buildContent() (string, error) {
 
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, TemplateData{
+		BaseName:    hg.generator.BaseName,
 		HeaderGuard: headerGuard,
 		Constants:   hg.generator.Constants,
 		Classes:     hg.generator.Classes,

--- a/internal/extgen/hfile_test.go
+++ b/internal/extgen/hfile_test.go
@@ -1,10 +1,11 @@
 package extgen
 
 import (
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +44,7 @@ func TestHeaderGenerator_BuildContent(t *testing.T) {
 				"#ifndef _SIMPLE_H",
 				"#define _SIMPLE_H",
 				"#include <php.h>",
-				"extern zend_module_entry ext_module_entry;",
+				"extern zend_module_entry simple_module_entry;",
 				"#endif",
 			},
 		},
@@ -128,7 +129,7 @@ func TestHeaderGenerator_BasicStructure(t *testing.T) {
 
 	expectedElements := []string{
 		"#include <php.h>",
-		"extern zend_module_entry ext_module_entry;",
+		"extern zend_module_entry structtest_module_entry;",
 	}
 
 	for _, element := range expectedElements {
@@ -264,7 +265,7 @@ func TestHeaderGenerator_MinimalContent(t *testing.T) {
 		"#ifndef _MINIMAL_H",
 		"#define _MINIMAL_H",
 		"#include <php.h>",
-		"extern zend_module_entry ext_module_entry;",
+		"extern zend_module_entry minimal_module_entry;",
 		"#endif",
 	}
 
@@ -287,7 +288,7 @@ func testHeaderBasicStructure(t *testing.T, content, baseName string) {
 		"#ifndef _" + headerGuard,
 		"#define _" + headerGuard,
 		"#include <php.h>",
-		"extern zend_module_entry ext_module_entry;",
+		"extern zend_module_entry test_extension_module_entry;",
 		"#endif",
 	}
 

--- a/internal/extgen/srcanalyzer.go
+++ b/internal/extgen/srcanalyzer.go
@@ -10,11 +10,11 @@ import (
 
 type SourceAnalyzer struct{}
 
-func (sa *SourceAnalyzer) analyze(filename string) (imports []string, internalFunctions []string, err error) {
+func (sa *SourceAnalyzer) analyze(filename string) (imports []string, variables []string, internalFunctions []string, err error) {
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
 	if err != nil {
-		return nil, nil, fmt.Errorf("parsing file: %w", err)
+		return nil, nil, nil, fmt.Errorf("parsing file: %w", err)
 	}
 
 	for _, imp := range node.Imports {
@@ -30,12 +30,58 @@ func (sa *SourceAnalyzer) analyze(filename string) (imports []string, internalFu
 
 	sourceContent, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, nil, fmt.Errorf("reading source file: %w", err)
+		return nil, nil, nil, fmt.Errorf("reading source file: %w", err)
 	}
 
+	variables = sa.extractVariables(string(sourceContent))
 	internalFunctions = sa.extractInternalFunctions(string(sourceContent))
 
-	return imports, internalFunctions, nil
+	return imports, variables, internalFunctions, nil
+}
+
+func (sa *SourceAnalyzer) extractVariables(content string) []string {
+	lines := strings.Split(content, "\n")
+	var (
+		variables  []string
+		currentVar strings.Builder
+		inVarBlock bool
+		parenCount int
+	)
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmedLine, "var ") && !inVarBlock {
+			if strings.Contains(trimmedLine, "(") {
+				inVarBlock = true
+				parenCount = 1
+				currentVar.Reset()
+				currentVar.WriteString(line + "\n")
+			} else {
+				variables = append(variables, strings.TrimSpace(line))
+			}
+		} else if inVarBlock {
+			currentVar.WriteString(line + "\n")
+
+			for _, char := range line {
+				switch char {
+				case '(':
+					parenCount++
+				case ')':
+					parenCount--
+				}
+			}
+
+			if parenCount == 0 {
+				varContent := currentVar.String()
+				variables = append(variables, strings.TrimSpace(varContent))
+				inVarBlock = false
+				currentVar.Reset()
+			}
+		}
+	}
+
+	return variables
 }
 
 func (sa *SourceAnalyzer) extractInternalFunctions(content string) []string {

--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -5,17 +5,21 @@ package {{.PackageName}}
 #include "{{.BaseName}}.h"
 */
 import "C"
-import "runtime/cgo"
 {{- range .Imports}}
 import {{.}}
 {{- end}}
 
 func init() {
-	frankenphp.RegisterExtension(unsafe.Pointer(&C.ext_module_entry))
+	frankenphp.RegisterExtension(unsafe.Pointer(&C.{{.BaseName}}_module_entry))
 }
-{{range .Constants}}
+{{- range .Constants}}
 const {{.Name}} = {{.Value}}
 {{- end}}
+
+{{ range .Variables}}
+{{.}}
+{{- end}}
+
 {{range .InternalFunctions}}
 {{.}}
 {{- end}}

--- a/internal/extgen/templates/extension.h.tpl
+++ b/internal/extgen/templates/extension.h.tpl
@@ -4,7 +4,7 @@
 #include <php.h>
 #include <stdint.h>
 
-extern zend_module_entry ext_module_entry;
+extern zend_module_entry {{.BaseName}}_module_entry;
 
 {{if .Constants}}
 /* User defined constants */{{end}}


### PR DESCRIPTION
Support declaring local variables in the extension Go file.

Also, it fixes the module entry name by using the name part of the extension go file. Before that, it crashed when the the file is not named `ext.go`.

Finally, I removed the `runtime/cgo` import, which doesn't seem used.