### PR TITLE
make WorkerExtension embeddable

### DIFF
--- a/threadFramework_test.go
+++ b/threadFramework_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockWorkerExtension implements the WorkerExtensionInterface interface
+// mockWorkerExtension implements the WorkerExtension interface
 type mockWorkerExtension struct {
-	WorkerExtension
+	Worker
 }
 
 func newMockWorkerExtension(name, fileName string, minThreads int) *mockWorkerExtension {
 	return &mockWorkerExtension{
-		WorkerExtension: WorkerExtension{
+		Worker: Worker{
 			ExtensionName:  name,
 			WorkerFileName: fileName,
 			WorkerEnv:      nil,

--- a/threadworker.go
+++ b/threadworker.go
@@ -20,7 +20,7 @@ type workerThread struct {
 	dummyContext    *frankenPHPContext
 	workerContext   *frankenPHPContext
 	backoff         *exponentialBackoff
-	externalWorker  WorkerExtensionInterface
+	externalWorker  WorkerExtension
 	isBootingScript bool // true if the worker has not reached frankenphp_handle_request yet
 }
 

--- a/threadworker.go
+++ b/threadworker.go
@@ -20,7 +20,7 @@ type workerThread struct {
 	dummyContext    *frankenPHPContext
 	workerContext   *frankenPHPContext
 	backoff         *exponentialBackoff
-	externalWorker  WorkerExtension
+	externalWorker  WorkerExtensionInterface
 	isBootingScript bool // true if the worker has not reached frankenphp_handle_request yet
 }
 


### PR DESCRIPTION
This introduces a small BC break: moving the interface of `WorkerExtension` to `WorkerExtensionInterface` and creating a new embeddable struct called `WorkerExtension`.