### PR TITLE
fix: free request context if php_request_startup() errors.

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -964,6 +964,7 @@ static int frankenphp_request_startup() {
     return SUCCESS;
   }
 
+  frankenphp_free_request_context();
   php_request_shutdown((void *)0);
 
   return FAILURE;


### PR DESCRIPTION
This possibly fixes #1841

`php_request_shutdown()` tries to `efree()` the request context, but we don't allocate the context with `emalloc()`.