### PR TITLE
feat: add support for exclusion patterns with '!' prefix

### DIFF
--- a/internal/watcher/pattern.go
+++ b/internal/watcher/pattern.go
@@ -19,6 +19,7 @@ type pattern struct {
 	parsedValues []string
 	events       chan eventHolder
 	failureCount int
+	isExclude    bool
 
 	watcher *watcher.Watcher
 }
@@ -33,8 +34,17 @@ func (p *pattern) startSession() {
 
 // this method prepares the pattern struct (aka /path/*pattern)
 func (p *pattern) parse() (err error) {
-	// first we clean the value
-	absPattern, err := fastabs.FastAbs(p.value)
+	// detect exclusion before resolving to absolute
+	raw := strings.TrimSpace(p.value)
+	if strings.HasPrefix(raw, "!") {
+		p.isExclude = true
+		raw = strings.TrimSpace(strings.TrimPrefix(raw, "!"))
+	} else {
+		p.isExclude = false
+	}
+
+	// then we clean the value
+	absPattern, err := fastabs.FastAbs(raw)
 	if err != nil {
 		return err
 	}
@@ -81,7 +91,7 @@ func (p *pattern) parse() (err error) {
 	return nil
 }
 
-func (p *pattern) allowReload(event *watcher.Event) bool {
+func (p *pattern) matchesEvent(event *watcher.Event) bool {
 	if !isValidEventType(event.EffectType) || !isValidPathType(event) {
 		return false
 	}
@@ -90,6 +100,15 @@ func (p *pattern) allowReload(event *watcher.Event) bool {
 	// so we need to also check Event.AssociatedPathName
 	// see https://github.com/php/frankenphp/issues/1375
 	return p.isValidPattern(event.PathName) || p.isValidPattern(event.AssociatedPathName)
+}
+
+func (p *pattern) allowReload(event *watcher.Event) bool {
+	// Excludes never trigger reload by themselves, but they still match events for filtering.
+	if p.isExclude {
+		return false
+	}
+
+	return p.matchesEvent(event)
 }
 
 func (p *pattern) handle(event *watcher.Event) {

--- a/internal/watcher/pattern_test.go
+++ b/internal/watcher/pattern_test.go
@@ -355,6 +355,44 @@ func TestAnAssociatedEventTriggersTheWatcher(t *testing.T) {
 	assert.Equal(t, e, (<-w.events).event)
 }
 
+func TestGlobalWatcherIsExcludedEvent(t *testing.T) {
+	pg := &PatternGroup{Patterns: []string{"/app/**/*.php", "!/app/vendor/**"}}
+
+	include := &pattern{patternGroup: pg, value: "/app/**/*.php"}
+	exclude := &pattern{patternGroup: pg, value: "!/app/vendor/**"}
+
+	require.NoError(t, include.parse())
+	require.NoError(t, exclude.parse())
+
+	gw := &globalWatcher{
+		groups:   []*PatternGroup{pg},
+		watchers: []*pattern{include, exclude},
+		excludes: map[*PatternGroup][]*pattern{pg: {exclude}},
+	}
+
+	inVendor := &watcher.Event{PathName: "/app/vendor/pkg/file.php"}
+	assert.True(t, include.matchesEvent(inVendor))
+	assert.True(t, gw.isExcludedEvent(pg, inVendor))
+
+	notInVendor := &watcher.Event{PathName: "/app/src/file.php"}
+	assert.True(t, include.matchesEvent(notInVendor))
+	assert.False(t, gw.isExcludedEvent(pg, notInVendor))
+}
+
+func TestExcludeMatchesAssociatedPath(t *testing.T) {
+	pg := &PatternGroup{Patterns: []string{"/app/**/*.php", "!/app/vendor/**"}}
+
+	exclude := &pattern{patternGroup: pg, value: "!/app/vendor/**"}
+	require.NoError(t, exclude.parse())
+
+	gw := &globalWatcher{
+		excludes: map[*PatternGroup][]*pattern{pg: {exclude}},
+	}
+
+	e := &watcher.Event{PathName: "/tmp/temporary", AssociatedPathName: "/app/vendor/x/file.php"}
+	assert.True(t, gw.isExcludedEvent(pg, e))
+}
+
 func relativeDir(t *testing.T, relativePath string) string {
 	t.Helper()
 


### PR DESCRIPTION
Resolve #2095

Add exclusion pattern support to allow users to exclude specific paths from triggering reloads. Patterns prefixed with '!' are now parsed as exclusions and stored separately. The globalWatcher checks if events match any exclusion patterns before processing them, preventing excluded paths from triggering reloads while still allowing them to be matched for filtering purposes.

- Add isExclude field to track exclusion patterns
- Parse '!' prefix during pattern initialization
- Rename allowReload to matchesEvent for clarity on matching logic
- Extract exclusion check into separate allowReload wrapper
- Add isExcludedEvent method to globalWatcher for event filtering
- Filter excluded events before debouncing in event listener