### PR TITLE
fix `frankenphp trust` failing because admin api isn't started #1846

### DIFF
--- a/package/debian/postinst.sh
+++ b/package/debian/postinst.sh
@@ -63,5 +63,9 @@ if command -v setcap >/dev/null 2>&1; then
 fi
 
 if [ -x /usr/bin/frankenphp ]; then
+	HOME=/var/lib/frankenphp /usr/bin/frankenphp run --config /dev/null &
+	FRANKENPHP_PID=$!
 	HOME=/var/lib/frankenphp /usr/bin/frankenphp trust || true
+	kill "$FRANKENPHP_PID" || true
+	wait "$FRANKENPHP_PID" 2>/dev/null || true
 fi

--- a/package/rhel/postinstall.sh
+++ b/package/rhel/postinstall.sh
@@ -32,5 +32,9 @@ if command -v setcap >/dev/null 2>&1; then
 fi
 
 if [ -x /usr/bin/frankenphp ]; then
+	HOME=/var/lib/frankenphp /usr/bin/frankenphp run --config /dev/null &
+	FRANKENPHP_PID=$!
 	HOME=/var/lib/frankenphp /usr/bin/frankenphp trust || :
+	kill "$FRANKENPHP_PID" || :
+	wait "$FRANKENPHP_PID" 2>/dev/null || :
 fi


### PR DESCRIPTION
closes #1846
update frankenphp trust command to start it before so the admin api call doesn't fail 

I hope this is the right way to go about it, I couldn't find an alternative