### PR TITLE
feat: allow passing parameters to the PHP callback and accessing its return value

### DIFF
--- a/context.go
+++ b/context.go
@@ -28,7 +28,9 @@ type frankenPHPContext struct {
 	// Whether the request is already closed by us
 	isDone bool
 
-	responseWriter http.ResponseWriter
+	responseWriter    http.ResponseWriter
+	handlerParameters any
+	handlerReturn     any
 
 	done      chan any
 	startedAt time.Time

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -432,10 +432,10 @@ PHP_FUNCTION(frankenphp_handle_request) {
   zend_unset_timeout();
 #endif
 
-  bool has_request = go_frankenphp_worker_handle_request_start(thread_index);
+  struct go_frankenphp_worker_handle_request_start_return result = go_frankenphp_worker_handle_request_start(thread_index);
   if (frankenphp_worker_request_startup() == FAILURE
       /* Shutting down */
-      || !has_request) {
+      || !result.r0) {
     RETURN_FALSE;
   }
 
@@ -450,10 +450,18 @@ PHP_FUNCTION(frankenphp_handle_request) {
 
   /* Call the PHP func passed to frankenphp_handle_request() */
   zval retval = {0};
+  zval *callback_ret = NULL;
+
   fci.size = sizeof fci;
   fci.retval = &retval;
-  if (zend_call_function(&fci, &fcc) == SUCCESS) {
-    zval_ptr_dtor(&retval);
+  fci.params = result.r1;
+  fci.param_count = 1;
+
+  fprintf(stderr, "Calling user function\n");
+  if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+    fprintf(stderr, "Success\n");
+
+    callback_ret = &retval;
   }
 
   /*
@@ -467,7 +475,13 @@ PHP_FUNCTION(frankenphp_handle_request) {
   }
 
   frankenphp_worker_request_shutdown();
-  go_frankenphp_finish_worker_request(thread_index);
+  fprintf(stderr, "go_frankenphp_finish_worker_request\n");
+  go_frankenphp_finish_worker_request(thread_index, callback_ret);
+  if (callback_ret != NULL) {
+    zval_ptr_dtor(&retval);
+  }
+
+  fprintf(stderr, "return\n");
 
   RETURN_TRUE;
 }

--- a/threadFramework.go
+++ b/threadFramework.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-// WorkerExtension allows you to register an external worker where instead of calling frankenphp handlers on
+// EXPERIMENTAL: WorkerExtension allows you to register an external worker where instead of calling frankenphp handlers on
 // frankenphp_handle_request(), the ProvideRequest method is called. You are responsible for providing a standard
 // http.Request that will be conferred to the underlying worker script.
 //
@@ -39,18 +39,22 @@ type WorkerExtension interface {
 	ProvideRequest() *WorkerRequest
 }
 
+// EXPERIMENTAL
 type WorkerRequest struct {
 	// The request for your worker script to handle
 	Request *http.Request
-	// Response is a response writer that provides the output of the provided request
+	// Response is a response writer that provides the output of the provided request, it must not be nil to access the request body
 	Response http.ResponseWriter
-	// Done is an optional channel that will be closed when the request processing is complete
-	Done chan struct{}
+	// CallbackParameters is an optional field that will be converted in PHP types and passed as parameter to the PHP callback
+	CallbackParameters any
+	// AfterFunc is an optional function that will be called after the request is processed with the original value, the return of the PHP callback, converted in Go types, is passed as parameter
+	AfterFunc func(callbackReturn any)
 }
 
 var externalWorkers = make(map[string]WorkerExtension)
 var externalWorkerMutex sync.Mutex
 
+// EXPERIMENTAL
 func RegisterExternalWorker(worker WorkerExtension) {
 	externalWorkerMutex.Lock()
 	defer externalWorkerMutex.Unlock()
@@ -77,17 +81,22 @@ func startExternalWorkerPipe(w *worker, externalWorker WorkerExtension, thread *
 
 		if fc, ok := fromContext(fr.Context()); ok {
 			fc.responseWriter = rq.Response
+			fc.handlerParameters = rq.CallbackParameters
 
 			// Queue the request and wait for completion if Done channel was provided
 			logger.LogAttrs(context.Background(), slog.LevelInfo, "queue the external worker request", slog.String("worker", w.name), slog.Int("thread", thread.threadIndex))
 
 			w.requestChan <- fc
-			if rq.Done != nil {
+			if rq.AfterFunc != nil {
 				go func() {
 					<-fc.done
-					close(rq.Done)
+
+					if rq.AfterFunc != nil {
+						rq.AfterFunc(fc.handlerReturn)
+					}
 				}()
 			}
+
 		}
 	}
 }

--- a/threadworker.go
+++ b/threadworker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"time"
+	"unsafe"
 )
 
 // representation of a thread assigned to a worker script
@@ -159,7 +160,7 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 }
 
 // waitForWorkerRequest is called during frankenphp_handle_request in the php worker script.
-func (handler *workerThread) waitForWorkerRequest() bool {
+func (handler *workerThread) waitForWorkerRequest() (bool, any) {
 	// unpin any memory left over from previous requests
 	handler.thread.Unpin()
 
@@ -195,7 +196,7 @@ func (handler *workerThread) waitForWorkerRequest() bool {
 			C.frankenphp_reset_opcache()
 		}
 
-		return false
+		return false, nil
 	case fc = <-handler.thread.requestChan:
 	case fc = <-handler.worker.requestChan:
 	}
@@ -205,23 +206,33 @@ func (handler *workerThread) waitForWorkerRequest() bool {
 
 	logger.LogAttrs(ctx, slog.LevelDebug, "request handling started", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex), slog.String("url", fc.request.RequestURI))
 
-	return true
+	return true, fc.handlerParameters
 }
 
 // go_frankenphp_worker_handle_request_start is called at the start of every php request served.
 //
 //export go_frankenphp_worker_handle_request_start
-func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) C.bool {
+func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) (C.bool, unsafe.Pointer) {
 	handler := phpThreads[threadIndex].handler.(*workerThread)
-	return C.bool(handler.waitForWorkerRequest())
+	hasRequest, parameters := handler.waitForWorkerRequest()
+
+	if parameters != nil {
+		p := PHPValue(parameters)
+		handler.thread.Pin(p)
+
+		return C.bool(hasRequest), p
+	}
+
+	return C.bool(hasRequest), nil
 }
 
 // go_frankenphp_finish_worker_request is called at the end of every php request served.
 //
 //export go_frankenphp_finish_worker_request
-func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t) {
+func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t, retval *C.zval) {
 	thread := phpThreads[threadIndex]
 	fc := thread.getRequestContext()
+	fc.handlerReturn = GoValue(unsafe.Pointer(retval))
 
 	fc.closeContext()
 	thread.handler.(*workerThread).workerContext = nil


### PR DESCRIPTION
Usage:

```go
import (
	"net/http"
	"net/url"

	"github.com/dunglas/frankenphp"
)

var w = &worker{
	messages: make(chan message),
}

func init() {
	frankenphp.RegisterExternalWorker(w)
}

type worker struct {
	messages chan message
}

func (w *worker) Name() string {
	return "m#MyWorker"
}

func (w *worker) FileName() string {
	return "worker.php"
}

func (w *worker) GetMinThreads() int {
	return 1
}

func (w *worker) ThreadActivatedNotification(int)   {}
func (w *worker) ThreadDrainNotification(int)       {}
func (w *worker) ThreadDeactivatedNotification(int) {}
func (w *worker) Env() frankenphp.PreparedEnv {
	return frankenphp.PreparedEnv{}
}

var u = &url.URL{Host: "my-service.alt", Path: "/my-service"}

func (w *worker) ProvideRequest() *frankenphp.WorkerRequest {
	m := <-w.messages

	return &frankenphp.WorkerRequest{
		Request: &http.Request{URL: u}},
		CallbackParameters: m.request,
		AfterFunc: func(callbackReturn any) {
			m.responseChan <- callbackReturn
		},
	}
}
```

```php
<?php

// Handler outside the loop for better performance (doing less work)
$handler = static function (array $request): array  {
	// Do something with the request

    return ['message' => "Hello, {$request['Name']}"];
};

$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
    $keepRunning = \frankenphp_handle_request($handler);

    // Call the garbage collector to reduce the chances of it being triggered in the middle of the handling of a request
    gc_collect_cycles();

    if (!$keepRunning) {
      break;
    }
}
```