### PR TITLE
add WorkingDirectory to make mercure.db files work without absolut paths

### DIFF
--- a/package/rhel/frankenphp.service
+++ b/package/rhel/frankenphp.service
@@ -9,6 +9,7 @@ Group=frankenphp
 ExecStartPre=/usr/bin/frankenphp validate --config /etc/frankenphp/Caddyfile
 ExecStart=/usr/bin/frankenphp run --environ --config /etc/frankenphp/Caddyfile
 ExecReload=/usr/bin/frankenphp reload --config /etc/frankenphp/Caddyfile
+WorkingDirectory=/var/lib/frankenphp
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512


### PR DESCRIPTION
I wonder if something has changed here? It no longer uses the $HOME directory of the user by default, but the working directory.