### PR TITLE
docs: Add warning on stateful services and shared memory model

### DIFF
--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -7,10 +7,7 @@ FrankenPHP traitera les requêtes entrantes en quelques millisecondes.
 
 Attention, ce mode ajoute un nouveau paradigme de développement. Si votre code n'est pas stateless (sans état), l'activation du mode worker risque d'introduire des comportements inattendus.
 
-Contrairement au modèle PHP-FPM traditionnel ("Shared Nothing"), où la mémoire est effacée après chaque requête.
-
-L'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
-
+Contrairement au modèle PHP-FPM traditionnel, l'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
 L'article suivant résume très bien ce problème et explique comment y remédier, notamment pour les applications Symfony en utilisant ResetInterface pour garantir que vos services sont "propres" à chaque nouvelle requête.
 
 **Ressources supplémentaires :**

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -15,9 +15,9 @@ L'article suivant résume très bien ce problème et explique comment y remédie
 
 **Ressources supplémentaires :**
 
-* **Article (EN)** : [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explique le problème en détail et présente des solutions.
-* **Symfony** : La [documentation de Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) aborde également ce concept de "stateless worker".
-* **Outil** : [phanalist](https://github.com/denzyldick/phanalist) est un analyseur statique (mentionné dans l'article) qui peut vous aider à détecter les services "stateful" dans votre code.
+- Article (EN) : [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explique le problème en détail et présente des solutions.
+- Symfony : La [documentation de Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) aborde également ce concept de "stateless worker".
+- Outil : [phanalist](https://github.com/denzyldick/phanalist) est un analyseur statique (mentionné dans l'article) qui peut vous aider à détecter les services "stateful" dans votre code.
 
 ## Démarrage des scripts workers
 

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -3,18 +3,16 @@
 Démarrez votre application une fois et gardez-la en mémoire.
 FrankenPHP traitera les requêtes entrantes en quelques millisecondes.
 
-## Un changement de paradigme
-
-Attention, ce mode ajoute un nouveau paradigme de développement. Si votre code n'est pas stateless (sans état), l'activation du mode worker risque d'introduire des comportements inattendus.
+## Avertissement sur la conception Stateful
 
 Contrairement au modèle PHP-FPM traditionnel, l'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
 L'article suivant résume très bien ce problème et explique comment y remédier, notamment pour les applications Symfony en utilisant ResetInterface pour garantir que vos services sont "propres" à chaque nouvelle requête.
 
 **Ressources supplémentaires :**
 
-- Article (EN) : [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explique le problème en détail et présente des solutions.
+- Article (EN) : [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g)
 - Symfony : La [documentation de Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) aborde également ce concept de "stateless worker".
-- Outil : [phanalist](https://github.com/denzyldick/phanalist) est un analyseur statique (mentionné dans l'article) qui peut vous aider à détecter les services "stateful" dans votre code.
+- Outil : [phanalist](https://github.com/denzyldick/phanalist) est un analyseur statique qui peut vous aider à détecter les services "stateful" dans votre code.
 
 ## Démarrage des scripts workers
 

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -3,6 +3,22 @@
 Démarrez votre application une fois et gardez-la en mémoire.
 FrankenPHP traitera les requêtes entrantes en quelques millisecondes.
 
+## Un changement de paradigme : Le modèle "Shared Memory"
+
+Attention, ce mode ajoute un nouveau paradigme de développement. Si votre code n'est pas stateless (sans état), l'activation du mode worker risque d'introduire des comportements inattendus.
+
+Contrairement au modèle PHP-FPM traditionnel ("Shared Nothing"), où la mémoire est effacée après chaque requête, le mode worker de FrankenPHP utilise un modèle de mémoire partagée ("Shared Memory Model").
+
+L'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
+
+L'article suivant résume très bien ce problème et explique comment y remédier, notamment pour les applications Symfony en utilisant ResetInterface pour garantir que vos services sont "propres" à chaque nouvelle requête.
+
+**Ressources supplémentaires :**
+
+* **Article (EN)** : [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explique le problème en détail et présente des solutions.
+* **Symfony** : La [documentation de Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) aborde également ce concept de "stateless worker".
+* **Outil** : [phanalist](https://github.com/denzyldick/phanalist) est un analyseur statique (mentionné dans l'article) qui peut vous aider à détecter les services "stateful" dans votre code.
+
 ## Démarrage des scripts workers
 
 ### Docker

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -3,11 +3,11 @@
 Démarrez votre application une fois et gardez-la en mémoire.
 FrankenPHP traitera les requêtes entrantes en quelques millisecondes.
 
-## Un changement de paradigme : Le modèle "Shared Memory"
+## Un changement de paradigme
 
 Attention, ce mode ajoute un nouveau paradigme de développement. Si votre code n'est pas stateless (sans état), l'activation du mode worker risque d'introduire des comportements inattendus.
 
-Contrairement au modèle PHP-FPM traditionnel ("Shared Nothing"), où la mémoire est effacée après chaque requête, le mode worker de FrankenPHP utilise un modèle de mémoire partagée ("Shared Memory Model").
+Contrairement au modèle PHP-FPM traditionnel ("Shared Nothing"), où la mémoire est effacée après chaque requête.
 
 L'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
 

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -5,8 +5,8 @@ FrankenPHP traitera les requêtes entrantes en quelques millisecondes.
 
 ## Avertissement sur la conception Stateful
 
-Contrairement au modèle PHP-FPM traditionnel, l'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données ou des états incohérents si votre application n'est pas conçue pour cela.
-L'article suivant résume très bien ce problème et explique comment y remédier, notamment pour les applications Symfony en utilisant ResetInterface pour garantir que vos services sont "propres" à chaque nouvelle requête.
+Contrairement au modèle PHP-FPM traditionnel, l'application reste chargée en mémoire entre les requêtes. Par conséquent, tout état stocké dans vos services (propriétés d'objet, singletons, etc.) sera conservé et partagé entre les requêtes successives traitées par le même worker. Cela peut entraîner des fuites de données et de mémoires ou des états incohérents si votre application n'est pas conçue pour cela.
+L'article suivant résume ce problème et explique comment y remédier, notamment pour les applications Symfony en utilisant ResetInterface pour garantir que vos services sont "réinitialisés" à chaque nouvelle requête.
 
 **Ressources supplémentaires :**
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -15,9 +15,10 @@ The following article summarizes this issue very well and explains how to fix it
 
 **Additional Resources:**
 
-* **Article**: [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explains the problem in detail and presents solutions.
-* **Symfony**: [The Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) documentation also discusses this "stateless worker" concept.
-* **Tool**: [phanalist](https://github.com/denzyldick/phanalist) is a static analyzer (mentioned in the article) that can help you detect "stateful" services in your code.
+- Article: [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explains the problem in detail and presents solutions.
+- Symfony: [The Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) documentation also discusses this "stateless worker" concept.
+- Tool: [phanalist](https://github.com/denzyldick/phanalist) is a static analyzer (mentioned in the article) that can help you detect "stateful" services in your code.
+
 ## Starting Worker Scripts
 
 ### Docker

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -3,11 +3,11 @@
 Boot your application once and keep it in memory.
 FrankenPHP will handle incoming requests in a few milliseconds.
 
-## A Paradigm Shift: The "Shared Memory" Model
+## A Paradigm Shift
 
 Warning: This mode introduces a new development paradigm. If your code is not stateless, enabling worker mode risks introducing unexpected behavior.
 
-Unlike the traditional PHP-FPM model ("Shared Nothing"), where memory is cleared after every request, FrankenPHP's worker mode uses a "Shared Memory Model".
+Unlike the traditional PHP-FPM model ("Shared Nothing"), where memory is cleared after every request.
 
 The application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -3,6 +3,21 @@
 Boot your application once and keep it in memory.
 FrankenPHP will handle incoming requests in a few milliseconds.
 
+## A Paradigm Shift: The "Shared Memory" Model
+
+Warning: This mode introduces a new development paradigm. If your code is not stateless, enabling worker mode risks introducing unexpected behavior.
+
+Unlike the traditional PHP-FPM model ("Shared Nothing"), where memory is cleared after every request, FrankenPHP's worker mode uses a "Shared Memory Model".
+
+The application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
+
+The following article summarizes this issue very well and explains how to fix it, notably for Symfony applications using ResetInterface to ensure your services are "clean" for every new request.
+
+**Additional Resources:**
+
+* **Article**: [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explains the problem in detail and presents solutions.
+* **Symfony**: [The Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) documentation also discusses this "stateless worker" concept.
+* **Tool**: [phanalist](https://github.com/denzyldick/phanalist) is a static analyzer (mentioned in the article) that can help you detect "stateful" services in your code.
 ## Starting Worker Scripts
 
 ### Docker

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -5,8 +5,8 @@ FrankenPHP will handle incoming requests in a few milliseconds.
 
 ## Warning about stateful design
 
-Unlike with the traditional PHP-FPM model, the application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
-The following article summarizes this issue very well and explains how to fix it, notably for Symfony applications using ResetInterface to ensure your services are "clean" for every new request.
+Unlike with the traditional PHP-FPM model, the application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks and memory issues, or inconsistent states if your application is not designed for it.
+The following article summarizes this issue and explains how to fix it, notably for Symfony applications using ResetInterface to ensure your services are "reset" for every new request.
 
 **Additional Resources:**
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -7,10 +7,7 @@ FrankenPHP will handle incoming requests in a few milliseconds.
 
 Warning: This mode introduces a new development paradigm. If your code is not stateless, enabling worker mode risks introducing unexpected behavior.
 
-Unlike the traditional PHP-FPM model ("Shared Nothing"), where memory is cleared after every request.
-
-The application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
-
+Unlike with the traditional PHP-FPM model, the application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
 The following article summarizes this issue very well and explains how to fix it, notably for Symfony applications using ResetInterface to ensure your services are "clean" for every new request.
 
 **Additional Resources:**

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -3,18 +3,16 @@
 Boot your application once and keep it in memory.
 FrankenPHP will handle incoming requests in a few milliseconds.
 
-## A Paradigm Shift
-
-Warning: This mode introduces a new development paradigm. If your code is not stateless, enabling worker mode risks introducing unexpected behavior.
+## Warning about stateful design
 
 Unlike with the traditional PHP-FPM model, the application remains loaded in memory between requests. Consequently, any state stored in your services (object properties, singletons, etc.) will be preserved and shared across successive requests handled by the same worker. This can lead to data leaks or inconsistent states if your application is not designed for it.
 The following article summarizes this issue very well and explains how to fix it, notably for Symfony applications using ResetInterface to ensure your services are "clean" for every new request.
 
 **Additional Resources:**
 
-- Article: [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g) - Explains the problem in detail and presents solutions.
+- Article: [Getting your Symfony app ready for Swoole, RoadRunner, and FrankenPHP](https://dev.to/sergiid/getting-symfony-app-ready-for-swoole-roadrunner-and-frankenphp-no-ai-involved-2d0g)
 - Symfony: [The Messenger](https://symfony.com/doc/current/messenger.html#stateless-worker) documentation also discusses this "stateless worker" concept.
-- Tool: [phanalist](https://github.com/denzyldick/phanalist) is a static analyzer (mentioned in the article) that can help you detect "stateful" services in your code.
+- Tool: [phanalist](https://github.com/denzyldick/phanalist) is a static analyzer that can help you detect "stateful" services in your code.
 
 ## Starting Worker Scripts
 


### PR DESCRIPTION
This Pull Request proposes an update to the documentation to better explain FrankenPHP's Worker Mode.

The goal is to provide clear information regarding:

Associated Risks of state persistence (stateful services) across consecutive requests.

Best practices and tools (such as Symfony's ResetInterface or phanalist) to ensure a successful migration of applications to this high-performance model.

This clarification aims to prevent unexpected behaviors and facilitate the adoption of Worker Mode.