### PR TITLE
fix: returns a zend_array directly in types.go

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -126,7 +126,7 @@ func process_data_ordered_map(arr *C.zval) unsafe.Pointer {
 		// do something with key and value
 	}
 
-	// return an ordered array
+	// return an ordered zend_array
 	// if 'Order' is not empty, only the key-value pairs in 'Order' will be respected
 	return frankenphp.PHPAssociativeArray(AssociativeArray{
 		Map: map[string]any{
@@ -148,7 +148,7 @@ func process_data_unordered_map(arr *C.zval) unsafe.Pointer {
 		// do something with key and value
 	}
 
-	// return an unordered array
+	// return an unordered zend_array
 	return frankenphp.PHPMap(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
@@ -165,7 +165,7 @@ func process_data_packed(arr *C.zval) unsafe.Pointer {
 		// do something with index and value
 	}
 
-	// return a packed array
+	// return a packed zend_array
 	return frankenphp.PHPackedArray([]any{"value1", "value2", "value3"})
 }
 ```
@@ -180,9 +180,9 @@ func process_data_packed(arr *C.zval) unsafe.Pointer {
 
 ##### Available methods: Packed and Associative
 
-- `frankenphp.PHPAssociativeArray(arr frankenphp.AssociativeArray) unsafe.Pointer` - Convert to an ordered PHP array with key-value pairs
-- `frankenphp.PHPMap(arr map[string]any) unsafe.Pointer` - Convert a map to an unordered PHP array with key-value pairs
-- `frankenphp.PHPPackedArray(slice []any) unsafe.Pointer` - Convert a slice to a PHP packed array with indexed values only
+- `frankenphp.PHPAssociativeArray(arr frankenphp.AssociativeArray) unsafe.Pointer` - Convert to an ordered PHP zend_array with key-value pairs
+- `frankenphp.PHPMap(arr map[string]any) unsafe.Pointer` - Convert a map to an unordered PHP zend_array with key-value pairs
+- `frankenphp.PHPPackedArray(slice []any) unsafe.Pointer` - Convert a slice to a PHP packed zend_array with indexed values only
 - `frankenphp.GoAssociativeArray(arr unsafe.Pointer, ordered bool) frankenphp.AssociativeArray` - Convert a PHP array to an ordered Go `AssociativeArray` (map with order)
 - `frankenphp.GoMap(arr unsafe.Pointer) map[string]any` - Convert a PHP array to an unordered Go map
 - `frankenphp.GoPackedArray(arr unsafe.Pointer) []any` - Convert a PHP array to a Go slice

--- a/types.go
+++ b/types.go
@@ -1,6 +1,22 @@
 package frankenphp
 
 /*
+#cgo nocallback __zend_new_array__
+#cgo nocallback __zval_null__
+#cgo nocallback __zval_bool__
+#cgo nocallback __zval_long__
+#cgo nocallback __zval_double__
+#cgo nocallback __zval_string__
+#cgo nocallback __zval_arr__
+#cgo nocallback __emalloc__
+#cgo noescape __zend_new_array__
+#cgo noescape __zval_null__
+#cgo noescape __zval_bool__
+#cgo noescape __zval_long__
+#cgo noescape __zval_double__
+#cgo noescape __zval_string__
+#cgo noescape __zval_arr__
+#cgo noescape __emalloc__
 #include "types.h"
 */
 import "C"

--- a/types_test.go
+++ b/types_test.go
@@ -28,9 +28,10 @@ func TestGoString(t *testing.T) {
 	testOnDummyPHPThread(t, func() {
 		originalString := "Hello, World!"
 
-		convertedString := GoString(PHPString(originalString, false))
+		phpString := PHPString(originalString, false)
+		defer zendStringRelease(phpString)
 
-		assert.Equal(t, originalString, convertedString, "string -> zend_string -> string should yield an equal string")
+		assert.Equal(t, originalString, GoString(phpString), "string -> zend_string -> string should yield an equal string")
 	})
 }
 
@@ -41,9 +42,10 @@ func TestPHPMap(t *testing.T) {
 			"foo2": "bar2",
 		}
 
-		convertedMap := GoMap(PHPMap(originalMap))
+		phpArray := arrayAsZval(PHPMap(originalMap))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, originalMap, convertedMap, "associative array should be equal after conversion")
+		assert.Equal(t, originalMap, GoMap(phpArray), "associative array should be equal after conversion")
 	})
 }
 
@@ -57,9 +59,10 @@ func TestOrderedPHPAssociativeArray(t *testing.T) {
 			Order: []string{"foo2", "foo1"},
 		}
 
-		convertedArray := GoAssociativeArray(PHPAssociativeArray(originalArray))
+		phpArray := arrayAsZval(PHPAssociativeArray(originalArray))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, originalArray, convertedArray, "associative array should be equal after conversion")
+		assert.Equal(t, originalArray, GoAssociativeArray(phpArray), "associative array should be equal after conversion")
 	})
 }
 
@@ -67,9 +70,10 @@ func TestPHPPackedArray(t *testing.T) {
 	testOnDummyPHPThread(t, func() {
 		originalSlice := []any{"bar1", "bar2"}
 
-		convertedSlice := GoPackedArray(PHPPackedArray(originalSlice))
+		phpArray := arrayAsZval(PHPPackedArray(originalSlice))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, originalSlice, convertedSlice, "slice should be equal after conversion")
+		assert.Equal(t, originalSlice, GoPackedArray(phpArray), "slice should be equal after conversion")
 	})
 }
 
@@ -81,9 +85,10 @@ func TestPHPPackedArrayToGoMap(t *testing.T) {
 			"1": "bar2",
 		}
 
-		convertedMap := GoMap(PHPPackedArray(originalSlice))
+		phpArray := arrayAsZval(PHPPackedArray(originalSlice))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, expectedMap, convertedMap, "convert a packed to an associative array")
+		assert.Equal(t, expectedMap, GoMap(phpArray), "convert a packed to an associative array")
 	})
 }
 
@@ -98,9 +103,10 @@ func TestPHPAssociativeArrayToPacked(t *testing.T) {
 		}
 		expectedSlice := []any{"bar1", "bar2"}
 
-		convertedSlice := GoPackedArray(PHPAssociativeArray(originalArray))
+		phpArray := arrayAsZval(PHPAssociativeArray(originalArray))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, expectedSlice, convertedSlice, "convert an associative array to a slice")
+		assert.Equal(t, expectedSlice, GoPackedArray(phpArray), "convert an associative array to a slice")
 	})
 }
 
@@ -120,8 +126,9 @@ func TestNestedMixedArray(t *testing.T) {
 			},
 		}
 
-		convertedArray := GoMap(PHPMap(originalArray))
+		phpArray := arrayAsZval(PHPMap(originalArray))
+		defer zvalPtrDtor(phpArray)
 
-		assert.Equal(t, originalArray, convertedArray, "nested mixed array should be equal after conversion")
+		assert.Equal(t, originalArray, GoMap(phpArray), "nested mixed array should be equal after conversion")
 	})
 }


### PR DESCRIPTION
Should fix #1891.

Changes the PHP* array functions for extensions to return a `zend_array` instead of a `zval`.

In most cases it's easier to work with the `zend_array` and in the current setup the `zval` container sometimes needs pinning.

This PR also adds some wrapper functions so tests still work and some `#cgnocallback` and `#cgonoescape` optimizations