### PR TITLE
feat: background workers = non-HTTP workers with shared state

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Set CGO flags
         run: |
           {
-            echo "CGO_CFLAGS=$CFLAGS -I${PWD}/watcher/target/include -DFRANKENPHP_TEST $(php-config --includes)"
+            echo "CGO_CFLAGS=$CFLAGS -I${PWD}/watcher/target/include $(php-config --includes)"
             echo "CGO_LDFLAGS=$LDFLAGS $(php-config --ldflags) $(php-config --libs)"
           } >> "$GITHUB_ENV"
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,7 @@ jobs:
         # TODO: remove this workaround when fixed upstream
         run: sudo apt-get install --reinstall -y libbrotli-dev
       - name: Set CGO flags
-        run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include -DFRANKENPHP_TEST $(php-config --includes)" >> "${GITHUB_ENV}"
+        run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"
       - name: Build
         run: go build
       - name: Build testcli binary
@@ -138,7 +138,7 @@ jobs:
           echo "GEN_STUB_SCRIPT=${PWD}/php-${PHP_VERSION}/build/gen_stub.php" >> "${GITHUB_ENV}"
       - name: Set CGO flags
         run: |
-          echo "CGO_CFLAGS=-DFRANKENPHP_TEST $(php-config --includes)" >> "${GITHUB_ENV}"
+          echo "CGO_CFLAGS=$(php-config --includes)" >> "${GITHUB_ENV}"
           echo "CGO_LDFLAGS=$(php-config --ldflags) $(php-config --libs)" >> "${GITHUB_ENV}"
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
@@ -175,7 +175,7 @@ jobs:
       - name: Set CGO flags
         run: |
           {
-           echo "CGO_CFLAGS=-I/opt/homebrew/include/ -DFRANKENPHP_TEST $(php-config --includes)"
+           echo "CGO_CFLAGS=-I/opt/homebrew/include/ $(php-config --includes)"
            echo "CGO_LDFLAGS=-L/opt/homebrew/lib/ $(php-config --ldflags) $(php-config --libs)"
           } >> "${GITHUB_ENV}"
       - name: Build

--- a/bgworker.go
+++ b/bgworker.go
@@ -1,5 +1,6 @@
 package frankenphp
 
+// #include <stdint.h>
 // #include "frankenphp.h"
 import "C"
 import (
@@ -44,53 +45,12 @@ type backgroundWorkerExtras struct {
 	lazyStarted bool
 }
 
-// backgroundWorkerState is the per-instance readiness signal ensure()
-// blocks on. ready closes once the worker calls
-// frankenphp_get_worker_handle(); aborted closes on max_consecutive_failures
-// before that.
-type backgroundWorkerState struct {
-	ready     chan struct{}
-	readyOnce sync.Once
-
-	aborted   chan struct{}
-	abortOnce sync.Once
-	abortErr  error
-
-	// bootFailure carries the most recent pre-readiness crash so a
-	// timing-out ensure() can report it.
-	bootFailure atomic.Pointer[bootFailureInfo]
-}
-
 // bootFailureInfo is the boot-phase crash metadata surfaced by ensure().
 type bootFailureInfo struct {
 	entrypoint   string
 	exitStatus   int
 	failureCount int
-	// TODO(sidekicks): capture PG(last_error_message) once the C-side
-	// helper lands in the set_vars/get_vars step.
-	phpError string
-}
-
-func newBackgroundWorkerState() *backgroundWorkerState {
-	return &backgroundWorkerState{
-		ready:   make(chan struct{}),
-		aborted: make(chan struct{}),
-	}
-}
-
-// markReady fires on the first frankenphp_get_worker_handle() call after
-// each (re)boot. Idempotent: the channel only closes once.
-func (r *backgroundWorkerState) markReady() {
-	r.readyOnce.Do(func() { close(r.ready) })
-}
-
-// abort unblocks ensure() waiters when the boot sequence is abandoned
-// (max_consecutive_failures hit before readiness). Idempotent.
-func (r *backgroundWorkerState) abort(err error) {
-	r.abortOnce.Do(func() {
-		r.abortErr = err
-		close(r.aborted)
-	})
+	phpError     string
 }
 
 // Scope isolates background workers between php_server blocks; the
@@ -300,30 +260,30 @@ func getLookup(thread *phpThread) *backgroundWorkerLookup {
 	return backgroundLookups[0]
 }
 
-// ensureBackgroundWorker lazy-starts the named worker if needed and blocks
-// until it reaches readiness, aborts (max_consecutive_failures during boot),
-// or times out. Safe to call concurrently.
-func ensureBackgroundWorker(thread *phpThread, bgWorkerName string, timeout time.Duration) error {
+// startBackgroundWorker resolves `name` via lookup.byName / lookup.catchAll,
+// lazy-starting the thread if needed, and returns the per-instance state
+// slot the caller should wait on. Safe to call concurrently.
+func startBackgroundWorker(thread *phpThread, bgWorkerName string) (*backgroundWorkerState, error) {
 	if bgWorkerName == "" {
-		return fmt.Errorf("background worker name must not be empty")
+		return nil, fmt.Errorf("background worker name must not be empty")
 	}
 	lookup := getLookup(thread)
 	if lookup == nil {
-		return fmt.Errorf("no background worker configured")
+		return nil, fmt.Errorf("no background worker configured")
 	}
 
 	// byName is keyed by the user-facing (m#-stripped) name.
 	if w, ok := lookup.byName[bgWorkerName]; ok {
-		r, err := lazyStartNamedWorker(w)
+		sk, err := lazyStartNamedWorker(w)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+		return sk, nil
 	}
 
 	catchAll := lookup.catchAll
 	if catchAll == nil {
-		return fmt.Errorf("no background worker configured for name %q", bgWorkerName)
+		return nil, fmt.Errorf("no background worker configured for name %q", bgWorkerName)
 	}
 
 	// Reject so behavior doesn't silently split-brain across the eager
@@ -331,7 +291,7 @@ func ensureBackgroundWorker(thread *phpThread, bgWorkerName string, timeout time
 	// buildBackgroundWorkerLookups: module catch-alls carry the prefix,
 	// bgWorkerName from PHP never does.
 	if bgWorkerName == strings.TrimPrefix(catchAll.name, "m#") {
-		return fmt.Errorf(`cannot ensure() against "%s": it matches the catch-all's own name; use a distinct user-facing name`, bgWorkerName)
+		return nil, fmt.Errorf(`cannot ensure() against "%s": it matches the catch-all's own name; use a distinct user-facing name`, bgWorkerName)
 	}
 
 	// Hold catchAllMu across thread reservation + entry publication so a
@@ -340,29 +300,29 @@ func ensureBackgroundWorker(thread *phpThread, bgWorkerName string, timeout time
 	bg := catchAll.bg
 	bg.catchAllMu.Lock()
 
-	if r, ok := bg.catchAllNames[bgWorkerName]; ok {
+	if sk, ok := bg.catchAllNames[bgWorkerName]; ok {
 		bg.catchAllMu.Unlock()
-		return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+		return sk, nil
 	}
 
 	if bg.catchAllCap > 0 && len(bg.catchAllNames) >= bg.catchAllCap {
 		bg.catchAllMu.Unlock()
-		return fmt.Errorf("cannot start background worker %q: limit of %d reached (increase max threads or declare it as a named worker)", bgWorkerName, bg.catchAllCap)
+		return nil, fmt.Errorf("cannot start background worker %q: limit of %d reached (increase max threads or declare it as a named worker)", bgWorkerName, bg.catchAllCap)
 	}
 
-	r := newBackgroundWorkerState()
-	bg.catchAllNames[bgWorkerName] = r
+	sk := newBackgroundWorkerState()
+	bg.catchAllNames[bgWorkerName] = sk
 	bg.catchAllMu.Unlock()
 
-	if _, err := addBackgroundWorkerThread(catchAll, bgWorkerName, r); err != nil {
-		// Wake any concurrent waiter that picked up r from catchAllNames
+	if _, err := addBackgroundWorkerThread(catchAll, bgWorkerName, sk); err != nil {
+		// Wake any concurrent waiter that picked up sk from catchAllNames
 		// between our publish and this rollback so they see the start
 		// failure instead of timing out.
-		r.abort(err)
+		sk.abort(err)
 		bg.catchAllMu.Lock()
 		delete(bg.catchAllNames, bgWorkerName)
 		bg.catchAllMu.Unlock()
-		return fmt.Errorf("cannot start background worker %q: %w (increase max threads)", bgWorkerName, err)
+		return nil, fmt.Errorf("cannot start background worker %q: %w (increase max threads)", bgWorkerName, err)
 	}
 
 	if globalLogger.Enabled(globalCtx, slog.LevelInfo) {
@@ -370,7 +330,7 @@ func ensureBackgroundWorker(thread *phpThread, bgWorkerName string, timeout time
 			slog.String("name", bgWorkerName))
 	}
 
-	return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+	return sk, nil
 }
 
 // lazyStartNamedWorker returns the readiness slot the caller should
@@ -394,66 +354,121 @@ func lazyStartNamedWorker(w *worker) (*backgroundWorkerState, error) {
 	return r, nil
 }
 
-// waitForBackgroundWorkerReady blocks until the worker reaches readiness,
-// aborts, or the timeout elapses. A nil state degrades to ready-immediately
-// to avoid a deadlock for workers declared without an allocated slot.
-func waitForBackgroundWorkerReady(name string, r *backgroundWorkerState, timeout time.Duration) error {
-	if r == nil {
-		return nil
-	}
-	if timeout <= 0 {
-		timeout = defaultEnsureTimeout
-	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-r.ready:
-		return nil
-	case <-r.aborted:
-		return fmt.Errorf("background worker %q failed to start: %w", name, r.abortErr)
-	case <-timer.C:
-		return formatEnsureTimeoutError(name, r, timeout)
-	}
+// isBootstrapEnsure reports whether the calling thread is inside an HTTP
+// worker's boot phase. Bootstrap callers take the fail-fast path; runtime
+// callers (bg workers, classic requests) take the tolerant lazy-start path.
+func isBootstrapEnsure(thread *phpThread) bool {
+	handler, ok := thread.handler.(*workerThread)
+	return ok && handler.isBootingScript
 }
 
-func formatEnsureTimeoutError(name string, r *backgroundWorkerState, timeout time.Duration) error {
-	if bf := r.bootFailure.Load(); bf != nil {
+// formatBackgroundWorkerTimeoutError produces the timeout-error message
+// for an ensure() that didn't reach combined readiness in time. Mentions
+// the boot failure if one was recorded; otherwise reports which half of
+// the readiness signal the worker missed.
+func formatBackgroundWorkerTimeoutError(name string, sk *backgroundWorkerState, timeout time.Duration) string {
+	if info := sk.bootFailure.Load(); info != nil {
 		msg := fmt.Sprintf("background worker %q did not become ready within %s; last attempt %d failed (exit status %d, entrypoint %s)",
-			name, timeout, bf.failureCount, bf.exitStatus, bf.entrypoint)
-		if bf.phpError != "" {
-			msg += ": " + bf.phpError
+			name, timeout, info.failureCount, info.exitStatus, info.entrypoint)
+		if info.phpError != "" {
+			msg += ": " + info.phpError
 		}
-		return errors.New(msg)
+		return msg
 	}
-	return fmt.Errorf("background worker %q did not call frankenphp_get_worker_handle() within %s", name, timeout)
+	missing := []string{}
+	if !sk.hasHandle.Load() {
+		missing = append(missing, "frankenphp_get_worker_handle()")
+	}
+	if !sk.hasVars.Load() {
+		missing = append(missing, "frankenphp_set_vars()")
+	}
+	if len(missing) == 0 {
+		return fmt.Sprintf("background worker %q did not become ready within %s", name, timeout)
+	}
+	return fmt.Sprintf("background worker %q did not call %s within %s", name, strings.Join(missing, " and "), timeout)
 }
+
+// errBackgroundWorkerNotInsideBgThread is returned by set_vars when called
+// outside a bg-worker thread. Package-level so tests can match it.
+var errBackgroundWorkerNotInsideBgThread = errors.New("frankenphp_set_vars() can only be called from a background worker")
 
 // go_frankenphp_ensure_background_worker lazy-starts each named bg worker
-// (the C side has validated names are non-empty and unique) and blocks
-// until each signals readiness, aborts, or timeoutMs (ms; <=0 = default)
-// elapses.
+// (C side has validated names are non-empty + unique) and blocks until
+// each reaches combined readiness (get_worker_handle + set_vars), aborts,
+// or timeoutMs elapses (<=0 = default). Bootstrap callers (HTTP worker
+// pre-handle_request) fail fast on boot failures; runtime callers wait
+// out the restart/backoff cycle.
 //
 //export go_frankenphp_ensure_background_worker
 func go_frankenphp_ensure_background_worker(threadIndex C.uintptr_t, names **C.char, nameLens *C.size_t, nameCount C.int, timeoutMs C.int64_t) *C.char {
 	thread := phpThreads[threadIndex]
-	n := int(nameCount)
-	if n <= 0 {
-		return nil
-	}
 	timeout := time.Duration(int64(timeoutMs)) * time.Millisecond
+	if timeout <= 0 {
+		timeout = defaultEnsureTimeout
+	}
+
+	n := int(nameCount)
 	nameSlice := unsafe.Slice(names, n)
 	nameLenSlice := unsafe.Slice(nameLens, n)
+	bootstrap := isBootstrapEnsure(thread)
+
+	// Start each named worker first. Reserve their states so a shared
+	// deadline applies across the whole group (the caller gets one
+	// timeout value, not one per worker).
+	sks := make([]*backgroundWorkerState, n)
+	goNames := make([]string, n)
 	for i := 0; i < n; i++ {
-		goName := C.GoStringN(nameSlice[i], C.int(nameLenSlice[i]))
-		if err := ensureBackgroundWorker(thread, goName, timeout); err != nil {
+		goNames[i] = C.GoStringN(nameSlice[i], C.int(nameLenSlice[i]))
+		sk, err := startBackgroundWorker(thread, goNames[i])
+		if err != nil {
 			return C.CString(err.Error())
+		}
+		sks[i] = sk
+	}
+
+	deadline := time.After(timeout)
+	if bootstrap {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for i, sk := range sks {
+		wait:
+			for {
+				select {
+				case <-sk.ready:
+					break wait
+				case <-sk.aborted:
+					return C.CString(sk.abortErr.Error())
+				case <-deadline:
+					return C.CString(formatBackgroundWorkerTimeoutError(goNames[i], sk, timeout))
+				case <-globalCtx.Done():
+					return C.CString("frankenphp is shutting down")
+				case <-ticker.C:
+					if sk.bootFailure.Load() != nil {
+						return C.CString(formatBackgroundWorkerTimeoutError(goNames[i], sk, timeout))
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	for i, sk := range sks {
+		select {
+		case <-sk.ready:
+		case <-sk.aborted:
+			return C.CString(sk.abortErr.Error())
+		case <-deadline:
+			return C.CString(formatBackgroundWorkerTimeoutError(goNames[i], sk, timeout))
+		case <-globalCtx.Done():
+			return C.CString("frankenphp is shutting down")
 		}
 	}
 	return nil
 }
 
-// go_frankenphp_worker_ready closes the per-thread readiness channel on
-// the first frankenphp_get_worker_handle() call. Idempotent.
+// go_frankenphp_worker_ready marks the handle half of the combined
+// readiness signal on the per-thread state slot. The slot's ready channel
+// closes only once both handle and set_vars have fired. Idempotent.
 //
 //export go_frankenphp_worker_ready
 func go_frankenphp_worker_ready(threadIndex C.uintptr_t) {
@@ -465,7 +480,73 @@ func go_frankenphp_worker_ready(threadIndex C.uintptr_t) {
 	if !ok || handler == nil {
 		return
 	}
-	if r := handler.backgroundReady; r != nil {
-		r.markReady()
+	if sk := handler.backgroundWorker; sk != nil {
+		sk.markHandle()
 	}
+}
+
+// go_frankenphp_set_vars is called from PHP when a background worker
+// publishes its shared vars. The caller has already deep-copied the vars
+// into persistent memory; here we swap the pointer under the state lock
+// and hand back the old pointer so the C side can free it after the call.
+//
+//export go_frankenphp_set_vars
+func go_frankenphp_set_vars(threadIndex C.uintptr_t, varsPtr unsafe.Pointer, oldPtr *unsafe.Pointer) *C.char {
+	thread := phpThreads[threadIndex]
+
+	bgHandler, ok := thread.handler.(*backgroundWorkerThread)
+	if !ok || bgHandler.backgroundWorker == nil {
+		return C.CString(errBackgroundWorkerNotInsideBgThread.Error())
+	}
+
+	sk := bgHandler.backgroundWorker
+
+	sk.mu.Lock()
+	*oldPtr = sk.varsPtr
+	sk.varsPtr = varsPtr
+	sk.varsVersion.Add(1)
+	sk.mu.Unlock()
+
+	bgHandler.markBackgroundReady()
+
+	return nil
+}
+
+// go_frankenphp_get_vars resolves the named worker through the lookup
+// (named or catch-all), checks its sk.ready without starting the worker,
+// and copies its vars into the return value. If the caller hasn't called
+// ensure() first, this returns a "not ready" error.
+//
+//export go_frankenphp_get_vars
+func go_frankenphp_get_vars(threadIndex C.uintptr_t, name *C.char, nameLen C.size_t, returnValue *C.zval) *C.char {
+	thread := phpThreads[threadIndex]
+	lookup := getLookup(thread)
+	if lookup == nil {
+		return C.CString("no background worker configured")
+	}
+
+	goName := C.GoStringN(name, C.int(nameLen))
+	var sk *backgroundWorkerState
+	if w, ok := lookup.byName[goName]; ok {
+		sk = w.bg.ready
+	} else if ca := lookup.catchAll; ca != nil {
+		ca.bg.catchAllMu.Lock()
+		sk = ca.bg.catchAllNames[goName]
+		ca.bg.catchAllMu.Unlock()
+	}
+	if sk == nil {
+		return C.CString("background worker not found: " + goName + " (call frankenphp_ensure_background_worker first)")
+	}
+
+	select {
+	case <-sk.ready:
+	default:
+		return C.CString("background worker not ready: " + goName + " (no set_vars call yet)")
+	}
+
+	sk.mu.RLock()
+	C.frankenphp_copy_persistent_vars(returnValue, sk.varsPtr)
+	sk.mu.RUnlock()
+
+	return nil
 }

--- a/bgworker.go
+++ b/bgworker.go
@@ -1,0 +1,471 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+const (
+	// defaultMaxBackgroundWorkers is the default safety cap for catch-all
+	// background workers when the user doesn't set max_threads. Caps the
+	// number of distinct lazy-started instances from a single catch-all.
+	defaultMaxBackgroundWorkers = 16
+
+	// defaultEnsureTimeout is the default deadline applied when ensure() is
+	// called without an explicit timeout.
+	defaultEnsureTimeout = 30 * time.Second
+)
+
+// backgroundWorkerExtras holds bg-only lifecycle state.
+type backgroundWorkerExtras struct {
+	// ready is shared by named workers and a catch-all's eager pool;
+	// lazy-spawned catch-all instances each get their own slot in
+	// catchAllNames.
+	ready *backgroundWorkerState
+
+	// catchAllNames != nil marks this *worker as a scope's catch-all
+	// template. Lazy-spawned threads register here, up to catchAllCap.
+	catchAllCap   int
+	catchAllMu    sync.Mutex
+	catchAllNames map[string]*backgroundWorkerState
+
+	// lazyMu/lazyStarted gate the first thread spawn for a num=0 named
+	// bg worker. Unused for eager (num > 0) or catch-all templates.
+	lazyMu      sync.Mutex
+	lazyStarted bool
+}
+
+// backgroundWorkerState is the per-instance readiness signal ensure()
+// blocks on. ready closes once the worker calls
+// frankenphp_get_worker_handle(); aborted closes on max_consecutive_failures
+// before that.
+type backgroundWorkerState struct {
+	ready     chan struct{}
+	readyOnce sync.Once
+
+	aborted   chan struct{}
+	abortOnce sync.Once
+	abortErr  error
+
+	// bootFailure carries the most recent pre-readiness crash so a
+	// timing-out ensure() can report it.
+	bootFailure atomic.Pointer[bootFailureInfo]
+}
+
+// bootFailureInfo is the boot-phase crash metadata surfaced by ensure().
+type bootFailureInfo struct {
+	entrypoint   string
+	exitStatus   int
+	failureCount int
+	// TODO(sidekicks): capture PG(last_error_message) once the C-side
+	// helper lands in the set_vars/get_vars step.
+	phpError string
+}
+
+func newBackgroundWorkerState() *backgroundWorkerState {
+	return &backgroundWorkerState{
+		ready:   make(chan struct{}),
+		aborted: make(chan struct{}),
+	}
+}
+
+// markReady fires on the first frankenphp_get_worker_handle() call after
+// each (re)boot. Idempotent: the channel only closes once.
+func (r *backgroundWorkerState) markReady() {
+	r.readyOnce.Do(func() { close(r.ready) })
+}
+
+// abort unblocks ensure() waiters when the boot sequence is abandoned
+// (max_consecutive_failures hit before readiness). Idempotent.
+func (r *backgroundWorkerState) abort(err error) {
+	r.abortOnce.Do(func() {
+		r.abortErr = err
+		close(r.aborted)
+	})
+}
+
+// Scope isolates background workers between php_server blocks; the
+// zero value is the global/embed scope. Obtain values via NextScope.
+type Scope uint64
+
+var scopeCounter atomic.Uint64
+
+// NextScope returns a fresh scope value. Each php_server block should
+// call this once during provisioning.
+func NextScope() Scope {
+	return Scope(scopeCounter.Add(1))
+}
+
+// scopeLabels maps Scope -> human-readable label registered by the
+// embedder (e.g. the Caddy module).
+var scopeLabels sync.Map
+
+// SetScopeLabel attaches a human-readable label to a scope; the bg-worker
+// metric emitter renders it as e.g. server="api.example.com" instead of
+// an opaque numeric id. Empty labels are ignored.
+func SetScopeLabel(s Scope, label string) {
+	if label == "" {
+		return
+	}
+	scopeLabels.Store(s, label)
+}
+
+// scopeLabelOrID returns the label registered for s, or the numeric id
+// when none is set (including the zero/global scope), so callers always
+// get a non-empty value.
+func scopeLabelOrID(s Scope) string {
+	if label, ok := lookupScopeLabel(s); ok {
+		return label
+	}
+	return strconv.FormatUint(uint64(s), 10)
+}
+
+// lookupScopeLabel reports whether a label has been registered for s,
+// returning ("", false) when none has. Distinguishes "unset" from
+// "explicitly empty" without the numeric fallback.
+func lookupScopeLabel(s Scope) (string, bool) {
+	v, ok := scopeLabels.Load(s)
+	if !ok {
+		return "", false
+	}
+	return v.(string), true
+}
+
+// bgWorkerMetricName formats the metric label for a background worker:
+// "m#<scopeLabel>:<runtimeName>". scopeLabel is empty when the scope
+// has no registered label (embed/global, or before the embedder calls
+// SetScopeLabel). The "m#" prefix mirrors the m# convention used for
+// module workers; the colon keeps the format uniform so a single regex
+// (m#([^:]*):(.+)) parses both labelled and unlabelled forms.
+func bgWorkerMetricName(scope Scope, runtimeName string) string {
+	label, _ := lookupScopeLabel(scope)
+	return "m#" + label + ":" + runtimeName
+}
+
+// backgroundLookups maps scope -> lookup. Scope 0 is the global/embed scope.
+var backgroundLookups map[Scope]*backgroundWorkerLookup
+
+// backgroundWorkerLookup resolves a user-facing worker name to its *worker;
+// catchAll is the fallback when byName misses.
+type backgroundWorkerLookup struct {
+	byName   map[string]*worker
+	catchAll *worker
+}
+
+func newBackgroundWorkerLookup() *backgroundWorkerLookup {
+	return &backgroundWorkerLookup{
+		byName: make(map[string]*worker),
+	}
+}
+
+// resolve returns the worker for the given name, falling back to catchAll.
+func (l *backgroundWorkerLookup) resolve(name string) *worker {
+	if w, ok := l.byName[name]; ok {
+		return w
+	}
+	return l.catchAll
+}
+
+// isCatchAllName reports whether (name, fileName) designates a catch-all
+// (no user-supplied name; newWorker defaults the name to the absolute
+// file path). m# is stripped because module workers carry the prefix.
+func isCatchAllName(name, fileName string) bool {
+	phpName := strings.TrimPrefix(name, "m#")
+	return phpName == "" || phpName == fileName
+}
+
+func isCatchAllByName(w *worker) bool {
+	return isCatchAllName(w.name, w.fileName)
+}
+
+// buildBackgroundWorkerLookups maps each declared bg worker into its scope's
+// lookup. Per-scope name collisions are caught here because bg workers
+// intentionally skip the global workersByName map (so two scopes can share
+// a user-facing name).
+func buildBackgroundWorkerLookups(workers []*worker, opts []workerOpt) (map[Scope]*backgroundWorkerLookup, error) {
+	lookups := make(map[Scope]*backgroundWorkerLookup)
+
+	for i, o := range opts {
+		if !o.isBackgroundWorker {
+			continue
+		}
+
+		scope := o.scope
+		lookup, ok := lookups[scope]
+		if !ok {
+			lookup = newBackgroundWorkerLookup()
+			lookups[scope] = lookup
+		}
+
+		w := workers[i]
+		w.scope = scope
+
+		if isCatchAllByName(w) {
+			if lookup.catchAll != nil {
+				return nil, fmt.Errorf("duplicate catch-all background worker in the same scope")
+			}
+			w.bg.catchAllCap = defaultMaxBackgroundWorkers
+			if o.maxThreads > 0 {
+				w.bg.catchAllCap = o.maxThreads
+			}
+			w.bg.catchAllNames = make(map[string]*backgroundWorkerState)
+			lookup.catchAll = w
+		} else {
+			phpName := strings.TrimPrefix(w.name, "m#")
+			if _, exists := lookup.byName[phpName]; exists {
+				return nil, fmt.Errorf("duplicate background worker name %q in the same scope", phpName)
+			}
+			lookup.byName[phpName] = w
+		}
+	}
+
+	if len(lookups) == 0 {
+		return nil, nil
+	}
+	return lookups, nil
+}
+
+// reserveBackgroundWorkerThreads resolves max_threads defaults and
+// returns the thread budget to add to the pool. Mutates opt.workers
+// in place and pre-registers totalWorkers so a bg-only deployment
+// has the metric initialised.
+func reserveBackgroundWorkerThreads(opt *opt) int {
+	reserved := 0
+	for i, w := range opt.workers {
+		if !w.isBackgroundWorker {
+			continue
+		}
+		isCatchAll := isCatchAllName(w.name, w.fileName)
+
+		if w.maxThreads == 0 {
+			switch {
+			case isCatchAll:
+				// Lazy cap default for any catch-all.
+				opt.workers[i].maxThreads = defaultMaxBackgroundWorkers
+			case w.num == 0:
+				// Single-thread budget for a lazy named worker.
+				opt.workers[i].maxThreads = 1
+			}
+		}
+
+		var extra int
+		if isCatchAll {
+			// eager pool + lazy cap (independent budgets)
+			extra = w.num + opt.workers[i].maxThreads
+		} else {
+			extra = w.num
+			if opt.workers[i].maxThreads > extra {
+				extra = opt.workers[i].maxThreads
+			}
+		}
+		if extra < 1 {
+			extra = 1
+		}
+		reserved += extra
+		metrics.TotalWorkers(bgWorkerMetricName(w.scope, w.name), extra)
+	}
+	return reserved
+}
+
+// getLookup returns the background-worker lookup for the calling thread,
+// resolving the scope via worker handler -> request context -> global. A
+// scope with no declared workers falls through to scope 0 so embed-mode
+// workers stay reachable; declared scopes stay strictly isolated.
+func getLookup(thread *phpThread) *backgroundWorkerLookup {
+	if backgroundLookups == nil {
+		return nil
+	}
+	var scope Scope
+	if thread != nil {
+		if w := thread.handler.scopedWorker(); w != nil {
+			scope = w.scope
+		} else if fc, ok := fromContext(thread.context()); ok {
+			scope = fc.scope
+		}
+	}
+	if scope != 0 {
+		if l := backgroundLookups[scope]; l != nil {
+			return l
+		}
+	}
+	return backgroundLookups[0]
+}
+
+// ensureBackgroundWorker lazy-starts the named worker if needed and blocks
+// until it reaches readiness, aborts (max_consecutive_failures during boot),
+// or times out. Safe to call concurrently.
+func ensureBackgroundWorker(thread *phpThread, bgWorkerName string, timeout time.Duration) error {
+	if bgWorkerName == "" {
+		return fmt.Errorf("background worker name must not be empty")
+	}
+	lookup := getLookup(thread)
+	if lookup == nil {
+		return fmt.Errorf("no background worker configured")
+	}
+
+	// byName is keyed by the user-facing (m#-stripped) name.
+	if w, ok := lookup.byName[bgWorkerName]; ok {
+		r, err := lazyStartNamedWorker(w)
+		if err != nil {
+			return err
+		}
+		return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+	}
+
+	catchAll := lookup.catchAll
+	if catchAll == nil {
+		return fmt.Errorf("no background worker configured for name %q", bgWorkerName)
+	}
+
+	// Reject so behavior doesn't silently split-brain across the eager
+	// pool and a lazy-spawned instance. m#-strip matches
+	// buildBackgroundWorkerLookups: module catch-alls carry the prefix,
+	// bgWorkerName from PHP never does.
+	if bgWorkerName == strings.TrimPrefix(catchAll.name, "m#") {
+		return fmt.Errorf(`cannot ensure() against "%s": it matches the catch-all's own name; use a distinct user-facing name`, bgWorkerName)
+	}
+
+	// Hold catchAllMu across thread reservation + entry publication so a
+	// failed allocation can't leave a phantom registration visible to
+	// concurrent callers.
+	bg := catchAll.bg
+	bg.catchAllMu.Lock()
+
+	if r, ok := bg.catchAllNames[bgWorkerName]; ok {
+		bg.catchAllMu.Unlock()
+		return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+	}
+
+	if bg.catchAllCap > 0 && len(bg.catchAllNames) >= bg.catchAllCap {
+		bg.catchAllMu.Unlock()
+		return fmt.Errorf("cannot start background worker %q: limit of %d reached (increase max threads or declare it as a named worker)", bgWorkerName, bg.catchAllCap)
+	}
+
+	r := newBackgroundWorkerState()
+	bg.catchAllNames[bgWorkerName] = r
+	bg.catchAllMu.Unlock()
+
+	if _, err := addBackgroundWorkerThread(catchAll, bgWorkerName, r); err != nil {
+		// Wake any concurrent waiter that picked up r from catchAllNames
+		// between our publish and this rollback so they see the start
+		// failure instead of timing out.
+		r.abort(err)
+		bg.catchAllMu.Lock()
+		delete(bg.catchAllNames, bgWorkerName)
+		bg.catchAllMu.Unlock()
+		return fmt.Errorf("cannot start background worker %q: %w (increase max threads)", bgWorkerName, err)
+	}
+
+	if globalLogger.Enabled(globalCtx, slog.LevelInfo) {
+		globalLogger.LogAttrs(globalCtx, slog.LevelInfo, "background worker started",
+			slog.String("name", bgWorkerName))
+	}
+
+	return waitForBackgroundWorkerReady(bgWorkerName, r, timeout)
+}
+
+// lazyStartNamedWorker returns the readiness slot the caller should
+// wait on. For num=0 workers it spawns the first thread under
+// bg.lazyMu (idempotent); the snapshot captured under the lock stays
+// consistent with any concurrent invalidateBackgroundEntry.
+func lazyStartNamedWorker(w *worker) (*backgroundWorkerState, error) {
+	if w.num > 0 {
+		return w.bg.ready, nil
+	}
+	w.bg.lazyMu.Lock()
+	defer w.bg.lazyMu.Unlock()
+	if w.bg.lazyStarted {
+		return w.bg.ready, nil
+	}
+	r := w.bg.ready
+	if _, err := addBackgroundWorkerThread(w, w.name, r); err != nil {
+		return nil, fmt.Errorf("cannot start background worker %q: %w (increase max threads)", w.name, err)
+	}
+	w.bg.lazyStarted = true
+	return r, nil
+}
+
+// waitForBackgroundWorkerReady blocks until the worker reaches readiness,
+// aborts, or the timeout elapses. A nil state degrades to ready-immediately
+// to avoid a deadlock for workers declared without an allocated slot.
+func waitForBackgroundWorkerReady(name string, r *backgroundWorkerState, timeout time.Duration) error {
+	if r == nil {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = defaultEnsureTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-r.ready:
+		return nil
+	case <-r.aborted:
+		return fmt.Errorf("background worker %q failed to start: %w", name, r.abortErr)
+	case <-timer.C:
+		return formatEnsureTimeoutError(name, r, timeout)
+	}
+}
+
+func formatEnsureTimeoutError(name string, r *backgroundWorkerState, timeout time.Duration) error {
+	if bf := r.bootFailure.Load(); bf != nil {
+		msg := fmt.Sprintf("background worker %q did not become ready within %s; last attempt %d failed (exit status %d, entrypoint %s)",
+			name, timeout, bf.failureCount, bf.exitStatus, bf.entrypoint)
+		if bf.phpError != "" {
+			msg += ": " + bf.phpError
+		}
+		return errors.New(msg)
+	}
+	return fmt.Errorf("background worker %q did not call frankenphp_get_worker_handle() within %s", name, timeout)
+}
+
+// go_frankenphp_ensure_background_worker lazy-starts each named bg worker
+// (the C side has validated names are non-empty and unique) and blocks
+// until each signals readiness, aborts, or timeoutMs (ms; <=0 = default)
+// elapses.
+//
+//export go_frankenphp_ensure_background_worker
+func go_frankenphp_ensure_background_worker(threadIndex C.uintptr_t, names **C.char, nameLens *C.size_t, nameCount C.int, timeoutMs C.int64_t) *C.char {
+	thread := phpThreads[threadIndex]
+	n := int(nameCount)
+	if n <= 0 {
+		return nil
+	}
+	timeout := time.Duration(int64(timeoutMs)) * time.Millisecond
+	nameSlice := unsafe.Slice(names, n)
+	nameLenSlice := unsafe.Slice(nameLens, n)
+	for i := 0; i < n; i++ {
+		goName := C.GoStringN(nameSlice[i], C.int(nameLenSlice[i]))
+		if err := ensureBackgroundWorker(thread, goName, timeout); err != nil {
+			return C.CString(err.Error())
+		}
+	}
+	return nil
+}
+
+// go_frankenphp_worker_ready closes the per-thread readiness channel on
+// the first frankenphp_get_worker_handle() call. Idempotent.
+//
+//export go_frankenphp_worker_ready
+func go_frankenphp_worker_ready(threadIndex C.uintptr_t) {
+	thread := phpThreads[threadIndex]
+	if thread == nil {
+		return
+	}
+	handler, ok := thread.handler.(*backgroundWorkerThread)
+	if !ok || handler == nil {
+		return
+	}
+	if r := handler.backgroundReady; r != nil {
+		r.markReady()
+	}
+}

--- a/bgworker.go
+++ b/bgworker.go
@@ -513,12 +513,19 @@ func go_frankenphp_set_vars(threadIndex C.uintptr_t, varsPtr unsafe.Pointer, old
 }
 
 // go_frankenphp_get_vars resolves the named worker through the lookup
-// (named or catch-all), checks its sk.ready without starting the worker,
-// and copies its vars into the return value. If the caller hasn't called
+// (named or catch-all), checks sk.ready without starting the worker, and
+// copies its vars into the return value. If the caller hasn't called
 // ensure() first, this returns a "not ready" error.
 //
+// callerVersion / outVersion implement a per-request cache:
+//   - If callerVersion is non-nil and equals the current varsVersion,
+//     the copy is skipped; outVersion is still set so the C side can
+//     reuse its cached zval with pointer equality.
+//   - Otherwise returnValue receives a fresh deep copy and outVersion
+//     reports the version that copy corresponds to.
+//
 //export go_frankenphp_get_vars
-func go_frankenphp_get_vars(threadIndex C.uintptr_t, name *C.char, nameLen C.size_t, returnValue *C.zval) *C.char {
+func go_frankenphp_get_vars(threadIndex C.uintptr_t, name *C.char, nameLen C.size_t, returnValue *C.zval, callerVersion *C.uint64_t, outVersion *C.uint64_t) *C.char {
 	thread := phpThreads[threadIndex]
 	lookup := getLookup(thread)
 	if lookup == nil {
@@ -544,8 +551,21 @@ func go_frankenphp_get_vars(threadIndex C.uintptr_t, name *C.char, nameLen C.siz
 		return C.CString("background worker not ready: " + goName + " (no set_vars call yet)")
 	}
 
+	// Fast path: caller's cached version matches current. Skip the copy;
+	// the caller will reuse its cached zval.
+	if callerVersion != nil && outVersion != nil {
+		v := sk.varsVersion.Load()
+		*outVersion = C.uint64_t(v)
+		if uint64(*callerVersion) == v {
+			return nil
+		}
+	}
+
 	sk.mu.RLock()
 	C.frankenphp_copy_persistent_vars(returnValue, sk.varsPtr)
+	if outVersion != nil {
+		*outVersion = C.uint64_t(sk.varsVersion.Load())
+	}
 	sk.mu.RUnlock()
 
 	return nil

--- a/bgworker_test.go
+++ b/bgworker_test.go
@@ -1,0 +1,86 @@
+package frankenphp_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackgroundWorkerLifecycle boots a background worker that touches a
+// sentinel file then parks on the stop pipe. It proves the bg worker runs
+// (sentinel appears) and that Shutdown returns within a reasonable time.
+func TestBackgroundWorkerLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-lifecycle.sentinel")
+
+	require.NoError(t, frankenphp.Init(
+		frankenphp.WithWorkers("bg-lifecycle", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	))
+	// Note: this test asserts on Shutdown timing, so it manages Shutdown
+	// itself instead of using setupFrankenPHP's t.Cleanup hook.
+
+	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+
+	done := make(chan struct{})
+	go func() {
+		frankenphp.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Shutdown did not return within 10s")
+	}
+}
+
+// TestBackgroundWorkerCrashRestarts boots a worker that exit(1)s on its
+// first run and touches a "restarted" sentinel on its second run. The
+// sentinel proves the crash-restart loop fired.
+func TestBackgroundWorkerCrashRestarts(t *testing.T) {
+	tmp := t.TempDir()
+	crashMarker := filepath.Join(tmp, "bg-crash.marker")
+	restarted := filepath.Join(tmp, "bg-crash.restarted")
+
+	setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-crash", "testdata/bgworker/crash.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{
+				"BG_CRASH_MARKER":       crashMarker,
+				"BG_RESTARTED_SENTINEL": restarted,
+			}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, restarted, "background worker did not restart after crash")
+}
+
+// TestBackgroundWorkerWithoutHTTP confirms that a request to a script
+// unrelated to the bg worker still works: the bg worker doesn't intercept
+// HTTP traffic.
+func TestBackgroundWorkerWithoutHTTP(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-nohttp.sentinel")
+
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-nohttp", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+
+	body := serveBody(t, testDataDir, "index.php")
+	assert.NotEmpty(t, body, "expected non-empty body from index.php")
+}

--- a/bgworker_test.go
+++ b/bgworker_test.go
@@ -1,86 +1,54 @@
 package frankenphp_test
 
 import (
-	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// TestBackgroundWorkerLifecycle boots a background worker that touches a
-// sentinel file then parks on the stop pipe. It proves the bg worker runs
-// (sentinel appears) and that Shutdown returns within a reasonable time.
-func TestBackgroundWorkerLifecycle(t *testing.T) {
-	tmp := t.TempDir()
-	sentinel := filepath.Join(tmp, "bg-lifecycle.sentinel")
-
-	require.NoError(t, frankenphp.Init(
-		frankenphp.WithWorkers("bg-lifecycle", "testdata/bgworker/basic.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
-		),
-		frankenphp.WithNumThreads(2),
-	))
-	// Note: this test asserts on Shutdown timing, so it manages Shutdown
-	// itself instead of using setupFrankenPHP's t.Cleanup hook.
-
-	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
-
-	done := make(chan struct{})
-	go func() {
-		frankenphp.Shutdown()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatalf("Shutdown did not return within 10s")
-	}
-}
-
-// TestBackgroundWorkerCrashRestarts boots a worker that exit(1)s on its
-// first run and touches a "restarted" sentinel on its second run. The
-// sentinel proves the crash-restart loop fired.
-func TestBackgroundWorkerCrashRestarts(t *testing.T) {
-	tmp := t.TempDir()
-	crashMarker := filepath.Join(tmp, "bg-crash.marker")
-	restarted := filepath.Join(tmp, "bg-crash.restarted")
-
-	setupFrankenPHP(t,
-		frankenphp.WithWorkers("bg-crash", "testdata/bgworker/crash.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{
-				"BG_CRASH_MARKER":       crashMarker,
-				"BG_RESTARTED_SENTINEL": restarted,
-			}),
-		),
-		frankenphp.WithNumThreads(2),
-	)
-
-	requireFileEventually(t, restarted, "background worker did not restart after crash")
-}
-
-// TestBackgroundWorkerWithoutHTTP confirms that a request to a script
-// unrelated to the bg worker still works: the bg worker doesn't intercept
-// HTTP traffic.
-func TestBackgroundWorkerWithoutHTTP(t *testing.T) {
-	tmp := t.TempDir()
-	sentinel := filepath.Join(tmp, "bg-nohttp.sentinel")
-
+// TestBackgroundWorker drives the minimal set_vars/get_vars path end-to-end:
+// a background worker publishes three values, then an HTTP request on a
+// separate thread reads them back by name.
+func TestBackgroundWorker(t *testing.T) {
 	testDataDir := setupFrankenPHP(t,
-		frankenphp.WithWorkers("bg-nohttp", "testdata/bgworker/basic.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
-		),
+		frankenphp.WithWorkers("bg-basic", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground()),
 		frankenphp.WithNumThreads(2),
 	)
 
-	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+	// Give the background worker time to boot, publish, and park on the
+	// stop stream. set_vars is synchronous but the first scheduling of the
+	// bg worker thread is a race with Init returning, so a short wait is
+	// cheaper than a ready-channel hook for this test.
+	deadline := time.Now().Add(3 * time.Second)
+	var out string
+	for time.Now().Before(deadline) {
+		out = serveBody(t, testDataDir, "bgworker/reader.php")
+		if !strings.Contains(out, "MISSING") && strings.Contains(out, "has-ready-at=1") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
-	body := serveBody(t, testDataDir, "index.php")
-	assert.NotEmpty(t, body, "expected non-empty body from index.php")
+	assert.Contains(t, out, "message=hello from background worker")
+	assert.Contains(t, out, "count=42")
+	assert.Contains(t, out, "has-ready-at=1")
+}
+
+// TestBackgroundWorkerErrorPaths covers the misuse errors that don't need
+// a running worker: get_vars on a nonexistent name, set_vars from outside
+// a background worker, and get_worker_handle from outside a background
+// worker. Runs as a non-worker request so none of the calls happen on a
+// bg-worker thread.
+func TestBackgroundWorkerErrorPaths(t *testing.T) {
+	testDataDir := setupFrankenPHP(t, frankenphp.WithNumThreads(2))
+
+	body := serveBody(t, testDataDir, "bgworker/errors.php")
+	assert.NotContains(t, body, "FAIL", "error-path script reported a failure:\n"+body)
+	assert.Contains(t, body, "OK missing:")
+	assert.Contains(t, body, "OK reject-non-bg:")
+	assert.Contains(t, body, "OK reject-handle:")
 }

--- a/bgworkerbatch_test.go
+++ b/bgworkerbatch_test.go
@@ -2,7 +2,6 @@ package frankenphp_test
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/dunglas/frankenphp"
@@ -10,98 +9,103 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEnsureBackgroundWorkerBatch declares a single catch-all bg worker
-// and ensures three distinct names from a single ensure() call. Each
-// catch-all instance touches a per-name sentinel; the test asserts that
-// all three appear, proving the array form started one worker per name.
+// TestEnsureBackgroundWorkerBatch ensures multiple workers in one call,
+// each publishing its own identity. Verifies the batch path (array arg)
+// shares one deadline across all workers.
 func TestEnsureBackgroundWorkerBatch(t *testing.T) {
-	tmp := t.TempDir()
 	testDataDir := setupFrankenPHP(t,
-		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerMaxThreads(8),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
-		frankenphp.WithNumThreads(8),
+		frankenphp.WithWorkers("worker-a", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithWorkers("worker-b", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithWorkers("worker-c", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(6),
 	)
 
 	body := serveBody(t, testDataDir, "bgworker/batch-ensure.php")
-	assert.Contains(t, body, "ok", "batch ensure script should echo ok, got: %q", body)
-
-	for _, name := range []string{"batch-a", "batch-b", "batch-c"} {
-		requireFileEventually(t, filepath.Join(tmp, name),
-			"catch-all instance %q should have written its sentinel", name)
-	}
+	assert.NotContains(t, body, "MISSING", "batch ensure should have started and published all workers:\n"+body)
+	assert.Contains(t, body, "worker-a=worker-a")
+	assert.Contains(t, body, "worker-b=worker-b")
+	assert.Contains(t, body, "worker-c=worker-c")
 }
 
-// TestEnsureBackgroundWorkerBatchEmpty exercises the C-side validation
-// that an empty array raises a ValueError before any worker is started.
-// The fixture catches the throwable and echoes its class.
+// TestEnsureBackgroundWorkerBatchEmpty verifies that an empty array is
+// rejected with a clear error rather than silently succeeding.
 func TestEnsureBackgroundWorkerBatchEmpty(t *testing.T) {
 	testDataDir := setupFrankenPHP(t,
-		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
-			frankenphp.WithWorkerBackground(),
-		),
-		frankenphp.WithNumThreads(2),
+		frankenphp.WithWorkers("bg", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
 	)
 
-	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=empty")
-	assert.Contains(t, body, "ValueError", "empty array should raise ValueError, got: %q", body)
+	php := `<?php
+try {
+    frankenphp_ensure_background_worker([], 1.0);
+    echo "FAIL no error";
+} catch (ValueError $e) {
+    echo "OK ", $e->getMessage();
+}`
+	tmp := testDataDir + "bg-batch-empty.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	body := serveBody(t, testDataDir, "bg-batch-empty.php")
+	assert.Contains(t, body, "OK ")
 	assert.Contains(t, body, "must not be empty")
+	assert.NotContains(t, body, "FAIL")
 }
 
-// TestEnsureBackgroundWorkerBatchNonString verifies a non-string element
-// raises a TypeError (PHP's standard for argument-type mismatches inside
-// our parsed array).
+// TestEnsureBackgroundWorkerBatchNonString verifies array-entry type
+// validation: non-string elements produce a TypeError.
 func TestEnsureBackgroundWorkerBatchNonString(t *testing.T) {
 	testDataDir := setupFrankenPHP(t,
-		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
-			frankenphp.WithWorkerBackground(),
-		),
-		frankenphp.WithNumThreads(2),
+		frankenphp.WithWorkers("bg", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
 	)
 
-	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=nonstring")
-	assert.Contains(t, body, "TypeError", "non-string element should raise TypeError, got: %q", body)
+	php := `<?php
+try {
+    frankenphp_ensure_background_worker(['bg', 42], 1.0);
+    echo "FAIL no error";
+} catch (TypeError $e) {
+    echo "OK ", $e->getMessage();
+}`
+	tmp := testDataDir + "bg-batch-nonstring.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	body := serveBody(t, testDataDir, "bg-batch-nonstring.php")
+	assert.Contains(t, body, "OK ")
+	assert.Contains(t, body, "must contain only strings")
+	assert.NotContains(t, body, "FAIL")
 }
 
-// TestEnsureBackgroundWorkerBatchDuplicate verifies that duplicate names
-// in the same batch are rejected as a ValueError, matching the e17577e
-// reference behavior (no silent dedup).
-func TestEnsureBackgroundWorkerBatchDuplicate(t *testing.T) {
+// TestBackgroundWorkerServerFlag confirms that a bg worker sees
+// FRANKENPHP_WORKER_BACKGROUND=true alongside FRANKENPHP_WORKER in
+// $_SERVER, so scripts can branch without checking every function
+// independently.
+func TestBackgroundWorkerServerFlag(t *testing.T) {
 	testDataDir := setupFrankenPHP(t,
-		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
-			frankenphp.WithWorkerBackground(),
-		),
-		frankenphp.WithNumThreads(2),
+		frankenphp.WithWorkers("flag-worker", "testdata/bgworker/bg-flag.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
 	)
 
-	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=duplicate")
-	assert.Contains(t, body, "ValueError", "duplicate name should raise ValueError, got: %q", body)
-	assert.Contains(t, body, "duplicate")
-}
+	// ensure() removes the race between Init returning and the eager
+	// bg-worker thread reaching its first set_vars.
+	php := `<?php
+frankenphp_ensure_background_worker('flag-worker');
+$vars = frankenphp_get_vars('flag-worker');
+echo 'name=', $vars['name'] ?? 'MISSING', "\n";
+echo 'is_background=', var_export($vars['is_background'] ?? 'MISSING', true), "\n";
+`
+	tmp := testDataDir + "bg-flag-reader.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
 
-// TestBackgroundWorkerBgFlag asserts that a bg worker script sees
-// $_SERVER['FRANKENPHP_WORKER_BACKGROUND'] === true. The fixture writes
-// var_export() of the value to a sentinel so the test can read the exact
-// PHP-level representation.
-func TestBackgroundWorkerBgFlag(t *testing.T) {
-	tmp := t.TempDir()
-	sentinel := filepath.Join(tmp, "bg-flag.sentinel")
-
-	setupFrankenPHP(t,
-		frankenphp.WithWorkers("bg-flag", "testdata/bgworker/bg-flag.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
-		),
-		frankenphp.WithNumThreads(2),
-	)
-
-	requireFileEventually(t, sentinel,
-		"bg worker should have written the FRANKENPHP_WORKER_BACKGROUND sentinel")
-
-	contents, err := os.ReadFile(sentinel)
-	require.NoError(t, err)
-	assert.Equal(t, "true", string(contents),
-		"$_SERVER['FRANKENPHP_WORKER_BACKGROUND'] should be the bool true")
+	body := serveBody(t, testDataDir, "bg-flag-reader.php")
+	assert.Contains(t, body, "name=flag-worker")
+	assert.Contains(t, body, "is_background=true")
 }

--- a/bgworkerbatch_test.go
+++ b/bgworkerbatch_test.go
@@ -1,0 +1,107 @@
+package frankenphp_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureBackgroundWorkerBatch declares a single catch-all bg worker
+// and ensures three distinct names from a single ensure() call. Each
+// catch-all instance touches a per-name sentinel; the test asserts that
+// all three appear, proving the array form started one worker per name.
+func TestEnsureBackgroundWorkerBatch(t *testing.T) {
+	tmp := t.TempDir()
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerMaxThreads(8),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		frankenphp.WithNumThreads(8),
+	)
+
+	body := serveBody(t, testDataDir, "bgworker/batch-ensure.php")
+	assert.Contains(t, body, "ok", "batch ensure script should echo ok, got: %q", body)
+
+	for _, name := range []string{"batch-a", "batch-b", "batch-c"} {
+		requireFileEventually(t, filepath.Join(tmp, name),
+			"catch-all instance %q should have written its sentinel", name)
+	}
+}
+
+// TestEnsureBackgroundWorkerBatchEmpty exercises the C-side validation
+// that an empty array raises a ValueError before any worker is started.
+// The fixture catches the throwable and echoes its class.
+func TestEnsureBackgroundWorkerBatchEmpty(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=empty")
+	assert.Contains(t, body, "ValueError", "empty array should raise ValueError, got: %q", body)
+	assert.Contains(t, body, "must not be empty")
+}
+
+// TestEnsureBackgroundWorkerBatchNonString verifies a non-string element
+// raises a TypeError (PHP's standard for argument-type mismatches inside
+// our parsed array).
+func TestEnsureBackgroundWorkerBatchNonString(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=nonstring")
+	assert.Contains(t, body, "TypeError", "non-string element should raise TypeError, got: %q", body)
+}
+
+// TestEnsureBackgroundWorkerBatchDuplicate verifies that duplicate names
+// in the same batch are rejected as a ValueError, matching the e17577e
+// reference behavior (no silent dedup).
+func TestEnsureBackgroundWorkerBatchDuplicate(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	body := serveBody(t, testDataDir, "bgworker/batch-errors.php?mode=duplicate")
+	assert.Contains(t, body, "ValueError", "duplicate name should raise ValueError, got: %q", body)
+	assert.Contains(t, body, "duplicate")
+}
+
+// TestBackgroundWorkerBgFlag asserts that a bg worker script sees
+// $_SERVER['FRANKENPHP_WORKER_BACKGROUND'] === true. The fixture writes
+// var_export() of the value to a sentinel so the test can read the exact
+// PHP-level representation.
+func TestBackgroundWorkerBgFlag(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-flag.sentinel")
+
+	setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-flag", "testdata/bgworker/bg-flag.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, sentinel,
+		"bg worker should have written the FRANKENPHP_WORKER_BACKGROUND sentinel")
+
+	contents, err := os.ReadFile(sentinel)
+	require.NoError(t, err)
+	assert.Equal(t, "true", string(contents),
+		"$_SERVER['FRANKENPHP_WORKER_BACKGROUND'] should be the bool true")
+}

--- a/bgworkercache_test.go
+++ b/bgworkercache_test.go
@@ -1,0 +1,56 @@
+package frankenphp_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetVarsCacheIdentity verifies that two get_vars calls within one
+// request return the *same* zval (pointer identity via ===) when the
+// worker hasn't published a new version in between. This is the user-
+// visible guarantee that proves the per-request cache is wired.
+func TestGetVarsCacheIdentity(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("cache-worker", "testdata/background-worker-cache-fixture.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	body := serveBody(t, testDataDir, "background-worker-cache-identity.php")
+	assert.Contains(t, body, "first=cached-value")
+	assert.Contains(t, body, "second=cached-value")
+	assert.Contains(t, body, "identical=true", "cached zvals must be === across repeated reads:\n"+body)
+}
+
+// TestGetVarsCacheManyReads exercises the cache path under load: one
+// request calls get_vars 500 times against a nested-array worker. The
+// second call onward is a cache hit; the test just asserts the script
+// completes without corruption.
+func TestGetVarsCacheManyReads(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("cache-worker", "testdata/background-worker-cache-fixture.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	// ensure() first so the eager-start race doesn't surface before the
+	// 500-read loop even begins.
+	php := `<?php
+frankenphp_ensure_background_worker('cache-worker');
+for ($i = 0; $i < 500; $i++) {
+    $vars = frankenphp_get_vars('cache-worker');
+}
+echo 'ok=', $vars['marker'] ?? 'MISSING', "\n";`
+	tmp := testDataDir + "bg-cache-many.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	body := serveBody(t, testDataDir, "bg-cache-many.php")
+	assert.Contains(t, body, "ok=cached-value", "500 cached reads should all succeed:\n"+body)
+	assert.False(t, strings.Contains(body, "Fatal error") || strings.Contains(body, "corrupted"), "no corruption expected:\n"+body)
+}

--- a/bgworkercoverage_test.go
+++ b/bgworkercoverage_test.go
@@ -1,0 +1,185 @@
+package frankenphp_test
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBackgroundWorkerCrashRestart covers the crash-recovery path: the
+// worker publishes count=1, crashes, is auto-restarted, then publishes
+// count=2. The reader polls get_vars() (which never blocks) and must
+// eventually observe the post-restart snapshot. Along the way get_vars()
+// returns the pre-crash snapshot, proving vars are kept in persistent
+// memory across worker deaths.
+func TestBackgroundWorkerCrashRestart(t *testing.T) {
+	// Clean any stale marker from prior runs of this PID so the first boot
+	// attempt is guaranteed to take the crash branch.
+	matches, _ := filepath.Glob(os.TempDir() + "/bg-worker-crash-*")
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("crash-worker", "testdata/bgworker/crash.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	php := `<?php
+frankenphp_ensure_background_worker('crash-worker', 5.0);
+$vars = frankenphp_get_vars('crash-worker');
+echo 'count=', $vars['count'] ?? 'MISSING', ' phase=', $vars['phase'] ?? 'MISSING';
+`
+	deadline := time.Now().Add(5 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		last = serveInlinePHP(t, testDataDir, "bg-crash-reader.php", php)
+		if strings.Contains(last, "count=2") && strings.Contains(last, "phase=post-restart") {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("did not observe post-restart snapshot within 5s; last=%q", last)
+}
+
+// TestBackgroundWorkerTypeValidation drives the set_vars() allow-list from
+// inside a bg worker: int values and keys, nested arrays, and enum cases
+// are accepted; objects and references are rejected with ValueError.
+// The final published RESULTS string carries every branch outcome, and
+// the enum case round-trips to the same ::class::$name on the reader.
+func TestBackgroundWorkerTypeValidation(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("type-worker", "testdata/bgworker/types.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	php := `<?php
+enum BgTestStatus { case Active; case Inactive; }
+for ($i = 0; $i < 200; $i++) {
+    try {
+        $vars = frankenphp_get_vars('type-worker');
+        if (isset($vars['RESULTS'])) break;
+    } catch (\RuntimeException $e) {}
+    usleep(10000);
+}
+echo 'RESULTS=', $vars['RESULTS'] ?? 'MISSING', "\n";
+echo 'ENUM_ROUNDTRIP=', (isset($vars['status']) && $vars['status'] === BgTestStatus::Active) ? 'match' : 'mismatch', "\n";
+`
+	out := serveInlinePHP(t, testDataDir, "bg-type-reader.php", php)
+
+	assert.Contains(t, out, "INT_VAL:allowed")
+	assert.Contains(t, out, "INT_KEY:allowed")
+	assert.Contains(t, out, "NESTED:allowed")
+	assert.Contains(t, out, "OBJECT:blocked")
+	assert.Contains(t, out, "REFERENCE:blocked")
+	assert.Contains(t, out, "ENUM_ROUNDTRIP=match", "enum case should restore to the same instance:\n"+out)
+}
+
+// TestBackgroundWorkerBinarySafe verifies that values pass through
+// set_vars/get_vars byte-for-byte: embedded NUL, multibyte UTF-8 and
+// empty string all survive the persistent-memory deep copy without
+// truncation or re-encoding.
+func TestBackgroundWorkerBinarySafe(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("binary-worker", "testdata/bgworker/binary.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	php := `<?php
+for ($i = 0; $i < 200; $i++) {
+    try {
+        $vars = frankenphp_get_vars('binary-worker');
+        if (isset($vars['BINARY'])) break;
+    } catch (\RuntimeException $e) {}
+    usleep(10000);
+}
+echo 'BINARY_HEX=', bin2hex($vars['BINARY'] ?? ''), "\n";
+echo 'BINARY_LEN=', strlen($vars['BINARY'] ?? ''), "\n";
+echo 'UTF8=', $vars['UTF8'] ?? '', "\n";
+echo 'EMPTY_EXISTS=', array_key_exists('EMPTY', $vars) ? '1' : '0', "\n";
+echo 'EMPTY_LEN=', strlen($vars['EMPTY'] ?? 'missing'), "\n";
+`
+	out := serveInlinePHP(t, testDataDir, "bg-binary-reader.php", php)
+
+	assert.Contains(t, out, "BINARY_HEX="+hex.EncodeToString([]byte("hello\x00world")))
+	assert.Contains(t, out, "BINARY_LEN=11")
+	assert.Contains(t, out, "UTF8=héllo wörld 🚀")
+	assert.Contains(t, out, "EMPTY_EXISTS=1")
+	assert.Contains(t, out, "EMPTY_LEN=0")
+}
+
+// TestBackgroundWorkerEnumMissing guards the generational deserializer:
+// when the bg worker publishes an enum whose class is absent from the
+// reader's process image, get_vars() must throw a LogicException rather
+// than return a corrupt zval. The enum class is only declared in the bg
+// worker entrypoint, so the reader's request has no way to reconstruct
+// the case.
+func TestBackgroundWorkerEnumMissing(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("enum-worker", "testdata/bgworker/enum-only.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	php := `<?php
+// WorkerOnlyEnum is intentionally NOT declared here.
+for ($i = 0; $i < 200; $i++) {
+    try {
+        $vars = frankenphp_get_vars('enum-worker');
+        echo 'NO_ERROR val_type=', get_debug_type($vars['val'] ?? null);
+        return;
+    } catch (\LogicException $e) {
+        echo 'LogicException: ', $e->getMessage();
+        return;
+    } catch (\RuntimeException $e) {
+        usleep(10000);
+    }
+}
+echo 'TIMEOUT';
+`
+	out := serveInlinePHP(t, testDataDir, "bg-enum-missing-reader.php", php)
+
+	assert.NotContains(t, out, "NO_ERROR", "enum should not have materialized:\n"+out)
+	assert.NotContains(t, out, "TIMEOUT", "worker never published:\n"+out)
+	assert.Contains(t, out, "LogicException")
+	assert.Contains(t, out, "WorkerOnlyEnum", "missing class name must appear in the error:\n"+out)
+}
+
+// TestBackgroundWorkerSignalingStreamResource confirms that the value
+// returned by frankenphp_get_worker_handle() is a real PHP stream
+// resource. Complements the bounded-wall-clock force-kill test: that
+// one proves the pipe closes on shutdown, this one proves the handle
+// is a proper resource in the first place (not null, not an int, not
+// a user object).
+func TestBackgroundWorkerSignalingStreamResource(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("stream-worker", "testdata/bgworker/stream-probe.php", 1,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
+	)
+
+	php := `<?php
+for ($i = 0; $i < 200; $i++) {
+    try {
+        $vars = frankenphp_get_vars('stream-worker');
+        if (isset($vars['stream_type'])) break;
+    } catch (\RuntimeException $e) {}
+    usleep(10000);
+}
+echo 'stream_type=', $vars['stream_type'] ?? 'MISSING', "\n";
+echo 'is_resource=', var_export($vars['is_resource'] ?? 'MISSING', true), "\n";
+`
+	out := serveInlinePHP(t, testDataDir, "bg-stream-reader.php", php)
+
+	assert.Contains(t, out, "stream_type=stream", "get_worker_handle() must return a stream resource:\n"+out)
+	assert.Contains(t, out, "is_resource=true")
+}

--- a/bgworkerensure_test.go
+++ b/bgworkerensure_test.go
@@ -1,0 +1,224 @@
+package frankenphp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureBackgroundWorkerNamedLazy declares a num=0 named worker, then
+// calls ensure() to lazy-start it. The fixture writes a sentinel named
+// after FRANKENPHP_WORKER so we can confirm the right instance ran.
+func TestEnsureBackgroundWorkerNamedLazy(t *testing.T) {
+	tmp := t.TempDir()
+	setupBgWorker(t,
+		WithWorkers("bg-lazy", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		WithNumThreads(2),
+	)
+
+	// num=0 means no eager start: the sentinel should not exist yet.
+	require.NoFileExists(t, filepath.Join(tmp, "bg-lazy"), "lazy worker should not have started yet")
+
+	require.NoError(t, ensureBackgroundWorker(nil, "bg-lazy", 5*time.Second))
+	requireSentinelEventually(t, filepath.Join(tmp, "bg-lazy"),
+		"ensure() should have lazy-started the named bg worker")
+}
+
+// TestEnsureBackgroundWorkerCatchAll declares a single catch-all (no name)
+// and invokes ensure() with two distinct names. Each name should spawn an
+// independent instance from the same entrypoint and write its own sentinel.
+func TestEnsureBackgroundWorkerCatchAll(t *testing.T) {
+	tmp := t.TempDir()
+	setupBgWorker(t,
+		// Name-less bg worker = catch-all.
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		WithNumThreads(4),
+	)
+
+	for _, name := range []string{"job-a", "job-b"} {
+		require.NoError(t, ensureBackgroundWorker(nil, name, 5*time.Second), "ensure(%s)", name)
+	}
+
+	for _, name := range []string{"job-a", "job-b"} {
+		requireSentinelEventually(t, filepath.Join(tmp, name),
+			"catch-all instance %q should have written its sentinel", name)
+	}
+}
+
+// TestEnsureBackgroundWorkerCatchAllCap exercises max_threads on the
+// catch-all: third distinct name beyond the cap should error.
+func TestEnsureBackgroundWorkerCatchAllCap(t *testing.T) {
+	tmp := t.TempDir()
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerMaxThreads(2),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		WithNumThreads(4),
+	)
+
+	require.NoError(t, ensureBackgroundWorker(nil, "cap-a", 5*time.Second))
+	require.NoError(t, ensureBackgroundWorker(nil, "cap-b", 5*time.Second))
+
+	require.ErrorContains(t,
+		ensureBackgroundWorker(nil, "cap-c", 5*time.Second),
+		"limit of 2 reached",
+		"third ensure must hit the catch-all cap")
+}
+
+// TestEnsureBackgroundWorkerUndeclared confirms ensure() on an undeclared
+// name with no catch-all returns the configuration error.
+func TestEnsureBackgroundWorkerUndeclared(t *testing.T) {
+	setupBgWorker(t,
+		WithWorkers("bg-known", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+		),
+		WithNumThreads(2),
+	)
+
+	require.ErrorContains(t,
+		ensureBackgroundWorker(nil, "other-name", 5*time.Second),
+		"no background worker configured for name")
+}
+
+// TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected verifies
+// ensure() rejects the catch-all's own filepath uniformly across
+// num=0 and num=1.
+func TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	// The catch-all's user-facing name is its absolute file path
+	// (set by newWorker when the declaration leaves name empty).
+	absPath := filepath.Join(cwd, "testdata/bgworker/named.php")
+
+	for _, tc := range []struct {
+		label string
+		num   int
+	}{
+		{"lazy num=0", 0},
+		{"eager num=1", 1},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			setupBgWorker(t,
+				WithWorkers("", "testdata/bgworker/named.php", tc.num,
+					WithWorkerBackground(),
+				),
+				WithNumThreads(2),
+			)
+
+			err := ensureBackgroundWorker(nil, absPath, 1*time.Second)
+			require.Error(t, err, "ensure() with the catch-all's file path must be rejected")
+			// Echoes the rejected input so a PHP caller can see what
+			// they passed; "catch-all's own name" surfaces the cause.
+			assert.Contains(t, err.Error(), absPath, "error must echo the rejected input")
+			assert.Contains(t, err.Error(), "catch-all's own name", "error must explain why the input was rejected")
+		})
+	}
+}
+
+// TestEnsureBackgroundWorkerConcurrent confirms the doc claim that ensure()
+// is safe to call concurrently: 16 goroutines hitting the same lazy-named
+// declaration produce exactly one spawned thread. Without serialising the
+// lazy-start gate (bgLazyStartMu), the second caller could observe the
+// flag before the first caller has completed thread reservation, leaving
+// the worker in an inconsistent state.
+func TestEnsureBackgroundWorkerConcurrent(t *testing.T) {
+	setupBgWorker(t,
+		WithWorkers("bg-concurrent", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+		),
+		WithNumThreads(8),
+	)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = ensureBackgroundWorker(nil, "bg-concurrent", 5*time.Second)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d", i)
+	}
+
+	// The lazy-named declaration should resolve to its single *worker,
+	// and exactly one thread should have been spawned by the lazy-start
+	// path despite the 16 concurrent ensure() callers.
+	lookup := backgroundLookups[0]
+	require.NotNil(t, lookup)
+	w := lookup.byName["bg-concurrent"]
+	require.NotNil(t, w)
+	assert.Equal(t, 1, w.countThreads(), "exactly one worker thread expected")
+}
+
+// TestEnsureBackgroundWorkerTimeout proves ensure() blocks until either
+// the worker hits its readiness boundary (frankenphp_get_worker_handle())
+// or the timeout expires. The fixture sleep()s without ever calling the
+// readiness function, so the second branch must fire.
+func TestEnsureBackgroundWorkerTimeout(t *testing.T) {
+	setupBgWorker(t,
+		WithWorkers("bg-no-handle", "testdata/bgworker/no-handle.php", 0,
+			WithWorkerBackground(),
+		),
+		WithNumThreads(2),
+	)
+
+	start := time.Now()
+	err := ensureBackgroundWorker(nil, "bg-no-handle", 1*time.Second)
+	deadline := start.Add(1 * time.Second)
+
+	require.ErrorContains(t, err,
+		"did not call frankenphp_get_worker_handle()",
+		"ensure() must time out at the readiness boundary")
+	// Lower bound: timer must actually have run; allow a little slop for
+	// timer scheduling.
+	assert.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond, "ensure() must wait the full timeout")
+	// Upper bound: ensure() returned close to the deadline (didn't hang).
+	assert.WithinDuration(t, deadline, time.Now(), 4*time.Second, "ensure() must return within a small slack window after the timeout")
+}
+
+// TestEnsureBackgroundWorkerBootFailure declares a worker whose entrypoint
+// throws on its very first line. ensure() should surface the boot crash
+// metadata (entrypoint, exit status, attempt count) instead of just
+// reporting a generic timeout. We use a max_consecutive_failures cap so
+// the worker stops respawning and the abort path fires deterministically.
+func TestEnsureBackgroundWorkerBootFailure(t *testing.T) {
+	setupBgWorker(t,
+		WithWorkers("bg-boot-fail", "testdata/bgworker/boot-fail.php", 0,
+			WithWorkerBackground(),
+			WithWorkerMaxFailures(2),
+		),
+		WithNumThreads(2),
+	)
+
+	err := ensureBackgroundWorker(nil, "bg-boot-fail", 5*time.Second)
+	require.Error(t, err, "ensure() must surface the boot failure")
+	msg := err.Error()
+	// One of two paths: either the abort fired (cap reached) and the error
+	// mentions max_consecutive_failures, or the timeout fired with the
+	// bootFailureInfo attached so the message mentions exit status.
+	assert.True(t,
+		strings.Contains(msg, "exit status") || strings.Contains(msg, "max_consecutive_failures") || strings.Contains(msg, "failed to start"),
+		"ensure() error must reflect the boot crash, got: %s", msg)
+}

--- a/bgworkerensure_test.go
+++ b/bgworkerensure_test.go
@@ -1,224 +1,123 @@
-package frankenphp
+package frankenphp_test
 
 import (
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
+	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestEnsureBackgroundWorkerNamedLazy declares a num=0 named worker, then
-// calls ensure() to lazy-start it. The fixture writes a sentinel named
-// after FRANKENPHP_WORKER so we can confirm the right instance ran.
+// TestEnsureBackgroundWorkerNamedLazy drives ensure() against a declared
+// named worker with num=0 (lazy). First request lazy-starts it; set_vars
+// publishes; get_vars reads the published vars.
 func TestEnsureBackgroundWorkerNamedLazy(t *testing.T) {
-	tmp := t.TempDir()
-	setupBgWorker(t,
-		WithWorkers("bg-lazy", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
-		WithNumThreads(2),
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-lazy", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
 	)
 
-	// num=0 means no eager start: the sentinel should not exist yet.
-	require.NoFileExists(t, filepath.Join(tmp, "bg-lazy"), "lazy worker should not have started yet")
-
-	require.NoError(t, ensureBackgroundWorker(nil, "bg-lazy", 5*time.Second))
-	requireSentinelEventually(t, filepath.Join(tmp, "bg-lazy"),
-		"ensure() should have lazy-started the named bg worker")
+	body := serveBody(t, testDataDir, "bgworker/ensure-from-handler.php")
+	assert.NotContains(t, body, "MISSING", "ensure() should have lazy-started the worker and published vars:\n"+body)
+	assert.Contains(t, body, "ensured-name=bg-lazy")
 }
 
 // TestEnsureBackgroundWorkerCatchAll declares a single catch-all (no name)
-// and invokes ensure() with two distinct names. Each name should spawn an
-// independent instance from the same entrypoint and write its own sentinel.
+// and invokes ensure() twice with distinct names. Each name should start
+// its own instance from the same entrypoint and publish its own vars.
 func TestEnsureBackgroundWorkerCatchAll(t *testing.T) {
-	tmp := t.TempDir()
-	setupBgWorker(t,
-		// Name-less bg worker = catch-all.
-		WithWorkers("", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
-		WithNumThreads(4),
+	testDataDir := setupFrankenPHP(t,
+		// Name-less bg worker = catch-all. max_threads on a catch-all is
+		// the cap on lazy-started instances; it also drives the thread
+		// budget that calculateMaxThreads reserves for the catch-all.
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerMaxThreads(4)),
+		frankenphp.WithNumThreads(5),
 	)
 
 	for _, name := range []string{"job-a", "job-b"} {
-		require.NoError(t, ensureBackgroundWorker(nil, name, 5*time.Second), "ensure(%s)", name)
-	}
-
-	for _, name := range []string{"job-a", "job-b"} {
-		requireSentinelEventually(t, filepath.Join(tmp, name),
-			"catch-all instance %q should have written its sentinel", name)
+		body := serveBody(t, testDataDir, "bgworker/ensure-reader.php?name="+name)
+		assert.Contains(t, body, "name="+name, "catch-all instance %s did not publish its name:\n%s", name, body)
 	}
 }
 
-// TestEnsureBackgroundWorkerCatchAllCap exercises max_threads on the
-// catch-all: third distinct name beyond the cap should error.
+// TestEnsureBackgroundWorkerCatchAllCap sets max_threads on a catch-all so
+// the third distinct name ensure() hits the cap error.
 func TestEnsureBackgroundWorkerCatchAllCap(t *testing.T) {
-	tmp := t.TempDir()
-	setupBgWorker(t,
-		WithWorkers("", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-			WithWorkerMaxThreads(2),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
-		WithNumThreads(4),
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerMaxThreads(2)),
+		frankenphp.WithNumThreads(5),
 	)
 
-	require.NoError(t, ensureBackgroundWorker(nil, "cap-a", 5*time.Second))
-	require.NoError(t, ensureBackgroundWorker(nil, "cap-b", 5*time.Second))
+	for _, name := range []string{"cap-a", "cap-b"} {
+		body := serveBody(t, testDataDir, "bgworker/ensure-reader.php?name="+name)
+		require.NotContains(t, body, "limit of", "first two ensures should succeed, got:\n"+body)
+	}
 
-	require.ErrorContains(t,
-		ensureBackgroundWorker(nil, "cap-c", 5*time.Second),
-		"limit of 2 reached",
-		"third ensure must hit the catch-all cap")
+	// Third should fail with a cap error.
+	body := serveBody(t, testDataDir, "bgworker/ensure-reader.php?name=cap-c")
+	assert.Contains(t, body, "limit of 2 reached", "third ensure must hit the catch-all cap:\n"+body)
 }
 
-// TestEnsureBackgroundWorkerUndeclared confirms ensure() on an undeclared
-// name with no catch-all returns the configuration error.
+// TestEnsureBackgroundWorkerUndeclared checks that ensure() on a name that
+// is neither declared nor covered by a catch-all returns an error.
 func TestEnsureBackgroundWorkerUndeclared(t *testing.T) {
-	setupBgWorker(t,
-		WithWorkers("bg-known", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-		),
-		WithNumThreads(2),
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-lazy", "testdata/bgworker/named.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(2),
 	)
 
-	require.ErrorContains(t,
-		ensureBackgroundWorker(nil, "other-name", 5*time.Second),
-		"no background worker configured for name")
+	// Script tries to ensure('other-name') which is neither named nor catch-all.
+	php := `<?php
+try {
+    frankenphp_ensure_background_worker('other-name', 2.0);
+    echo "FAIL no error";
+} catch (RuntimeException $e) {
+    echo "OK ", $e->getMessage();
+}`
+	tmp := testDataDir + "bg-ensure-undeclared.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	body := serveBody(t, testDataDir, "bg-ensure-undeclared.php")
+	assert.Contains(t, body, "OK no background worker configured for name", "ensure of undeclared name should error:\n"+body)
+	assert.NotContains(t, body, "FAIL")
 }
 
-// TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected verifies
-// ensure() rejects the catch-all's own filepath uniformly across
-// num=0 and num=1.
-func TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	// The catch-all's user-facing name is its absolute file path
-	// (set by newWorker when the declaration leaves name empty).
-	absPath := filepath.Join(cwd, "testdata/bgworker/named.php")
-
-	for _, tc := range []struct {
-		label string
-		num   int
-	}{
-		{"lazy num=0", 0},
-		{"eager num=1", 1},
-	} {
-		t.Run(tc.label, func(t *testing.T) {
-			setupBgWorker(t,
-				WithWorkers("", "testdata/bgworker/named.php", tc.num,
-					WithWorkerBackground(),
-				),
-				WithNumThreads(2),
-			)
-
-			err := ensureBackgroundWorker(nil, absPath, 1*time.Second)
-			require.Error(t, err, "ensure() with the catch-all's file path must be rejected")
-			// Echoes the rejected input so a PHP caller can see what
-			// they passed; "catch-all's own name" surfaces the cause.
-			assert.Contains(t, err.Error(), absPath, "error must echo the rejected input")
-			assert.Contains(t, err.Error(), "catch-all's own name", "error must explain why the input was rejected")
-		})
-	}
-}
-
-// TestEnsureBackgroundWorkerConcurrent confirms the doc claim that ensure()
-// is safe to call concurrently: 16 goroutines hitting the same lazy-named
-// declaration produce exactly one spawned thread. Without serialising the
-// lazy-start gate (bgLazyStartMu), the second caller could observe the
-// flag before the first caller has completed thread reservation, leaving
-// the worker in an inconsistent state.
-func TestEnsureBackgroundWorkerConcurrent(t *testing.T) {
-	setupBgWorker(t,
-		WithWorkers("bg-concurrent", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-		),
-		WithNumThreads(8),
+// TestBackgroundWorkerBootFailureError confirms that an entrypoint which
+// throws during boot surfaces the captured details through ensure()'s
+// timeout error message: entrypoint path, attempt count, and the PHP
+// RuntimeException message. Runs as a non-worker request so ensure uses
+// the tolerant lazy-start path (no fail-fast).
+func TestBackgroundWorkerBootFailureError(t *testing.T) {
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("boot-fail-worker", "testdata/bgworker/boot-fail.php", 0,
+			frankenphp.WithWorkerBackground()),
+		frankenphp.WithNumThreads(3),
 	)
 
-	const goroutines = 16
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make([]error, goroutines)
-	start := make(chan struct{})
-	for i := 0; i < goroutines; i++ {
-		go func(idx int) {
-			defer wg.Done()
-			<-start
-			errs[idx] = ensureBackgroundWorker(nil, "bg-concurrent", 5*time.Second)
-		}(i)
-	}
-	close(start)
-	wg.Wait()
+	php := `<?php
+try {
+    frankenphp_ensure_background_worker('boot-fail-worker', 1.0);
+    echo "FAIL no error";
+} catch (\RuntimeException $e) {
+    echo $e->getMessage();
+}`
+	tmp := testDataDir + "bg-boot-fail.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
 
-	for i, err := range errs {
-		require.NoError(t, err, "goroutine %d", i)
-	}
-
-	// The lazy-named declaration should resolve to its single *worker,
-	// and exactly one thread should have been spawned by the lazy-start
-	// path despite the 16 concurrent ensure() callers.
-	lookup := backgroundLookups[0]
-	require.NotNil(t, lookup)
-	w := lookup.byName["bg-concurrent"]
-	require.NotNil(t, w)
-	assert.Equal(t, 1, w.countThreads(), "exactly one worker thread expected")
-}
-
-// TestEnsureBackgroundWorkerTimeout proves ensure() blocks until either
-// the worker hits its readiness boundary (frankenphp_get_worker_handle())
-// or the timeout expires. The fixture sleep()s without ever calling the
-// readiness function, so the second branch must fire.
-func TestEnsureBackgroundWorkerTimeout(t *testing.T) {
-	setupBgWorker(t,
-		WithWorkers("bg-no-handle", "testdata/bgworker/no-handle.php", 0,
-			WithWorkerBackground(),
-		),
-		WithNumThreads(2),
-	)
-
-	start := time.Now()
-	err := ensureBackgroundWorker(nil, "bg-no-handle", 1*time.Second)
-	deadline := start.Add(1 * time.Second)
-
-	require.ErrorContains(t, err,
-		"did not call frankenphp_get_worker_handle()",
-		"ensure() must time out at the readiness boundary")
-	// Lower bound: timer must actually have run; allow a little slop for
-	// timer scheduling.
-	assert.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond, "ensure() must wait the full timeout")
-	// Upper bound: ensure() returned close to the deadline (didn't hang).
-	assert.WithinDuration(t, deadline, time.Now(), 4*time.Second, "ensure() must return within a small slack window after the timeout")
-}
-
-// TestEnsureBackgroundWorkerBootFailure declares a worker whose entrypoint
-// throws on its very first line. ensure() should surface the boot crash
-// metadata (entrypoint, exit status, attempt count) instead of just
-// reporting a generic timeout. We use a max_consecutive_failures cap so
-// the worker stops respawning and the abort path fires deterministically.
-func TestEnsureBackgroundWorkerBootFailure(t *testing.T) {
-	setupBgWorker(t,
-		WithWorkers("bg-boot-fail", "testdata/bgworker/boot-fail.php", 0,
-			WithWorkerBackground(),
-			WithWorkerMaxFailures(2),
-		),
-		WithNumThreads(2),
-	)
-
-	err := ensureBackgroundWorker(nil, "bg-boot-fail", 5*time.Second)
-	require.Error(t, err, "ensure() must surface the boot failure")
-	msg := err.Error()
-	// One of two paths: either the abort fired (cap reached) and the error
-	// mentions max_consecutive_failures, or the timeout fired with the
-	// bootFailureInfo attached so the message mentions exit status.
-	assert.True(t,
-		strings.Contains(msg, "exit status") || strings.Contains(msg, "max_consecutive_failures") || strings.Contains(msg, "failed to start"),
-		"ensure() error must reflect the boot crash, got: %s", msg)
+	body := serveBody(t, testDataDir, "bg-boot-fail.php")
+	assert.NotContains(t, body, "FAIL", "ensure should have thrown:\n"+body)
+	assert.Contains(t, body, `"boot-fail-worker"`)
+	assert.Contains(t, body, filepath.Join("bgworker", "boot-fail.php"), "entrypoint path must appear in the error:\n"+body)
+	assert.Contains(t, body, "attempt", "attempt count must appear:\n"+body)
+	assert.Contains(t, body, "intentional boot failure for test", "PHP exception message must be captured:\n"+body)
 }

--- a/bgworkerhelpers_test.go
+++ b/bgworkerhelpers_test.go
@@ -1,0 +1,57 @@
+package frankenphp_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/require"
+)
+
+// requireFileEventually asserts that `path` appears on disk before the
+// deadline. Wraps require.Eventually so call sites stay short.
+func requireFileEventually(t testing.TB, path string, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, msgAndArgs...)
+}
+
+// setupFrankenPHP boots FrankenPHP with the given options, registers
+// Shutdown as a t.Cleanup, and returns the absolute path to the testdata
+// directory. Saves the boilerplate every bg-worker test repeats.
+func setupFrankenPHP(t *testing.T, opts ...frankenphp.Option) (testDataDir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataDir = cwd + "/testdata/"
+	require.NoError(t, frankenphp.Init(opts...))
+	t.Cleanup(frankenphp.Shutdown)
+	return
+}
+
+// serveBody runs `script` (relative to testDataDir, may include a query
+// string) through FrankenPHP and returns the response body. ErrRejected is
+// treated as a non-fatal outcome so worker-mode quirks don't fail tests
+// that only care about the script's stdout.
+func serveBody(t *testing.T, testDataDir, scriptAndQuery string, opts ...frankenphp.RequestOption) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "http://example.com/"+scriptAndQuery, nil)
+	reqOpts := append([]frankenphp.RequestOption{
+		frankenphp.WithRequestDocumentRoot(testDataDir, false),
+	}, opts...)
+	fr, err := frankenphp.NewRequestWithContext(req, reqOpts...)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	if err := frankenphp.ServeHTTP(w, fr); err != nil {
+		require.ErrorAs(t, err, &frankenphp.ErrRejected{})
+	}
+	body, err := io.ReadAll(w.Result().Body)
+	require.NoError(t, err)
+	return string(body)
+}

--- a/bgworkerhelpers_test.go
+++ b/bgworkerhelpers_test.go
@@ -5,20 +5,21 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/require"
 )
 
-// requireFileEventually asserts that `path` appears on disk before the
-// deadline. Wraps require.Eventually so call sites stay short.
-func requireFileEventually(t testing.TB, path string, msgAndArgs ...any) {
+// serveInlinePHP writes a small PHP fixture under testDataDir, serves it
+// via ServeHTTP, removes it on cleanup, and returns the response body.
+// The file name should not exist already; it is registered for
+// t.Cleanup-driven removal.
+func serveInlinePHP(t *testing.T, testDataDir, name, php string) string {
 	t.Helper()
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(path)
-		return err == nil
-	}, 5*time.Second, 25*time.Millisecond, msgAndArgs...)
+	path := testDataDir + name
+	require.NoError(t, os.WriteFile(path, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(path) })
+	return serveBody(t, testDataDir, name)
 }
 
 // setupFrankenPHP boots FrankenPHP with the given options, registers

--- a/bgworkerinternal_test.go
+++ b/bgworkerinternal_test.go
@@ -1,8 +1,13 @@
 package frankenphp
 
 import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,12 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBackgroundWorkerRestartForceKillsStuckThread exercises the force-kill
-// path: the fixture sleep()s without watching the stop pipe, so
-// handler.drain() cannot wake it. RestartWorkers must go through the
+// TestBackgroundWorkerRestartForceKillsStuckThread actually exercises the
+// force-kill path: the fixture sleep()s without watching the stop pipe,
+// so handler.drain() cannot wake it. RestartWorkers must go through the
 // grace-period timeout and the force-kill primitive (pthread_kill on
 // Linux/FreeBSD) to finish within the budget. Skips platforms where
-// force-kill cannot interrupt a blocking syscall.
+// force-kill cannot interrupt a blocking syscall (macOS has no realtime
+// signals, Windows non-alertable Sleep stays uninterruptible).
 func TestBackgroundWorkerRestartForceKillsStuckThread(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "freebsd" {
 		t.Skipf("force-kill cannot interrupt blocking syscalls on %s", runtime.GOOS)
@@ -25,23 +31,42 @@ func TestBackgroundWorkerRestartForceKillsStuckThread(t *testing.T) {
 	drainGracePeriod = 2 * time.Second
 	t.Cleanup(func() { drainGracePeriod = prev })
 
-	tmp := t.TempDir()
-	sentinel := filepath.Join(tmp, "bg-stuck.sentinel")
+	cwd, _ := os.Getwd()
+	testDataDir := cwd + "/testdata/"
 
-	setupBgWorker(t,
-		WithWorkers("bg-stuck", "testdata/bgworker/stuck.php", 1,
-			WithWorkerBackground(),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
-		),
+	require.NoError(t, Init(
+		WithWorkers("bg-stuck", testDataDir+"bgworker/stuck.php", 1,
+			WithWorkerBackground()),
 		WithNumThreads(2),
-	)
+	))
+	t.Cleanup(Shutdown)
 
-	// Wait until the bg worker touched the sentinel (the line right
-	// before sleep(60)) so we know it is parked in the blocking syscall
-	// when the drain fires - that's the only way to prove the
-	// force-kill code path was exercised, not the stop-pipe EOF path
-	// (the fixture doesn't open the stop pipe at all).
-	requireSentinelEventually(t, sentinel, "bg worker never entered sleep()")
+	// Wait until the bg worker published 'ready' (the line right before
+	// sleep(60)) so we know it is actually parked in the blocking
+	// syscall when the drain fires - that's the only way to prove the
+	// force-kill code path was exercised, not the stop-pipe EOF path.
+	readerPHP := `<?php
+try {
+    $vars = frankenphp_get_vars('bg-stuck');
+    echo 'ready=', $vars['ready'] ?? 'MISSING';
+} catch (\Throwable $e) {
+    echo 'err=', $e->getMessage();
+}`
+	tmp := testDataDir + "bg-stuck-reader.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(readerPHP), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	require.Eventually(t, func() bool {
+		req := httptest.NewRequest("GET", "http://example.com/bg-stuck-reader.php", nil)
+		fr, err := NewRequestWithContext(req, WithRequestDocumentRoot(testDataDir, false))
+		if err != nil {
+			return false
+		}
+		w := httptest.NewRecorder()
+		_ = ServeHTTP(w, fr)
+		body, _ := io.ReadAll(w.Result().Body)
+		return strings.Contains(string(body), "ready=1")
+	}, 5*time.Second, 25*time.Millisecond, "bg worker never entered sleep()")
 
 	start := time.Now()
 	RestartWorkers()
@@ -51,10 +76,13 @@ func TestBackgroundWorkerRestartForceKillsStuckThread(t *testing.T) {
 		"drain must force-kill the stuck bg worker within the grace period")
 }
 
-// TestEnsureBackgroundWorkerCatchAllNumPlusLazy exercises a catch-all
-// with both an eager pool (num=1) and lazy ensures: every ensure() must
-// succeed alongside the eager thread, since num and the catch-all cap
-// reserve independent thread budgets.
+// TestEnsureBackgroundWorkerCatchAllNumPlusLazy declares a catch-all with
+// an eager pool (num=1) and no explicit max_threads. The previous
+// reservation logic only counted max(num, max_threads) and would
+// undercount when num>0 with max_threads unset, leaving lazy ensure()
+// callers without inactive thread slots even though the cap (16) said
+// they were allowed. With the fix in place, all four lazy ensure()s
+// must succeed alongside the eager pool thread.
 func TestEnsureBackgroundWorkerCatchAllNumPlusLazy(t *testing.T) {
 	tmp := t.TempDir()
 	setupBgWorker(t,
@@ -74,9 +102,13 @@ func TestEnsureBackgroundWorkerCatchAllNumPlusLazy(t *testing.T) {
 	}
 }
 
-// TestBackgroundWorkerCatchAllEagerInstance verifies that a catch-all
-// declared with num>0 actually boots and runs the script — the
-// catch-all flag must not silently disable the eager pool.
+// TestBackgroundWorkerCatchAllEagerInstance proves that the eager
+// num>0 pool of a catch-all worker actually boots and runs to
+// readiness, alongside any lazy ensure() instances. The previous
+// reservation logic was sufficient for the eager thread to land in a
+// PHP slot but did not assert it actually executed; this guards
+// against a regression where catch-all eager num is silently treated
+// as a no-op.
 func TestBackgroundWorkerCatchAllEagerInstance(t *testing.T) {
 	tmp := t.TempDir()
 	sentinel := filepath.Join(tmp, "eager")
@@ -88,13 +120,15 @@ func TestBackgroundWorkerCatchAllEagerInstance(t *testing.T) {
 		WithNumThreads(2),
 	)
 	requireSentinelEventually(t, sentinel,
-		"eager catch-all instance must reach readiness")
+		"eager catch-all instance must reach readiness and write its sentinel")
 }
 
-// TestEnsureBackgroundWorkerPostBootCrashLoopAborts verifies that a
-// worker which reaches readiness once and then keeps crashing aborts
-// ensure() callers, instead of leaving them stuck on the stale "ready"
-// signal.
+// TestEnsureBackgroundWorkerPostBootCrashLoopAborts proves that a worker
+// which reaches readiness once (closing r.ready) and then crashes
+// repeatedly post-readiness eventually surfaces the failure to ensure()
+// callers via r.aborted, instead of leaving them with a stale "ready"
+// signal pointing at a dead worker. Regression test for the silent-
+// failure mode in the cap branch of afterScriptExecution.
 func TestEnsureBackgroundWorkerPostBootCrashLoopAborts(t *testing.T) {
 	setupBgWorker(t,
 		WithWorkers("flapper", "testdata/bgworker/readiness-then-crash.php", 0,
@@ -104,20 +138,27 @@ func TestEnsureBackgroundWorkerPostBootCrashLoopAborts(t *testing.T) {
 		WithNumThreads(2),
 	)
 
-	// Returns once the fixture signals readiness via frankenphp_get_worker_handle().
+	// First call returns once the worker reaches readiness — the
+	// fixture's frankenphp_get_worker_handle() fires markReady before
+	// the script exit(1)s.
 	require.NoError(t, ensureBackgroundWorker(nil, "flapper", 5*time.Second))
 
-	// Subsequent ensure()s must surface the failure: prior abort or a
-	// fresh thread that crashes again. Never nil.
+	// After at most max_consecutive_failures = 2 post-readiness crashes
+	// (each <1s with quadratic backoff capped at 1s), the cap branch
+	// fires abort() + invalidates the registry slot. Subsequent
+	// ensure() calls either see the prior abort, or lazy-spawn a fresh
+	// thread that ALSO crashes and aborts. Either way: error, not nil.
 	require.Eventually(t, func() bool {
 		return ensureBackgroundWorker(nil, "flapper", 1*time.Second) != nil
 	}, 10*time.Second, 100*time.Millisecond,
-		"ensure() must surface post-boot crash-loop")
+		"ensure() must surface post-boot crash-loop instead of silently returning nil")
 }
 
-// TestEnsureBackgroundWorkerCatchAllRespawnAfterCap verifies that once
-// a catch-all instance trips the failure cap, the slot is released so
-// a retried ensure() can lazy-spawn a fresh thread under the same name.
+// TestEnsureBackgroundWorkerCatchAllRespawnAfterCap proves that
+// invalidateBackgroundEntry actually reclaims the catch-all slot after
+// the cap fires: a fixture that crashes its first N boots and succeeds
+// on boot N+1 must end up reaching readiness via a retried ensure(),
+// rather than being permanently stuck behind the cap.
 func TestEnsureBackgroundWorkerCatchAllRespawnAfterCap(t *testing.T) {
 	tmp := t.TempDir()
 	setupBgWorker(t,
@@ -127,23 +168,132 @@ func TestEnsureBackgroundWorkerCatchAllRespawnAfterCap(t *testing.T) {
 			WithWorkerMaxFailures(2),
 			WithWorkerEnv(map[string]string{
 				"BG_MARKER_DIR": tmp,
-				// Crash boots 1..3, succeed on boot 4. The cap fires on
-				// the 3rd crash because failureCount is checked before
-				// the increment in afterScriptExecution.
+				// Fail boots 1..3, succeed boot 4+. afterScriptExecution
+				// in threadbackgroundworker.go checks failureCount >= max
+				// before the failureCount++ at the bottom, so max=2 means
+				// the cap fires on the 3rd crash.
 				"BG_FAIL_UNTIL": "3",
 			}),
 		),
 		WithNumThreads(3),
 	)
 
+	// First ensure() drives boots 1..3 (all crash, cap hits, abort
+	// fires + catch-all entry invalidated).
 	err := ensureBackgroundWorker(nil, "respawn", 5*time.Second)
 	require.Error(t, err, "first ensure() must hit the cap")
 
+	// A retry must lazy-spawn a fresh thread (boot 4) that reaches
+	// readiness. Without invalidate, catchAllNames["respawn"] would
+	// still hold the prior aborted r and ensure() would short-circuit
+	// with the stale error.
 	require.Eventually(t, func() bool {
 		return ensureBackgroundWorker(nil, "respawn", 5*time.Second) == nil
 	}, 15*time.Second, 100*time.Millisecond,
-		"retry must lazy-spawn a fresh thread after the cap")
+		"ensure() must lazy-spawn a fresh thread after the cap invalidates the slot")
 
 	requireSentinelEventually(t, filepath.Join(tmp, "ready"),
 		"recovered worker must reach readiness")
 }
+
+// TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected verifies
+// ensure() rejects the catch-all's own filepath uniformly across
+// num=0 and num=1.
+func TestEnsureBackgroundWorkerCatchAllSelfIdentityRejected(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	// The catch-all's user-facing name is its absolute file path
+	// (set by newWorker when the declaration leaves name empty).
+	absPath := filepath.Join(cwd, "testdata/bgworker/named.php")
+
+	for _, tc := range []struct {
+		label string
+		num   int
+	}{
+		{"lazy num=0", 0},
+		{"eager num=1", 1},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			setupBgWorker(t,
+				WithWorkers("", "testdata/bgworker/named.php", tc.num,
+					WithWorkerBackground(),
+				),
+				WithNumThreads(2),
+			)
+
+			err := ensureBackgroundWorker(nil, absPath, 1*time.Second)
+			require.Error(t, err, "ensure() with the catch-all's file path must be rejected")
+			// Echoes the rejected input so a PHP caller can see what
+			// they passed; "catch-all's own name" surfaces the cause.
+			assert.Contains(t, err.Error(), absPath, "error must echo the rejected input")
+			assert.Contains(t, err.Error(), "catch-all's own name", "error must explain why the input was rejected")
+		})
+	}
+}
+
+// TestBackgroundWorkerCatchAllPerScope declares a catch-all in two
+// distinct scopes and verifies that ensure() in scope A consumes a slot
+// from scope A's catch-all only, leaving scope B's catch-all untouched.
+func TestBackgroundWorkerCatchAllPerScope(t *testing.T) {
+	scopeA := NextScope()
+	scopeB := NextScope()
+
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a")
+	dirB := filepath.Join(tmp, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0o755))
+	require.NoError(t, os.MkdirAll(dirB, 0o755))
+
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeA),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirA}),
+		),
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeB),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirB}),
+		),
+		WithNumThreads(4),
+	)
+
+	// Pre-conditions: each scope's catch-all is empty.
+	require.Empty(t, backgroundLookups[scopeA].catchAll.bg.catchAllNames, "scope A catch-all must start empty")
+	require.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must start empty")
+
+	// Drive ensure() through a fake "request" context tagged to scope A.
+	fc := newFrankenPHPContext()
+	fc.scope = scopeA
+	ctx := context.WithValue(context.Background(), contextKey, fc)
+	thread := &phpThread{}
+	thread.handler = &fakeContextThread{ctx: ctx}
+	require.NoError(t, ensureBackgroundWorker(thread, "job-a", 5*time.Second))
+
+	// The lazy-started instance must land in scope A's catch-all only.
+	require.Eventually(t, func() bool {
+		_, ok := backgroundLookups[scopeA].catchAll.bg.catchAllNames["job-a"]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "ensure() must populate scope A's catch-all")
+	assert.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must remain untouched")
+
+	assert.Equal(t, 1, backgroundLookups[scopeA].catchAll.countThreads(), "scope A catch-all must host exactly one thread")
+	assert.Equal(t, 0, backgroundLookups[scopeB].catchAll.countThreads(), "scope B catch-all must host zero threads")
+
+	requireSentinelEventually(t, filepath.Join(dirA, "job-a"),
+		"scope A catch-all instance must write its sentinel under scope A's BG_SENTINEL_DIR")
+}
+
+// fakeContextThread is a threadHandler stub for the request-context
+// fallback path in getLookup.
+type fakeContextThread struct {
+	ctx context.Context
+}
+
+func (h *fakeContextThread) name() string                          { return "fake" }
+func (h *fakeContextThread) beforeScriptExecution() string         { return "" }
+func (h *fakeContextThread) afterScriptExecution(int)              {}
+func (h *fakeContextThread) frankenPHPContext() *frankenPHPContext { return nil }
+func (h *fakeContextThread) drain()                                {}
+func (h *fakeContextThread) context() context.Context              { return h.ctx }
+func (h *fakeContextThread) scopedWorker() *worker                 { return nil }

--- a/bgworkerinternal_test.go
+++ b/bgworkerinternal_test.go
@@ -1,0 +1,149 @@
+package frankenphp
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackgroundWorkerRestartForceKillsStuckThread exercises the force-kill
+// path: the fixture sleep()s without watching the stop pipe, so
+// handler.drain() cannot wake it. RestartWorkers must go through the
+// grace-period timeout and the force-kill primitive (pthread_kill on
+// Linux/FreeBSD) to finish within the budget. Skips platforms where
+// force-kill cannot interrupt a blocking syscall.
+func TestBackgroundWorkerRestartForceKillsStuckThread(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "freebsd" {
+		t.Skipf("force-kill cannot interrupt blocking syscalls on %s", runtime.GOOS)
+	}
+
+	prev := drainGracePeriod
+	drainGracePeriod = 2 * time.Second
+	t.Cleanup(func() { drainGracePeriod = prev })
+
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-stuck.sentinel")
+
+	setupBgWorker(t,
+		WithWorkers("bg-stuck", "testdata/bgworker/stuck.php", 1,
+			WithWorkerBackground(),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		WithNumThreads(2),
+	)
+
+	// Wait until the bg worker touched the sentinel (the line right
+	// before sleep(60)) so we know it is parked in the blocking syscall
+	// when the drain fires - that's the only way to prove the
+	// force-kill code path was exercised, not the stop-pipe EOF path
+	// (the fixture doesn't open the stop pipe at all).
+	requireSentinelEventually(t, sentinel, "bg worker never entered sleep()")
+
+	start := time.Now()
+	RestartWorkers()
+	// Drain budget = grace period (2s) + slack for signal dispatch and
+	// drain completion.
+	assert.WithinDuration(t, start, time.Now(), 5*time.Second,
+		"drain must force-kill the stuck bg worker within the grace period")
+}
+
+// TestEnsureBackgroundWorkerCatchAllNumPlusLazy exercises a catch-all
+// with both an eager pool (num=1) and lazy ensures: every ensure() must
+// succeed alongside the eager thread, since num and the catch-all cap
+// reserve independent thread budgets.
+func TestEnsureBackgroundWorkerCatchAllNumPlusLazy(t *testing.T) {
+	tmp := t.TempDir()
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/named.php", 1,
+			WithWorkerBackground(),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		WithNumThreads(2),
+	)
+
+	for _, name := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, ensureBackgroundWorker(nil, name, 5*time.Second), "ensure(%s)", name)
+	}
+	for _, name := range []string{"a", "b", "c", "d"} {
+		requireSentinelEventually(t, filepath.Join(tmp, name),
+			"lazy catch-all instance %q should have written its sentinel", name)
+	}
+}
+
+// TestBackgroundWorkerCatchAllEagerInstance verifies that a catch-all
+// declared with num>0 actually boots and runs the script — the
+// catch-all flag must not silently disable the eager pool.
+func TestBackgroundWorkerCatchAllEagerInstance(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "eager")
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/eager-catchall.php", 1,
+			WithWorkerBackground(),
+			WithWorkerEnv(map[string]string{"BG_EAGER_SENTINEL": sentinel}),
+		),
+		WithNumThreads(2),
+	)
+	requireSentinelEventually(t, sentinel,
+		"eager catch-all instance must reach readiness")
+}
+
+// TestEnsureBackgroundWorkerPostBootCrashLoopAborts verifies that a
+// worker which reaches readiness once and then keeps crashing aborts
+// ensure() callers, instead of leaving them stuck on the stale "ready"
+// signal.
+func TestEnsureBackgroundWorkerPostBootCrashLoopAborts(t *testing.T) {
+	setupBgWorker(t,
+		WithWorkers("flapper", "testdata/bgworker/readiness-then-crash.php", 0,
+			WithWorkerBackground(),
+			WithWorkerMaxFailures(2),
+		),
+		WithNumThreads(2),
+	)
+
+	// Returns once the fixture signals readiness via frankenphp_get_worker_handle().
+	require.NoError(t, ensureBackgroundWorker(nil, "flapper", 5*time.Second))
+
+	// Subsequent ensure()s must surface the failure: prior abort or a
+	// fresh thread that crashes again. Never nil.
+	require.Eventually(t, func() bool {
+		return ensureBackgroundWorker(nil, "flapper", 1*time.Second) != nil
+	}, 10*time.Second, 100*time.Millisecond,
+		"ensure() must surface post-boot crash-loop")
+}
+
+// TestEnsureBackgroundWorkerCatchAllRespawnAfterCap verifies that once
+// a catch-all instance trips the failure cap, the slot is released so
+// a retried ensure() can lazy-spawn a fresh thread under the same name.
+func TestEnsureBackgroundWorkerCatchAllRespawnAfterCap(t *testing.T) {
+	tmp := t.TempDir()
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/fail-then-succeed.php", 0,
+			WithWorkerBackground(),
+			WithWorkerMaxThreads(2),
+			WithWorkerMaxFailures(2),
+			WithWorkerEnv(map[string]string{
+				"BG_MARKER_DIR": tmp,
+				// Crash boots 1..3, succeed on boot 4. The cap fires on
+				// the 3rd crash because failureCount is checked before
+				// the increment in afterScriptExecution.
+				"BG_FAIL_UNTIL": "3",
+			}),
+		),
+		WithNumThreads(3),
+	)
+
+	err := ensureBackgroundWorker(nil, "respawn", 5*time.Second)
+	require.Error(t, err, "first ensure() must hit the cap")
+
+	require.Eventually(t, func() bool {
+		return ensureBackgroundWorker(nil, "respawn", 5*time.Second) == nil
+	}, 15*time.Second, 100*time.Millisecond,
+		"retry must lazy-spawn a fresh thread after the cap")
+
+	requireSentinelEventually(t, filepath.Join(tmp, "ready"),
+		"recovered worker must reach readiness")
+}

--- a/bgworkerinternalhelpers_test.go
+++ b/bgworkerinternalhelpers_test.go
@@ -1,6 +1,7 @@
 package frankenphp
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -29,4 +30,25 @@ func requireSentinelEventually(t testing.TB, path string, msgAndArgs ...any) {
 		_, err := os.Stat(path)
 		return err == nil
 	}, 5*time.Second, 10*time.Millisecond, msgAndArgs...)
+}
+
+// ensureBackgroundWorker starts the named bg worker and waits for
+// readiness, abort, or timeout. Test-only adapter mirroring the C
+// entry-point's wait without the formatted-error machinery.
+func ensureBackgroundWorker(thread *phpThread, name string, timeout time.Duration) error {
+	sk, err := startBackgroundWorker(thread, name)
+	if err != nil {
+		return err
+	}
+	if timeout <= 0 {
+		timeout = defaultEnsureTimeout
+	}
+	select {
+	case <-sk.ready:
+		return nil
+	case <-sk.aborted:
+		return sk.abortErr
+	case <-time.After(timeout):
+		return fmt.Errorf("background worker %q failed to start within %v", name, timeout)
+	}
 }

--- a/bgworkerinternalhelpers_test.go
+++ b/bgworkerinternalhelpers_test.go
@@ -1,0 +1,32 @@
+package frankenphp
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setupBgWorker boots FrankenPHP with the given options (internal-package
+// variant), registers Shutdown as a t.Cleanup, and returns the absolute
+// path to the testdata directory.
+func setupBgWorker(t *testing.T, opts ...Option) (testDataDir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataDir = cwd + "/testdata/"
+	require.NoError(t, Init(opts...))
+	t.Cleanup(Shutdown)
+	return
+}
+
+// requireSentinelEventually asserts that `path` appears on disk before the
+// deadline. Wraps require.Eventually so call sites stay short.
+func requireSentinelEventually(t testing.TB, path string, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, msgAndArgs...)
+}

--- a/bgworkerpool_test.go
+++ b/bgworkerpool_test.go
@@ -2,57 +2,69 @@ package frankenphp_test
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestBackgroundWorkerPool declares a named bg worker with num=3 (pool of
-// three threads). Each thread touches a unique sentinel under
-// BG_SENTINEL_DIR via tempnam(), so the test can assert that all three
-// pool threads booted independently. Covers the lifted num>1 +
-// max_threads>1 constraints and the per-thread stop pipe.
+// TestBackgroundWorkerPool declares a named bg worker with num=3 (pool
+// of three threads). All three threads should boot, share the same
+// registered backgroundWorkerState, and the reader can see the pool's
+// vars. This covers the lifted num>1 + max_threads>1 constraint.
 func TestBackgroundWorkerPool(t *testing.T) {
-	tmp := t.TempDir()
-	setupFrankenPHP(t,
+	testDataDir := setupFrankenPHP(t,
 		frankenphp.WithWorkers("pool-worker", "testdata/bgworker/pool.php", 3,
 			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerMaxThreads(3),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
+			frankenphp.WithWorkerMaxThreads(3)),
 		frankenphp.WithNumThreads(6),
 	)
 
-	require.Eventually(t, func() bool {
-		entries, err := os.ReadDir(tmp)
-		return err == nil && len(entries) == 3
-	}, 5*time.Second, 25*time.Millisecond,
-		"expected 3 distinct pool sentinels under %s", tmp)
+	// Read the pool worker's vars via get_vars; all three threads share
+	// the same state so we don't need to target a specific one. ensure()
+	// waits for at least one pool thread's first set_vars so the eager
+	// start can't race the reader.
+	php := `<?php
+frankenphp_ensure_background_worker('pool-worker');
+$vars = frankenphp_get_vars('pool-worker');
+echo 'name=', $vars['name'] ?? 'MISSING', "\n";
+echo 'has-pid=', isset($vars['pid']) ? '1' : '0', "\n";
+`
+	tmp := testDataDir + "pool-reader.php"
+	require.NoError(t, os.WriteFile(tmp, []byte(php), 0644))
+	t.Cleanup(func() { _ = os.Remove(tmp) })
+
+	body := serveBody(t, testDataDir, "pool-reader.php")
+	assert.NotContains(t, body, "MISSING", "pool worker should have published its vars:\n"+body)
+	assert.Contains(t, body, "name=pool-worker")
+	assert.Contains(t, body, "has-pid=1")
 }
 
 // TestBackgroundWorkerMultiEntrypoint declares two named bg workers that
-// share the same entrypoint file. Each gets its own *worker, so both Init
-// successfully (no filename-collision rejection) and both produce
-// sentinels.
+// share the same entrypoint file. Each registry is independent, so ensure()
+// + get_vars resolve to the correct instance by name.
 func TestBackgroundWorkerMultiEntrypoint(t *testing.T) {
-	tmp := t.TempDir()
-	setupFrankenPHP(t,
+	testDataDir := setupFrankenPHP(t,
 		frankenphp.WithWorkers("shared-a", "testdata/bgworker/named.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
+			frankenphp.WithWorkerBackground()),
 		frankenphp.WithWorkers("shared-b", "testdata/bgworker/named.php", 1,
-			frankenphp.WithWorkerBackground(),
-			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
-		),
+			frankenphp.WithWorkerBackground()),
 		frankenphp.WithNumThreads(5),
 	)
 
-	for _, name := range []string{"shared-a", "shared-b"} {
-		requireFileEventually(t, filepath.Join(tmp, name),
-			"shared bg worker %q did not touch its sentinel", name)
+	read := func(name string) string {
+		php := `<?php
+frankenphp_ensure_background_worker(` + "'" + name + "'" + `);
+$vars = frankenphp_get_vars(` + "'" + name + "'" + `);
+echo $vars['FRANKENPHP_WORKER'] ?? 'MISSING';
+`
+		script := "multi-entry-reader-" + name + ".php"
+		require.NoError(t, os.WriteFile(testDataDir+script, []byte(php), 0644))
+		t.Cleanup(func() { _ = os.Remove(testDataDir + script) })
+		return serveBody(t, testDataDir, script)
 	}
+
+	assert.Equal(t, "shared-a", read("shared-a"), "shared-a name must resolve to its own worker")
+	assert.Equal(t, "shared-b", read("shared-b"), "shared-b name must resolve to its own worker")
 }

--- a/bgworkerpool_test.go
+++ b/bgworkerpool_test.go
@@ -1,0 +1,58 @@
+package frankenphp_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackgroundWorkerPool declares a named bg worker with num=3 (pool of
+// three threads). Each thread touches a unique sentinel under
+// BG_SENTINEL_DIR via tempnam(), so the test can assert that all three
+// pool threads booted independently. Covers the lifted num>1 +
+// max_threads>1 constraints and the per-thread stop pipe.
+func TestBackgroundWorkerPool(t *testing.T) {
+	tmp := t.TempDir()
+	setupFrankenPHP(t,
+		frankenphp.WithWorkers("pool-worker", "testdata/bgworker/pool.php", 3,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerMaxThreads(3),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		frankenphp.WithNumThreads(6),
+	)
+
+	require.Eventually(t, func() bool {
+		entries, err := os.ReadDir(tmp)
+		return err == nil && len(entries) == 3
+	}, 5*time.Second, 25*time.Millisecond,
+		"expected 3 distinct pool sentinels under %s", tmp)
+}
+
+// TestBackgroundWorkerMultiEntrypoint declares two named bg workers that
+// share the same entrypoint file. Each gets its own *worker, so both Init
+// successfully (no filename-collision rejection) and both produce
+// sentinels.
+func TestBackgroundWorkerMultiEntrypoint(t *testing.T) {
+	tmp := t.TempDir()
+	setupFrankenPHP(t,
+		frankenphp.WithWorkers("shared-a", "testdata/bgworker/named.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		frankenphp.WithWorkers("shared-b", "testdata/bgworker/named.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp}),
+		),
+		frankenphp.WithNumThreads(5),
+	)
+
+	for _, name := range []string{"shared-a", "shared-b"} {
+		requireFileEventually(t, filepath.Join(tmp, name),
+			"shared bg worker %q did not touch its sentinel", name)
+	}
+}

--- a/bgworkerscope_test.go
+++ b/bgworkerscope_test.go
@@ -1,0 +1,133 @@
+package frankenphp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNextScopeIsDistinct verifies the scope counter
+// hands out unique values on consecutive calls.
+func TestNextScopeIsDistinct(t *testing.T) {
+	a := NextScope()
+	b := NextScope()
+	assert.NotEqual(t, a, b, "consecutive scopes must differ")
+	assert.NotZero(t, a, "scopes must be non-zero (zero is the global scope)")
+	assert.NotZero(t, b, "scopes must be non-zero (zero is the global scope)")
+}
+
+// TestBackgroundWorkerSameNameDifferentScope declares two named bg
+// workers with the same user-facing name in distinct scopes. Both must
+// Init successfully (the global workersByName collision check must
+// recognize bg workers as scope-isolated).
+func TestBackgroundWorkerSameNameDifferentScope(t *testing.T) {
+	scopeA := NextScope()
+	scopeB := NextScope()
+
+	tmp := t.TempDir()
+
+	setupBgWorker(t,
+		WithWorkers("shared", "testdata/bgworker/named.php", 1,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeA),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp + "/a"}),
+		),
+		WithWorkers("shared", "testdata/bgworker/named.php", 1,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeB),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp + "/b"}),
+		),
+		WithNumThreads(4),
+	)
+
+	// Both lookups must exist and resolve "shared" to a *worker.
+	require.NotNil(t, backgroundLookups[scopeA], "scope A lookup missing")
+	require.NotNil(t, backgroundLookups[scopeB], "scope B lookup missing")
+	assert.NotNil(t, backgroundLookups[scopeA].byName["shared"], "scope A must resolve 'shared'")
+	assert.NotNil(t, backgroundLookups[scopeB].byName["shared"], "scope B must resolve 'shared'")
+	// And they must be distinct *worker instances (not the same pointer).
+	assert.NotSame(t,
+		backgroundLookups[scopeA].byName["shared"],
+		backgroundLookups[scopeB].byName["shared"],
+		"each scope must own a distinct *worker for the same name")
+}
+
+// TestBackgroundWorkerCatchAllPerScope declares a catch-all in two
+// distinct scopes and verifies that ensure() in scope A consumes a slot
+// from scope A's catch-all only, leaving scope B's catch-all untouched.
+func TestBackgroundWorkerCatchAllPerScope(t *testing.T) {
+	scopeA := NextScope()
+	scopeB := NextScope()
+
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a")
+	dirB := filepath.Join(tmp, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0o755))
+	require.NoError(t, os.MkdirAll(dirB, 0o755))
+
+	setupBgWorker(t,
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeA),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirA}),
+		),
+		WithWorkers("", "testdata/bgworker/named.php", 0,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeB),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirB}),
+		),
+		WithNumThreads(4),
+	)
+
+	// Pre-conditions: each scope's catch-all is empty.
+	require.Empty(t, backgroundLookups[scopeA].catchAll.bg.catchAllNames, "scope A catch-all must start empty")
+	require.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must start empty")
+
+	// Drive ensure() through a fake "request" context tagged to scope A.
+	// We use a request-scope tag (rather than a worker handler) because
+	// no scope-specific handler is running in the test.
+	fc := newFrankenPHPContext()
+	fc.scope = scopeA
+	ctx := context.WithValue(context.Background(), contextKey, fc)
+	thread := &phpThread{}
+	thread.handler = &fakeContextThread{ctx: ctx}
+	require.NoError(t, ensureBackgroundWorker(thread, "job-a", 5*time.Second))
+
+	// The lazy-started instance must land in scope A's catch-all only.
+	require.Eventually(t, func() bool {
+		_, ok := backgroundLookups[scopeA].catchAll.bg.catchAllNames["job-a"]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "ensure() must populate scope A's catch-all")
+	assert.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must remain untouched")
+
+	// All catch-all threads attach to the scope's catch-all *worker, so
+	// scope A's catch-all should have one thread (for "job-a") while
+	// scope B's catch-all should have none.
+	assert.Equal(t, 1, backgroundLookups[scopeA].catchAll.countThreads(), "scope A catch-all must host exactly one thread")
+	assert.Equal(t, 0, backgroundLookups[scopeB].catchAll.countThreads(), "scope B catch-all must host zero threads")
+
+	// Wait for the worker to write its sentinel so we know the right
+	// fixture ran (sanity check that env was inherited from scope A).
+	requireSentinelEventually(t, filepath.Join(dirA, "job-a"),
+		"scope A catch-all instance must write its sentinel under scope A's BG_SENTINEL_DIR")
+}
+
+// fakeContextThread is a threadHandler stub that lets a test drive
+// ensureBackgroundWorker via the request-context fallback path in
+// getLookup, without spinning up a real PHP thread.
+type fakeContextThread struct {
+	ctx context.Context
+}
+
+func (h *fakeContextThread) name() string                          { return "fake" }
+func (h *fakeContextThread) beforeScriptExecution() string         { return "" }
+func (h *fakeContextThread) afterScriptExecution(int)              {}
+func (h *fakeContextThread) frankenPHPContext() *frankenPHPContext { return nil }
+func (h *fakeContextThread) drain()                                {}
+func (h *fakeContextThread) context() context.Context              { return h.ctx }
+func (h *fakeContextThread) scopedWorker() *worker                 { return nil }

--- a/bgworkerscope_test.go
+++ b/bgworkerscope_test.go
@@ -1,133 +1,37 @@
-package frankenphp
+package frankenphp_test
 
 import (
-	"context"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
+	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// TestNextScopeIsDistinct verifies the scope counter
-// hands out unique values on consecutive calls.
-func TestNextScopeIsDistinct(t *testing.T) {
-	a := NextScope()
-	b := NextScope()
-	assert.NotEqual(t, a, b, "consecutive scopes must differ")
-	assert.NotZero(t, a, "scopes must be non-zero (zero is the global scope)")
-	assert.NotZero(t, b, "scopes must be non-zero (zero is the global scope)")
-}
+// TestBackgroundWorkerScopeIsolation declares two bg workers with the
+// *same* name in two distinct scopes. Requests scoped to each block must
+// resolve to their own worker, proving per-php_server isolation works.
+func TestBackgroundWorkerScopeIsolation(t *testing.T) {
+	scopeA := frankenphp.NextScope()
+	scopeB := frankenphp.NextScope()
 
-// TestBackgroundWorkerSameNameDifferentScope declares two named bg
-// workers with the same user-facing name in distinct scopes. Both must
-// Init successfully (the global workersByName collision check must
-// recognize bg workers as scope-isolated).
-func TestBackgroundWorkerSameNameDifferentScope(t *testing.T) {
-	scopeA := NextScope()
-	scopeB := NextScope()
-
-	tmp := t.TempDir()
-
-	setupBgWorker(t,
-		WithWorkers("shared", "testdata/bgworker/named.php", 1,
-			WithWorkerBackground(),
-			WithWorkerScope(scopeA),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp + "/a"}),
-		),
-		WithWorkers("shared", "testdata/bgworker/named.php", 1,
-			WithWorkerBackground(),
-			WithWorkerScope(scopeB),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": tmp + "/b"}),
-		),
-		WithNumThreads(4),
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("shared", "testdata/bgworker/scope-a.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerScope(scopeA)),
+		frankenphp.WithWorkers("shared", "testdata/bgworker/scope-b.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerScope(scopeB)),
+		frankenphp.WithNumThreads(4),
 	)
 
-	// Both lookups must exist and resolve "shared" to a *worker.
-	require.NotNil(t, backgroundLookups[scopeA], "scope A lookup missing")
-	require.NotNil(t, backgroundLookups[scopeB], "scope B lookup missing")
-	assert.NotNil(t, backgroundLookups[scopeA].byName["shared"], "scope A must resolve 'shared'")
-	assert.NotNil(t, backgroundLookups[scopeB].byName["shared"], "scope B must resolve 'shared'")
-	// And they must be distinct *worker instances (not the same pointer).
-	assert.NotSame(t,
-		backgroundLookups[scopeA].byName["shared"],
-		backgroundLookups[scopeB].byName["shared"],
-		"each scope must own a distinct *worker for the same name")
+	// Each scope's worker publishes its own marker under the same name
+	// ("shared"). The reader script reads get_vars('shared'); scope
+	// selection on the request determines which worker is resolved.
+	bodyA := serveBody(t, testDataDir, "bgworker/scope-reader.php",
+		frankenphp.WithRequestScope(scopeA))
+	bodyB := serveBody(t, testDataDir, "bgworker/scope-reader.php",
+		frankenphp.WithRequestScope(scopeB))
+
+	assert.Contains(t, bodyA, "scope=A", "scopeA request should resolve to worker-scope-a:\n"+bodyA)
+	assert.Contains(t, bodyB, "scope=B", "scopeB request should resolve to worker-scope-b:\n"+bodyB)
 }
-
-// TestBackgroundWorkerCatchAllPerScope declares a catch-all in two
-// distinct scopes and verifies that ensure() in scope A consumes a slot
-// from scope A's catch-all only, leaving scope B's catch-all untouched.
-func TestBackgroundWorkerCatchAllPerScope(t *testing.T) {
-	scopeA := NextScope()
-	scopeB := NextScope()
-
-	tmp := t.TempDir()
-	dirA := filepath.Join(tmp, "a")
-	dirB := filepath.Join(tmp, "b")
-	require.NoError(t, os.MkdirAll(dirA, 0o755))
-	require.NoError(t, os.MkdirAll(dirB, 0o755))
-
-	setupBgWorker(t,
-		WithWorkers("", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-			WithWorkerScope(scopeA),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirA}),
-		),
-		WithWorkers("", "testdata/bgworker/named.php", 0,
-			WithWorkerBackground(),
-			WithWorkerScope(scopeB),
-			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirB}),
-		),
-		WithNumThreads(4),
-	)
-
-	// Pre-conditions: each scope's catch-all is empty.
-	require.Empty(t, backgroundLookups[scopeA].catchAll.bg.catchAllNames, "scope A catch-all must start empty")
-	require.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must start empty")
-
-	// Drive ensure() through a fake "request" context tagged to scope A.
-	// We use a request-scope tag (rather than a worker handler) because
-	// no scope-specific handler is running in the test.
-	fc := newFrankenPHPContext()
-	fc.scope = scopeA
-	ctx := context.WithValue(context.Background(), contextKey, fc)
-	thread := &phpThread{}
-	thread.handler = &fakeContextThread{ctx: ctx}
-	require.NoError(t, ensureBackgroundWorker(thread, "job-a", 5*time.Second))
-
-	// The lazy-started instance must land in scope A's catch-all only.
-	require.Eventually(t, func() bool {
-		_, ok := backgroundLookups[scopeA].catchAll.bg.catchAllNames["job-a"]
-		return ok
-	}, 2*time.Second, 10*time.Millisecond, "ensure() must populate scope A's catch-all")
-	assert.Empty(t, backgroundLookups[scopeB].catchAll.bg.catchAllNames, "scope B catch-all must remain untouched")
-
-	// All catch-all threads attach to the scope's catch-all *worker, so
-	// scope A's catch-all should have one thread (for "job-a") while
-	// scope B's catch-all should have none.
-	assert.Equal(t, 1, backgroundLookups[scopeA].catchAll.countThreads(), "scope A catch-all must host exactly one thread")
-	assert.Equal(t, 0, backgroundLookups[scopeB].catchAll.countThreads(), "scope B catch-all must host zero threads")
-
-	// Wait for the worker to write its sentinel so we know the right
-	// fixture ran (sanity check that env was inherited from scope A).
-	requireSentinelEventually(t, filepath.Join(dirA, "job-a"),
-		"scope A catch-all instance must write its sentinel under scope A's BG_SENTINEL_DIR")
-}
-
-// fakeContextThread is a threadHandler stub that lets a test drive
-// ensureBackgroundWorker via the request-context fallback path in
-// getLookup, without spinning up a real PHP thread.
-type fakeContextThread struct {
-	ctx context.Context
-}
-
-func (h *fakeContextThread) name() string                          { return "fake" }
-func (h *fakeContextThread) beforeScriptExecution() string         { return "" }
-func (h *fakeContextThread) afterScriptExecution(int)              {}
-func (h *fakeContextThread) frankenPHPContext() *frankenPHPContext { return nil }
-func (h *fakeContextThread) drain()                                {}
-func (h *fakeContextThread) context() context.Context              { return h.ctx }
-func (h *fakeContextThread) scopedWorker() *worker                 { return nil }

--- a/caddy/app.go
+++ b/caddy/app.go
@@ -1,7 +1,6 @@
 package caddy
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -62,17 +61,24 @@ type FrankenPHPApp struct {
 
 	opts    []frankenphp.Option
 	metrics frankenphp.Metrics
-	ctx     context.Context
+	ctx     caddy.Context
 	logger  *slog.Logger
+
+	// scopeOwners is the per-php_server module registry used by Start
+	// to resolve a human-readable scope label (via the cascade in
+	// scopelabel.go) before frankenphp.Init starts any bg worker, so
+	// the very first metric call already carries the right prefix.
+	scopeOwnersMu sync.Mutex
+	scopeOwners   map[frankenphp.Scope]*FrankenPHPModule
 }
 
 var iniError = errors.New(`"php_ini" must be in the format: php_ini "<key>" "<value>"`)
 
 // CaddyModule returns the Caddy module information.
-func (f FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
+func (*FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "frankenphp",
-		New: func() caddy.Module { return &f },
+		New: func() caddy.Module { return new(FrankenPHPApp) },
 	}
 }
 
@@ -139,12 +145,49 @@ func (f *FrankenPHPApp) addModuleWorkers(workers ...workerConfig) ([]workerConfi
 	return workers, nil
 }
 
+// registerScopeOwner records the FrankenPHPModule that allocated the
+// given scope so Start() can resolve its label before frankenphp.Init.
+func (f *FrankenPHPApp) registerScopeOwner(scope frankenphp.Scope, mod *FrankenPHPModule) {
+	f.scopeOwnersMu.Lock()
+	defer f.scopeOwnersMu.Unlock()
+	if f.scopeOwners == nil {
+		f.scopeOwners = make(map[frankenphp.Scope]*FrankenPHPModule)
+	}
+	f.scopeOwners[scope] = mod
+}
+
+// resolveScopeLabels walks the http app's servers once per registered
+// module, picks the one whose route tree contains the module, runs the
+// scopelabel.go cascade, and stores the result via SetScopeLabel. Runs
+// before frankenphp.Init so the first metric emit on every bg worker
+// already carries the right "m#<label>:<name>" prefix.
+func (f *FrankenPHPApp) resolveScopeLabels() {
+	if len(f.scopeOwners) == 0 {
+		return
+	}
+	httpApp, err := f.ctx.AppIfConfigured("http")
+	if err != nil || httpApp == nil {
+		return
+	}
+	servers := httpApp.(*caddyhttp.App).Servers
+	for scope, mod := range f.scopeOwners {
+		for _, srv := range servers {
+			if label := mod.resolveScopeLabel(srv); label != "" {
+				frankenphp.SetScopeLabel(scope, label)
+				break
+			}
+		}
+	}
+}
+
 func (f *FrankenPHPApp) Start() error {
 	repl := caddy.NewReplacer()
 
 	optionsMU.RLock()
 	f.opts = append(f.opts, options...)
 	optionsMU.RUnlock()
+
+	f.resolveScopeLabels()
 
 	f.opts = append(f.opts,
 		frankenphp.WithContext(f.ctx),
@@ -166,6 +209,10 @@ func (f *FrankenPHPApp) Start() error {
 			frankenphp.WithWorkerMaxThreads(w.MaxThreads),
 			frankenphp.WithWorkerRequestOptions(w.requestOptions...),
 		)
+
+		if w.Background {
+			w.options = append(w.options, frankenphp.WithWorkerBackground())
+		}
 
 		f.opts = append(f.opts, frankenphp.WithWorkers(w.Name, repl.ReplaceKnown(w.FileName, ""), w.Num, w.options...))
 	}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -16,7 +16,7 @@ const (
 )
 
 func init() {
-	caddy.RegisterModule(FrankenPHPApp{})
+	caddy.RegisterModule(new(FrankenPHPApp))
 	caddy.RegisterModule(FrankenPHPModule{})
 	caddy.RegisterModule(FrankenPHPAdmin{})
 

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -3,6 +3,7 @@ package caddy_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -70,6 +71,57 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+// TestBackgroundWorker wires a named background worker through the
+// Caddyfile `worker { background; name ...; file ... }` syntax and reads
+// its vars from an HTTP request, proving the parser + app.Start wiring +
+// PHP API all cooperate.
+func TestBackgroundWorker(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	initServer(t, tester, `
+		{
+			skip_install_trust
+			admin localhost:2999
+			http_port `+testPort+`
+			https_port 9443
+			frankenphp {
+				worker {
+					name bg-basic
+					num 1
+					file ../testdata/bgworker/basic.php
+					background
+				}
+			}
+		}
+
+		localhost:`+testPort+` {
+			route {
+				php {
+					root ../testdata
+				}
+			}
+		}
+		`, "caddyfile")
+
+	// Background workers boot asynchronously with Init. Poll briefly for a
+	// non-MISSING response so we don't race against the first set_vars.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		resp, err := http.Get("http://localhost:" + testPort + "/bgworker/reader.php")
+		require.NoError(t, err)
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if !strings.Contains(string(body), "MISSING") {
+			require.Contains(t, string(body), "message=hello from background worker")
+			require.Contains(t, string(body), "count=42")
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background worker never published vars; last body: %q", body)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func TestPHP(t *testing.T) {

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -51,6 +51,7 @@ type FrankenPHPModule struct {
 	preparedEnvNeedsReplacement bool
 	logger                      *slog.Logger
 	requestOptions              []frankenphp.RequestOption
+	scope                       frankenphp.Scope
 }
 
 // CaddyModule returns the Caddy module information.
@@ -78,6 +79,14 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 
 	f.assignMercureHub(ctx)
 
+	// Each php_server block gets its own scope so workers declared with
+	// the same name in different blocks don't collide. Provision can be
+	// called more than once for the same module; only assign once.
+	if f.scope == 0 {
+		f.scope = frankenphp.NextScope()
+	}
+	fapp.registerScopeOwner(f.scope, f)
+
 	loggerOpt := frankenphp.WithRequestLogger(f.logger)
 	for i, wc := range f.Workers {
 		// make the file path absolute from the public directory
@@ -92,6 +101,7 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 		}
 
 		wc.requestOptions = append(wc.requestOptions, loggerOpt)
+		wc.options = append(wc.options, frankenphp.WithWorkerScope(f.scope))
 		f.Workers[i] = wc
 	}
 
@@ -241,6 +251,7 @@ func (f *FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 			opts,
 			frankenphp.WithOriginalRequest(new(ctx.Value(caddyhttp.OriginalRequestCtxKey).(http.Request))),
 			frankenphp.WithWorkerName(workerName),
+			frankenphp.WithRequestScope(f.scope),
 		)...,
 	)
 

--- a/caddy/scopelabel.go
+++ b/caddy/scopelabel.go
@@ -1,0 +1,59 @@
+package caddy
+
+import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// resolveScopeLabel picks a stable, human-friendly identifier for this
+// module's background-worker scope so metric/log emitters can render it
+// (e.g. server="api.example.com") instead of the opaque numeric id.
+// Cascade:
+//  1. First host of the route's host matcher.
+//  2. First listener address of the server.
+func (f *FrankenPHPModule) resolveScopeLabel(srv *caddyhttp.Server) string {
+	if h := findHostInRoutes(srv.Routes, f); h != "" {
+		return h
+	}
+	if len(srv.Listen) > 0 {
+		return srv.Listen[0]
+	}
+	return ""
+}
+
+// findHostInRoutes walks routes (recursing into Subroute handlers) to
+// locate the route that contains target, then returns the first host of
+// that route's host matcher. Returns "" if no enclosing route or no host
+// matcher is found.
+func findHostInRoutes(routes caddyhttp.RouteList, target caddyhttp.MiddlewareHandler) string {
+	for _, route := range routes {
+		if !routeContainsHandler(route, target) {
+			continue
+		}
+		for _, mset := range route.MatcherSets {
+			for _, m := range mset {
+				hp, ok := m.(*caddyhttp.MatchHost)
+				if !ok || hp == nil || len(*hp) == 0 {
+					continue
+				}
+				return (*hp)[0]
+			}
+		}
+	}
+	return ""
+}
+
+func routeContainsHandler(route caddyhttp.Route, target caddyhttp.MiddlewareHandler) bool {
+	for _, h := range route.Handlers {
+		if h == target {
+			return true
+		}
+		if sub, ok := h.(*caddyhttp.Subroute); ok {
+			for _, r := range sub.Routes {
+				if routeContainsHandler(r, target) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/caddy/workerconfig.go
+++ b/caddy/workerconfig.go
@@ -41,6 +41,8 @@ type workerConfig struct {
 	MatchPath []string `json:"match_path,omitempty"`
 	// MaxConsecutiveFailures sets the maximum number of consecutive failures before panicking (defaults to 6, set to -1 to never panick)
 	MaxConsecutiveFailures int `json:"max_consecutive_failures,omitempty"`
+	// Background marks this worker as a background (non-HTTP) worker.
+	Background bool `json:"background,omitempty"`
 
 	options        []frankenphp.WorkerOption
 	requestOptions []frankenphp.RequestOption
@@ -145,13 +147,25 @@ func unmarshalWorker(d *caddyfile.Dispenser) (workerConfig, error) {
 			}
 
 			wc.MaxConsecutiveFailures = v
+		case "background":
+			wc.Background = true
 		default:
-			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads", v)
+			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads, background", v)
 		}
 	}
 
 	if wc.FileName == "" {
 		return wc, d.Err(`the "file" argument must be specified`)
+	}
+
+	if wc.Background {
+		// Named bg workers: num is the pool size; max_threads currently has
+		// no effect (no auto-scaling for bg workers in this build). Catch-all
+		// bg workers: num is unused at the declaration level, max_threads
+		// caps how many distinct names can be lazy-started via ensure().
+		if len(wc.MatchPath) != 0 {
+			return wc, d.Err(`"match" is not supported for background workers`)
+		}
 	}
 
 	if frankenphp.EmbeddedAppPath != "" && filepath.IsLocal(wc.FileName) {

--- a/cgi.go
+++ b/cgi.go
@@ -44,7 +44,7 @@ var cStringHTTPMethods = map[string]*C.char{
 //
 // TODO: handle this case https://github.com/caddyserver/caddy/issues/3718
 // Inspired by https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
-func addKnownVariablesToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
+func addKnownVariablesToServer(thread *phpThread, fc *frankenPHPContext, trackVarsArray *C.zval) {
 	request := fc.request
 	// Separate remote IP and port; more lenient than net.SplitHostPort
 	var ip, port string
@@ -113,6 +113,21 @@ func addKnownVariablesToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
 
 	phpSelf := fc.scriptName + fc.pathInfo
 
+	// Worker identity for $_SERVER. Bg-worker threads override fc.worker
+	// because catch-all threads share the catch-all template *worker
+	// (whose name is the entrypoint path); the per-thread runtimeName is
+	// the actual ensure() argument. m# is stripped so PHP sees the user-
+	// facing name regardless of how the worker was registered.
+	var workerName string
+	var isBackgroundWorker bool
+	if bgHandler, ok := thread.handler.(*backgroundWorkerThread); ok {
+		workerName = strings.TrimPrefix(bgHandler.runtimeName, "m#")
+		isBackgroundWorker = true
+	} else if fc.worker != nil {
+		workerName = strings.TrimPrefix(fc.worker.name, "m#")
+		isBackgroundWorker = fc.worker.bg != nil
+	}
+
 	C.frankenphp_register_server_vars(trackVarsArray, C.frankenphp_server_vars{
 		// approximate total length to avoid array re-hashing:
 		// 28 CGI vars + headers + environment
@@ -156,6 +171,11 @@ func addKnownVariablesToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
 		request_scheme: rs,          // "http" or "https"
 		ssl_protocol:   sslProtocol, // values from tlsProtocol
 		https:          https,       // "on" or empty
+
+		// Worker identity (empty for non-worker requests)
+		worker_name:          toUnsafeChar(workerName),
+		worker_name_len:      C.size_t(len(workerName)),
+		is_background_worker: C._Bool(isBackgroundWorker),
 	})
 }
 
@@ -188,7 +208,7 @@ func go_register_server_variables(threadIndex C.uintptr_t, trackVarsArray *C.zva
 	fc := thread.frankenPHPContext()
 
 	if fc.request != nil {
-		addKnownVariablesToServer(fc, trackVarsArray)
+		addKnownVariablesToServer(thread, fc, trackVarsArray)
 		addHeadersToServer(thread.context(), fc.request, trackVarsArray)
 	}
 

--- a/context.go
+++ b/context.go
@@ -38,6 +38,10 @@ type frankenPHPContext struct {
 	handlerParameters  any
 	handlerReturn      any
 
+	// scope selects the per-php_server isolation boundary used by ensure()
+	// calls made from this request. Zero is the global scope.
+	scope Scope
+
 	done      chan any
 	startedAt time.Time
 }

--- a/context.go
+++ b/context.go
@@ -39,7 +39,7 @@ type frankenPHPContext struct {
 	handlerReturn      any
 
 	// scope selects the per-php_server isolation boundary used by ensure()
-	// calls made from this request. Zero is the global scope.
+	// / get_vars calls made from this request. Zero is the global scope.
 	scope Scope
 
 	done      chan any

--- a/docs/background-workers.md
+++ b/docs/background-workers.md
@@ -1,0 +1,269 @@
+# Background Workers
+
+Background workers are long-running PHP scripts that run outside the HTTP request cycle.
+They observe their environment and publish variables that HTTP threads (both [workers](worker.md) and classic requests) can read in real time.
+
+## How It Works
+
+1. A background worker runs its own event loop (subscribe to Redis, watch files, poll an API, etc.).
+2. It calls `frankenphp_set_vars()` to publish a snapshot of key-value pairs.
+3. HTTP threads call `frankenphp_ensure_background_worker()` to declare a dependency and make sure the worker is running (lazy-started if needed, blocks until it has published at least once).
+4. HTTP threads then call `frankenphp_get_vars()` to read the latest snapshot (pure read, no blocking, identical zval across repeated reads in one request).
+
+## Configuration
+
+Add `worker` directives with `background` to your [`php_server` or `php` block](config.md#caddyfile-config):
+
+```caddyfile
+example.com {
+    php_server {
+        # Named background workers
+        worker /app/bin/console {
+            background
+            name config-watcher
+        }
+        worker /app/bin/console {
+            background
+            name feature-flags
+        }
+
+        # Catch-all: handles any unlisted name via ensure_background_worker()
+        worker /app/bin/console {
+            background
+        }
+    }
+}
+```
+
+- **Named** (with `name`): lazy-started on first `ensure_background_worker()` call. If `num` is set to a positive integer, that many threads start eagerly at boot (pool mode); with `num 0` (default) the first `ensure()` starts one thread.
+- **Catch-all** (no `name`): lazy-started on demand for any name not matched by a `name` directive. `max_threads` caps the number of distinct names it can lazy-start (default 16). Without a catch-all, only declared names can be ensured.
+- Each `php_server` block has its own isolated scope: two blocks can use the same worker names without conflict.
+- `max_consecutive_failures`, `env`, and `watch` work the same as for HTTP workers.
+
+## PHP API
+
+### `frankenphp_ensure_background_worker(string|array $name, ?float $timeout = null): void`
+
+Declares a dependency on one or more background workers. Pass a single name or an array of names for batch dependency declaration; the timeout applies across all names in one call. `null` (the default) falls back to FrankenPHP's internal default deadline; a value `<= 0` raises `ValueError`. Behaviour depends on the caller context:
+
+- **In an HTTP worker script, before `frankenphp_handle_request()` (bootstrap)**: lazy-starts the worker (at-most-once) if not already running and blocks until it has called `set_vars()` at least once. Fails fast on boot failure (no exponential-backoff tolerance): if the first boot attempts fail, the exception is thrown right away with the captured details. Use this to declare dependencies up front so broken deps visibly fail the HTTP worker rather than let it serve degraded traffic.
+- **Everywhere else (inside `frankenphp_handle_request()`, or classic request-per-process)**: lazy-starts the worker and waits up to `$timeout`, tolerating transient boot failures via exponential backoff. The first caller pays the startup cost; subsequent callers in the same FrankenPHP process see the worker already reserved and return almost immediately. This supports the common pattern of library code loaded after bootstrap declaring its own dependencies lazily.
+
+```php
+// HTTP worker, bootstrap phase
+frankenphp_ensure_background_worker('redis-watcher'); // fail-fast
+
+while (frankenphp_handle_request(function () {
+    $cfg = frankenphp_get_vars('redis-watcher'); // pure read
+})) { gc_collect_cycles(); }
+
+// Non-worker mode, every request
+frankenphp_ensure_background_worker('redis-watcher'); // tolerant
+$cfg = frankenphp_get_vars('redis-watcher');
+
+// Batch form, shared deadline across workers
+frankenphp_ensure_background_worker(['redis-watcher', 'config-watcher'], 5.0);
+```
+
+- Throws `RuntimeException` on timeout, missing entrypoint, or boot failure. The exception contains the captured failure details when available: resolved entrypoint path, exit status, number of attempts, and the last PHP error (message, file, line).
+- Pick a short `$timeout` (e.g. `1.0`) to fail fast; pick a longer one to tolerate slow/flaky startups.
+- `ValueError` is raised for an empty names array; `TypeError` is raised if the array contains non-strings.
+
+### `frankenphp_get_vars(string $name): array`
+
+Pure read: returns the latest published vars from a running background worker. Does not start workers or wait for readiness.
+
+```php
+$redis = frankenphp_get_vars('redis-watcher');
+// ['MASTER_HOST' => '10.0.0.1', 'MASTER_PORT' => 6379]
+```
+
+- Throws `RuntimeException` if the worker isn't running or hasn't called `set_vars()` yet. Call `frankenphp_ensure_background_worker()` first to ensure readiness.
+- Within a single HTTP request, repeated calls with the same name return the **same** cached array: `$a === $b` holds, and the lookup is O(1) after the first call.
+- Works in both worker and non-worker mode.
+
+### `frankenphp_set_vars(array $vars): void`
+
+Publishes vars from inside a background worker. Each call **replaces** the entire vars array atomically.
+
+Allowed value types: `null`, scalars (`bool`, `int`, `float`, `string`), nested `array`s whose values are also allowed types, and **enum** instances. Objects (other than enum cases), resources, and references are rejected.
+
+- Throws `RuntimeException` if not called from a background worker thread.
+- Throws `ValueError` if values contain unsupported types.
+
+### `frankenphp_get_worker_handle(): resource`
+
+Returns a readable stream for receiving signals from FrankenPHP. On shutdown or restart the write end of the underlying pipe is closed, so `fgets()` returns `false` (EOF). Use `stream_select()` to wait between iterations instead of `sleep()`:
+
+```php
+function background_worker_should_stop(float $timeout = 0): bool
+{
+    static $stream;
+    $stream ??= frankenphp_get_worker_handle();
+    $s = (int) $timeout;
+
+    return match (@stream_select(...[[$stream], [], [], $s, (int) (($timeout - $s) * 1e6)])) {
+        0 => false,           // timeout, keep going
+        false => true,        // error, stop
+        default => false === fgets($stream), // EOF = stop
+    };
+}
+```
+
+> [!WARNING]
+> Avoid `sleep()` or `usleep()` in background workers: they block at the C level and cannot be interrupted cleanly. Use `stream_select()` with the signaling stream instead. If a worker ignores the signal, FrankenPHP force-kills it on Linux, FreeBSD and Windows after a 30-second grace period (see `Runtime Behaviour`).
+
+## Examples
+
+### Simple polling worker
+
+```php
+<?php
+// bin/console dispatches based on worker name
+
+$command = $_SERVER['FRANKENPHP_WORKER'] ?? '';
+
+match ($command) {
+    'config-watcher' => run_config_watcher(),
+    'feature-flags'  => run_feature_flags(),
+    default          => throw new \RuntimeException("Unknown background worker: $command"),
+};
+
+function run_config_watcher(): void
+{
+    $redis = new Redis();
+    $redis->pconnect('127.0.0.1');
+
+    do {
+        frankenphp_set_vars([
+            'maintenance'   => (bool) $redis->get('maintenance_mode'),
+            'feature_flags' => json_decode($redis->get('features'), true),
+        ]);
+    } while (!background_worker_should_stop(5.0)); // check every 5s
+}
+```
+
+### Event-driven worker
+
+For real-time subscriptions (Redis pub/sub, SSE, WebSocket), use an async library and register the signaling stream on the event loop:
+
+```php
+function run_redis_watcher(): void
+{
+    $signalingStream = frankenphp_get_worker_handle();
+    $sentinel = Amp\Redis\createRedisClient('tcp://sentinel-host:26379');
+
+    $subscription = $sentinel->subscribe('+switch-master');
+
+    Amp\async(function () use ($subscription) {
+        foreach ($subscription as $message) {
+            [$name, $oldIp, $oldPort, $newIp, $newPort] = explode(' ', $message);
+            frankenphp_set_vars([
+                'MASTER_HOST' => $newIp,
+                'MASTER_PORT' => (int) $newPort,
+            ]);
+        }
+    });
+
+    $master = $sentinel->rawCommand('SENTINEL', 'get-master-addr-by-name', 'mymaster');
+    frankenphp_set_vars([
+        'MASTER_HOST' => $master[0],
+        'MASTER_PORT' => (int) $master[1],
+    ]);
+
+    Amp\EventLoop::onReadable($signalingStream, function ($id) use ($signalingStream) {
+        if (false === fgets($signalingStream)) {
+            Amp\EventLoop::cancel($id); // EOF = stop
+        }
+    });
+    Amp\EventLoop::run();
+}
+```
+
+### HTTP worker depending on a background worker
+
+```php
+<?php
+// public/index.php
+
+$app = new App();
+$app->boot();
+
+// Declare dependencies once at bootstrap (fail-fast)
+frankenphp_ensure_background_worker(['config-watcher', 'feature-flags']);
+
+while (frankenphp_handle_request(function () use ($app) {
+    $config = frankenphp_get_vars('config-watcher'); // pure read
+
+    $_SERVER += [
+        'APP_REDIS_HOST' => $config['MASTER_HOST'],
+        'APP_REDIS_PORT' => $config['MASTER_PORT'],
+    ];
+    $app->handle($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);
+})) {
+    gc_collect_cycles();
+}
+```
+
+### Non-worker mode
+
+```php
+<?php
+// public/index.php, classic request-per-process
+
+frankenphp_ensure_background_worker('config-watcher');
+$config = frankenphp_get_vars('config-watcher');
+// ... handle the request
+```
+
+### Graceful degradation in CLI mode
+
+Running scripts with `frankenphp php-cli ...` does not load the `frankenphp` PHP module, so the background-worker functions do not exist. `function_exists()` returns `false` and library code can fall back to alternative sources:
+
+```php
+if (function_exists('frankenphp_get_vars')) {
+    frankenphp_ensure_background_worker('config-watcher');
+    $config = frankenphp_get_vars('config-watcher');
+} else {
+    $config = ['MASTER_HOST' => getenv('REDIS_HOST') ?: '127.0.0.1'];
+}
+```
+
+## Runtime Behaviour
+
+- Background workers get dedicated threads: they do not reduce HTTP capacity.
+- `max_execution_time` is automatically disabled for background workers.
+- `$_SERVER['FRANKENPHP_WORKER']` carries the worker's declared (or catch-all-resolved) name. Pre-existing user code that only checks `isset($_SERVER['FRANKENPHP_WORKER'])` keeps working.
+- `$_SERVER['FRANKENPHP_WORKER_BACKGROUND']` is `true` for background workers.
+- `$_SERVER['argv'] = [$entrypoint, $name]` in background workers (for `bin/console`-style dispatching).
+- Crash recovery: workers are automatically restarted with exponential backoff. During the restart window, `get_vars()` returns the last published data (stale but available) because vars are held in persistent memory across crashes. A warning is logged on crash.
+- On shutdown/restart the signaling stream is closed (EOF). Well-behaved workers that check the stream exit within the 30-second grace period. Stuck workers are force-killed on Linux, FreeBSD, and Windows.
+
+## Readiness
+
+`ensure()` blocks until the worker has reached its main loop, which means **both**:
+
+1. The worker called `frankenphp_get_worker_handle()` (it has installed its drain signal and is parked in `stream_select`).
+2. The worker called `frankenphp_set_vars()` at least once (it has published its initial state).
+
+Both halves are needed: a worker that registers the handle but never publishes vars hasn't actually finished bootstrapping, and a worker that publishes vars without holding the handle can't be drained gracefully. Each instance carries one combined-ready channel that closes exactly once when both halves have fired; `ensure()` waits on it (alongside an abort channel for `max_consecutive_failures` exhaustion and the per-call deadline).
+
+Readiness is sticky across crash-restarts: once a worker has announced "ready" once, the channel stays closed for any future `ensure()` caller, even after the script crashes and respawns. This is the right semantics for a long-lived dependency — callers don't pay the startup cost again if the worker is just briefly missing.
+
+If the worker crashes before reaching readiness, the boot-failure metadata (entrypoint, exit status, attempt count, and the captured `last_error_message`) is recorded on the readiness slot, so a timing-out `ensure()` raises a self-teaching `RuntimeException` with those details rather than a generic "did not call `frankenphp_get_worker_handle()` and `frankenphp_set_vars()` within Xs".
+
+For catch-all workers, each lazy-spawned name has its own readiness slot, so a stuck `foo` doesn't keep `ensure('bar')` waiting. For named pools (`num > 1`), the threads share one slot and the first to satisfy both halves wins.
+
+## Scoping
+
+Each `php_server` block gets its own isolated background-worker scope, so workers declared with the same `name` in different blocks do not collide. Resolution rules for `ensure()` / `get_vars()`:
+
+- A request inside a `php_server` block resolves first against that block's own declarations. If the block declares any background workers of its own, that lookup is authoritative and scope-isolated from every other block.
+- A request inside a `php_server` block that declares **no** background workers falls back to the global/embed scope (workers declared at the top-level `frankenphp` directive or via the Go library). This makes a single globally-declared worker reachable from all otherwise-unconfigured blocks.
+- Requests made outside any `php_server` block (e.g. when embedding FrankenPHP as a library) always resolve to the global/embed scope.
+
+## Limits
+
+- Named background workers with `num > 1` spin up a pool of threads that share the same published vars; `get_vars()` sees one consistent snapshot.
+- Multiple named background workers in the same block can share the same entrypoint file. Each declaration keeps its own `env`, `watch`, and failure policy.
+- Calling `ensure()` on a name that isn't declared and isn't covered by a catch-all raises `RuntimeException`.

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -38,12 +38,7 @@
 
 #include "_cgo_export.h"
 #include "frankenphp_arginfo.h"
-#ifdef FRANKENPHP_TEST
-/* The persistent_zval helpers are only compiled in when a consumer needs
- * them. The step that lands the first real caller (background workers)
- * will drop this guard. */
 #include "zval.h"
-#endif
 
 #if defined(PHP_WIN32) && defined(ZTS)
 ZEND_TSRMLS_CACHE_DEFINE()
@@ -95,6 +90,7 @@ __thread bool is_worker_thread = false;
 __thread bool is_background_worker = false;
 __thread int worker_stop_fds[2] = {-1, -1};
 __thread php_stream *worker_signaling_stream = NULL;
+__thread char *captured_last_php_error = NULL;
 __thread HashTable *sandboxed_env = NULL;
 
 #ifndef PHP_WIN32
@@ -297,6 +293,45 @@ static int frankenphp_worker_dup_fd(int fd) {
 #else
   return dup(fd);
 #endif
+}
+
+void frankenphp_copy_persistent_vars(zval *dst, void *persistent_ht) {
+  zval src;
+  ZVAL_ARR(&src, (HashTable *)persistent_ht);
+  persistent_zval_to_request(dst, &src);
+}
+
+/* Capture PG(last_error_*) into the thread-local captured_last_php_error.
+ * Called before php_request_shutdown, which clears PG(last_error_*).
+ * Format: "<message> in <file> on line <line>". */
+static void frankenphp_capture_last_php_error(void) {
+  if (captured_last_php_error != NULL) {
+    free(captured_last_php_error);
+    captured_last_php_error = NULL;
+  }
+  if (PG(last_error_message) == NULL) {
+    return;
+  }
+  const char *msg = ZSTR_VAL(PG(last_error_message));
+  size_t msg_len = ZSTR_LEN(PG(last_error_message));
+  const char *file =
+      PG(last_error_file) ? ZSTR_VAL(PG(last_error_file)) : "unknown";
+  size_t file_len = PG(last_error_file) ? ZSTR_LEN(PG(last_error_file)) : 7;
+  int line = PG(last_error_lineno);
+  size_t buf_len = msg_len + file_len + 32;
+  captured_last_php_error = malloc(buf_len);
+  if (captured_last_php_error != NULL) {
+    snprintf(captured_last_php_error, buf_len, "%.*s in %.*s on line %d",
+             (int)msg_len, msg, (int)file_len, file, line);
+  }
+}
+
+/* Return and take ownership of the captured error; caller frees with
+ * C.free. NULL if nothing was captured. */
+char *frankenphp_get_last_php_error(void) {
+  char *s = captured_last_php_error;
+  captured_last_php_error = NULL;
+  return s;
 }
 
 static void frankenphp_update_request_context() {
@@ -912,6 +947,61 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+PHP_FUNCTION(frankenphp_set_vars) {
+  zval *vars = NULL;
+
+  ZEND_PARSE_PARAMETERS_START(1, 1);
+  Z_PARAM_ARRAY(vars);
+  ZEND_PARSE_PARAMETERS_END();
+
+  /* Validate every value up front so allocation only happens for a tree
+   * we can fully round-trip. */
+  zval *val;
+  ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(vars), val) {
+    if (!persistent_zval_validate(val)) {
+      zend_value_error(
+          "frankenphp_set_vars(): values must be null, scalars, arrays, or "
+          "enums; objects (other than enums) and resources are not allowed");
+      RETURN_THROWS();
+    }
+  }
+  ZEND_HASH_FOREACH_END();
+
+  zval persistent;
+  persistent_zval_persist(&persistent, vars);
+
+  void *old = NULL;
+  char *error =
+      go_frankenphp_set_vars(thread_index, Z_ARRVAL(persistent), &old);
+  if (error) {
+    persistent_zval_free(&persistent);
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
+  if (old != NULL) {
+    zval old_zv;
+    ZVAL_ARR(&old_zv, (HashTable *)old);
+    persistent_zval_free(&old_zv);
+  }
+}
+
+PHP_FUNCTION(frankenphp_get_vars) {
+  zend_string *name = NULL;
+
+  ZEND_PARSE_PARAMETERS_START(1, 1);
+  Z_PARAM_STR(name);
+  ZEND_PARSE_PARAMETERS_END();
+
+  char *error = go_frankenphp_get_vars(thread_index, (char *)ZSTR_VAL(name),
+                                       ZSTR_LEN(name), return_value);
+  if (error) {
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
+}
+
 PHP_FUNCTION(frankenphp_ensure_background_worker) {
   zval *names_zv;
   double timeout = 0.0;
@@ -1097,53 +1187,10 @@ PHP_FUNCTION(frankenphp_get_worker_handle) {
   go_frankenphp_worker_ready(thread_index);
 }
 
-#ifdef FRANKENPHP_TEST
-/* Test-only entry point that exercises zval.h end-to-end:
- * validate -> persist (request -> persistent memory) ->
- * to_request (persistent -> fresh request memory) -> free persistent copy.
- * Compiled only when FRANKENPHP_TEST is defined; never registered
- * in production builds. */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(
-    arginfo_frankenphp_test_persist_roundtrip, 0, 1, IS_MIXED, 0)
-ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
-ZEND_END_ARG_INFO()
-
-PHP_FUNCTION(frankenphp_test_persist_roundtrip) {
-  zval *input;
-  ZEND_PARSE_PARAMETERS_START(1, 1)
-  Z_PARAM_ZVAL(input)
-  ZEND_PARSE_PARAMETERS_END();
-
-  if (!persistent_zval_validate(input)) {
-    zend_throw_exception(spl_ce_LogicException,
-                         "persistent_zval: value type not supported "
-                         "(only scalars, arrays, and enums are allowed)",
-                         0);
-    RETURN_THROWS();
-  }
-
-  zval persistent;
-  persistent_zval_persist(&persistent, input);
-  persistent_zval_to_request(return_value, &persistent);
-  persistent_zval_free(&persistent);
-}
-
-static const zend_function_entry frankenphp_test_hook_functions[] = {
-    PHP_FE(frankenphp_test_persist_roundtrip,
-           arginfo_frankenphp_test_persist_roundtrip) PHP_FE_END};
-#endif
-
 PHP_MINIT_FUNCTION(frankenphp) {
   register_frankenphp_symbols(module_number);
 #ifndef PHP_WIN32
   pthread_atfork(NULL, NULL, frankenphp_fork_child);
-#endif
-
-#ifdef FRANKENPHP_TEST
-  if (zend_register_functions(NULL, frankenphp_test_hook_functions, NULL,
-                              MODULE_PERSISTENT) == FAILURE) {
-    return FAILURE;
-  }
 #endif
 
   zend_function *func;
@@ -1324,6 +1371,25 @@ void frankenphp_register_server_vars(zval *track_vars_array,
     ZVAL_TRUE(&bg_zv);
     zend_hash_str_update(ht, "FRANKENPHP_WORKER_BACKGROUND",
                          sizeof("FRANKENPHP_WORKER_BACKGROUND") - 1, &bg_zv);
+
+    /* Bg workers have no real CLI argv; emulate one of the form
+     * [script_filename, worker_name] so user code can read the worker
+     * name via $argv[1] like a CLI script. Skipped when worker_name is
+     * empty (declared catch-all template threads with no identity). */
+    if (vars.worker_name && vars.worker_name_len > 0 && vars.script_filename) {
+      zval argv_array;
+      array_init(&argv_array);
+      add_next_index_stringl(&argv_array, vars.script_filename,
+                             vars.script_filename_len);
+      add_next_index_stringl(&argv_array, vars.worker_name,
+                             vars.worker_name_len);
+
+      zval argc_zv;
+      ZVAL_LONG(&argc_zv, 2);
+
+      zend_hash_str_update(ht, "argv", sizeof("argv") - 1, &argv_array);
+      zend_hash_str_update(ht, "argc", sizeof("argc") - 1, &argc_zv);
+    }
   }
 }
 
@@ -1581,6 +1647,10 @@ static void *php_thread(void *arg) {
                        zend_memory_usage(0), __ATOMIC_RELAXED);
 
       has_attempted_shutdown = true;
+
+      /* Capture the last PHP error before php_request_shutdown clears it,
+       * so background-worker boot failures can surface the cause. */
+      frankenphp_capture_last_php_error();
 
       /* shutdown the request, potential bailout to zend_catch */
       php_request_shutdown((void *)0);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -93,6 +93,31 @@ __thread php_stream *worker_signaling_stream = NULL;
 __thread char *captured_last_php_error = NULL;
 __thread HashTable *sandboxed_env = NULL;
 
+/* Per-thread cache for frankenphp_get_vars results. Maps worker name to
+ * { version, cached_zval }. When the Go side reports the version hasn't
+ * changed, the cached zval is returned with a refcount bump, giving the
+ * PHP caller the same HashTable pointer so repeated reads within a
+ * request run at O(1) without walking persistent memory every time. */
+typedef struct {
+  uint64_t version;
+  zval value;
+} bg_vars_cache_entry;
+__thread HashTable *bg_vars_cache = NULL;
+
+static void bg_vars_cache_dtor(zval *zv) {
+  bg_vars_cache_entry *entry = Z_PTR_P(zv);
+  zval_ptr_dtor(&entry->value);
+  free(entry);
+}
+
+static void bg_vars_cache_reset(void) {
+  if (bg_vars_cache) {
+    zend_hash_destroy(bg_vars_cache);
+    free(bg_vars_cache);
+    bg_vars_cache = NULL;
+  }
+}
+
 #ifndef PHP_WIN32
 static bool is_forked_child = false;
 static void frankenphp_fork_child(void) { is_forked_child = true; }
@@ -993,13 +1018,48 @@ PHP_FUNCTION(frankenphp_get_vars) {
   Z_PARAM_STR(name);
   ZEND_PARSE_PARAMETERS_END();
 
-  char *error = go_frankenphp_get_vars(thread_index, (char *)ZSTR_VAL(name),
-                                       ZSTR_LEN(name), return_value);
+  /* Look up a cached entry first so Go can short-circuit the copy when
+   * the background worker has not changed its vars since we last read
+   * them. On a cache hit we reuse the same zval, so $vars === $prev_vars
+   * holds across repeated reads within one request. */
+  uint64_t caller_version = 0;
+  uint64_t out_version = 0;
+  bg_vars_cache_entry *cached = NULL;
+  if (bg_vars_cache) {
+    zval *entry_zv = zend_hash_find(bg_vars_cache, name);
+    if (entry_zv) {
+      cached = Z_PTR_P(entry_zv);
+      caller_version = cached->version;
+    }
+  }
+
+  char *error = go_frankenphp_get_vars(
+      thread_index, (char *)ZSTR_VAL(name), ZSTR_LEN(name), return_value,
+      cached ? &caller_version : NULL, &out_version);
   if (error) {
     zend_throw_exception(spl_ce_RuntimeException, error, 0);
     free(error);
     RETURN_THROWS();
   }
+
+  if (cached && out_version == caller_version) {
+    /* Cache hit: Go skipped the copy. Return the cached zval. */
+    ZVAL_COPY(return_value, &cached->value);
+    return;
+  }
+
+  /* Cache miss: store the fresh copy so subsequent reads within this
+   * request can be served without walking persistent memory. */
+  if (!bg_vars_cache) {
+    bg_vars_cache = malloc(sizeof(HashTable));
+    zend_hash_init(bg_vars_cache, 4, NULL, bg_vars_cache_dtor, 1);
+  }
+  bg_vars_cache_entry *entry = malloc(sizeof(*entry));
+  entry->version = out_version;
+  ZVAL_COPY(&entry->value, return_value);
+  zval entry_zv;
+  ZVAL_PTR(&entry_zv, entry);
+  zend_hash_update(bg_vars_cache, name, &entry_zv);
 }
 
 PHP_FUNCTION(frankenphp_ensure_background_worker) {
@@ -1652,6 +1712,11 @@ static void *php_thread(void *arg) {
        * so background-worker boot failures can surface the cause. */
       frankenphp_capture_last_php_error();
 
+      /* Invalidate the per-request get_vars cache before php_request_shutdown
+       * tears down request memory: the cached zvals live in request memory
+       * and can't be freed after shutdown runs. */
+      bg_vars_cache_reset();
+
       /* shutdown the request, potential bailout to zend_catch */
       php_request_shutdown((void *)0);
       frankenphp_free_request_context();
@@ -1671,6 +1736,7 @@ static void *php_thread(void *arg) {
     if (!has_attempted_shutdown) {
       /* php_request_shutdown() was not called, force a shutdown now */
       reset_sandboxed_environment();
+      bg_vars_cache_reset();
       zend_try { php_request_shutdown((void *)0); }
       zend_catch {}
       zend_end_try();

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -16,6 +16,7 @@
 #else
 #include <php_config.h>
 #endif
+#include <main/php_streams.h>
 #include <php_ini.h>
 #include <php_main.h>
 #include <php_output.h>
@@ -91,6 +92,9 @@ HashTable *main_thread_env = NULL;
 
 __thread uintptr_t thread_index;
 __thread bool is_worker_thread = false;
+__thread bool is_background_worker = false;
+__thread int worker_stop_fds[2] = {-1, -1};
+__thread php_stream *worker_signaling_stream = NULL;
 __thread HashTable *sandboxed_env = NULL;
 
 #ifndef PHP_WIN32
@@ -203,11 +207,96 @@ void frankenphp_release_thread_for_kill(force_kill_slot slot) {
 #endif
 }
 
+static void frankenphp_worker_close_stop_fds(void);
+
 void frankenphp_update_local_thread_context(bool is_worker) {
+  /* A thread that previously ran as a bg worker can be recycled into an
+   * HTTP worker or a regular request thread; reset the bg-worker TLS so
+   * frankenphp_handle_request() and friends don't reject the caller. The
+   * cached worker_signaling_stream is already dangling here (its
+   * zend_resource was freed by php_request_shutdown's EG(regular_list)
+   * teardown), so just NULL it without dereferencing. */
+  bool was_background_worker = is_background_worker;
+
   is_worker_thread = is_worker;
+  is_background_worker = false;
+
+  if (was_background_worker) {
+    frankenphp_worker_close_stop_fds();
+    worker_signaling_stream = NULL;
+  }
 
   /* workers should keep running if the user aborts the connection */
   PG(ignore_user_abort) = is_worker ? 1 : original_user_abort_setting;
+}
+
+/* Background worker stop-pipe: anonymous pipe whose read end is exposed to
+ * the PHP script via frankenphp_get_worker_handle. When the Go side closes
+ * the write end (on drain), the read end reaches EOF so the script can
+ * return from stream_select and exit its loop. */
+static int frankenphp_worker_open_stop_pipe(void) {
+#ifdef PHP_WIN32
+  return _pipe(worker_stop_fds, 4096, _O_BINARY);
+#else
+  return pipe(worker_stop_fds);
+#endif
+}
+
+static void frankenphp_worker_close_stop_fds(void) {
+  for (int i = 0; i < 2; i++) {
+    if (worker_stop_fds[i] >= 0) {
+#ifdef PHP_WIN32
+      _close(worker_stop_fds[i]);
+#else
+      close(worker_stop_fds[i]);
+#endif
+      worker_stop_fds[i] = -1;
+    }
+  }
+}
+
+/* Marks the calling thread as a background worker, opens its stop pipe,
+ * transfers the write fd to the caller (clearing the TLS slot so later
+ * recycle won't double-close), and disarms max_execution_time. Returns
+ * -1 if the pipe could not be opened. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void) {
+  is_background_worker = true;
+  /* Drop the dangling stream pointer (see
+   * frankenphp_update_local_thread_context for why). */
+  worker_signaling_stream = NULL;
+  /* Bg workers don't enforce max_execution_time; disarm any lingering timer. */
+  zend_unset_timeout();
+
+  frankenphp_worker_close_stop_fds();
+  if (frankenphp_worker_open_stop_pipe() != 0) {
+    worker_stop_fds[0] = -1;
+    worker_stop_fds[1] = -1;
+    return -1;
+  }
+  int fd = worker_stop_fds[1];
+  worker_stop_fds[1] = -1;
+  return fd;
+}
+
+void frankenphp_worker_close_fd(int fd) {
+  if (fd < 0) {
+    return;
+  }
+  /* Closing the write end of the stop pipe lands as EOF on the read end,
+   * so the PHP side's stream_select returns promptly. */
+#ifdef PHP_WIN32
+  _close(fd);
+#else
+  close(fd);
+#endif
+}
+
+static int frankenphp_worker_dup_fd(int fd) {
+#ifdef PHP_WIN32
+  return _dup(fd);
+#else
+  return dup(fd);
+#endif
 }
 
 static void frankenphp_update_request_context() {
@@ -823,6 +912,191 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+PHP_FUNCTION(frankenphp_ensure_background_worker) {
+  zval *names_zv;
+  double timeout = 0.0;
+  bool timeout_is_null = true;
+
+  ZEND_PARSE_PARAMETERS_START(1, 2);
+  Z_PARAM_ZVAL(names_zv);
+  Z_PARAM_OPTIONAL
+  Z_PARAM_DOUBLE_OR_NULL(timeout, timeout_is_null);
+  ZEND_PARSE_PARAMETERS_END();
+
+  if (!timeout_is_null && timeout <= 0.0) {
+    zend_value_error("frankenphp_ensure_background_worker(): timeout must "
+                     "be > 0 (pass null to use the default)");
+    RETURN_THROWS();
+  }
+
+  /* Accept either a single string or an array of strings. For a single
+   * string we avoid the heap allocation by pointing at ZSTR fields
+   * directly via the on-stack one-element arrays. */
+  char *single_name_ptr = NULL;
+  size_t single_name_len = 0;
+  char **name_ptrs = NULL;
+  size_t *name_lens = NULL;
+  int name_count = 0;
+  bool heap_allocated = false;
+
+  if (Z_TYPE_P(names_zv) == IS_STRING) {
+    if (Z_STRLEN_P(names_zv) == 0) {
+      zend_value_error("frankenphp_ensure_background_worker(): name "
+                       "must not be empty");
+      RETURN_THROWS();
+    }
+    /* Reject embedded NUL bytes: PHP's zend_string is length-tagged so
+     * arbitrary bytes are technically legal, but the bg-worker name flows
+     * through C-string-aware paths (logging, $_SERVER export) where an
+     * embedded NUL would silently truncate. Fail loudly instead. */
+    if (memchr(Z_STRVAL_P(names_zv), '\0', Z_STRLEN_P(names_zv)) != NULL) {
+      zend_value_error("frankenphp_ensure_background_worker(): name "
+                       "must not contain null bytes");
+      RETURN_THROWS();
+    }
+    single_name_ptr = Z_STRVAL_P(names_zv);
+    single_name_len = Z_STRLEN_P(names_zv);
+    name_ptrs = &single_name_ptr;
+    name_lens = &single_name_len;
+    name_count = 1;
+  } else if (Z_TYPE_P(names_zv) == IS_ARRAY) {
+    HashTable *ht = Z_ARRVAL_P(names_zv);
+    name_count = zend_hash_num_elements(ht);
+    if (name_count == 0) {
+      zend_value_error("frankenphp_ensure_background_worker(): names array "
+                       "must not be empty");
+      RETURN_THROWS();
+    }
+    name_ptrs = emalloc(name_count * sizeof(*name_ptrs));
+    name_lens = emalloc(name_count * sizeof(*name_lens));
+    heap_allocated = true;
+    int idx = 0;
+    zval *v;
+    ZEND_HASH_FOREACH_VAL(ht, v) {
+      if (Z_TYPE_P(v) != IS_STRING) {
+        efree(name_ptrs);
+        efree(name_lens);
+        zend_type_error("frankenphp_ensure_background_worker(): names array "
+                        "must contain only strings");
+        RETURN_THROWS();
+      }
+      if (Z_STRLEN_P(v) == 0) {
+        efree(name_ptrs);
+        efree(name_lens);
+        zend_value_error("frankenphp_ensure_background_worker(): names array "
+                         "must not contain empty strings");
+        RETURN_THROWS();
+      }
+      /* Reject embedded NUL bytes: see single-string form above for the
+       * reasoning. Apply per-element so a mixed array is fully validated
+       * before any worker is started. */
+      if (memchr(Z_STRVAL_P(v), '\0', Z_STRLEN_P(v)) != NULL) {
+        efree(name_ptrs);
+        efree(name_lens);
+        zend_value_error("frankenphp_ensure_background_worker(): names array "
+                         "must not contain names with null bytes");
+        RETURN_THROWS();
+      }
+      /* Reject duplicates: O(n^2) is fine for the small batch sizes we
+       * expect here. */
+      for (int j = 0; j < idx; j++) {
+        if (name_lens[j] == (size_t)Z_STRLEN_P(v) &&
+            memcmp(name_ptrs[j], Z_STRVAL_P(v), name_lens[j]) == 0) {
+          efree(name_ptrs);
+          efree(name_lens);
+          zend_value_error(
+              "frankenphp_ensure_background_worker(): duplicate name %s",
+              Z_STRVAL_P(v));
+          RETURN_THROWS();
+        }
+      }
+      name_ptrs[idx] = Z_STRVAL_P(v);
+      name_lens[idx] = Z_STRLEN_P(v);
+      idx++;
+    }
+    ZEND_HASH_FOREACH_END();
+  } else {
+    zend_type_error("frankenphp_ensure_background_worker(): name must be a "
+                    "string or an array of strings");
+    RETURN_THROWS();
+  }
+
+  /* Seconds (PHP) -> ms (Go time.Duration). null = use the Go-side
+   * default; <=0 was rejected upfront. */
+  int64_t timeout_ms = 0;
+  if (!timeout_is_null) {
+    timeout_ms = (int64_t)(timeout * 1000.0);
+  }
+  char *error = go_frankenphp_ensure_background_worker(
+      thread_index, name_ptrs, name_lens, name_count, timeout_ms);
+  if (heap_allocated) {
+    efree(name_ptrs);
+    efree(name_lens);
+  }
+
+  if (error) {
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
+}
+
+PHP_FUNCTION(frankenphp_get_worker_handle) {
+  ZEND_PARSE_PARAMETERS_NONE();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_get_worker_handle() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  /* Return the cached stream on repeat calls. The first call (below) is
+   * the readiness boundary that ensure() blocks on; subsequent calls just
+   * hand back the same stream. */
+  if (worker_signaling_stream != NULL) {
+    php_stream_to_zval(worker_signaling_stream, return_value);
+    GC_ADDREF(Z_COUNTED_P(return_value));
+    return;
+  }
+
+  if (worker_stop_fds[0] < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create background worker stop pipe", 0);
+    RETURN_THROWS();
+  }
+
+  /* DUP so closing the PHP stream doesn't affect worker_stop_fds[0]; the
+   * original stays owned by the C side for cleanup at worker restart. */
+  int fd = frankenphp_worker_dup_fd(worker_stop_fds[0]);
+  if (fd < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to dup background worker stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  php_stream *stream = php_stream_fopen_from_fd(fd, "rb", NULL);
+  if (!stream) {
+    frankenphp_worker_close_fd(fd);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create stream from stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  worker_signaling_stream = stream;
+  php_stream_to_zval(stream, return_value);
+
+  /* Extra ref so PHP can't destroy the stream while TLS caches the pointer. */
+  GC_ADDREF(Z_COUNTED_P(return_value));
+
+  /* Signal that this worker has reached its main loop. ensure() callers
+   * waiting on this worker unblock here. Idempotent on the Go side
+   * (sync.Once-guarded), so a worker that crashed and respawned signals
+   * again on each fresh boot without harm. */
+  go_frankenphp_worker_ready(thread_index);
+}
+
 #ifdef FRANKENPHP_TEST
 /* Test-only entry point that exercises zval.h end-to-end:
  * validate -> persist (request -> persistent memory) ->
@@ -1035,6 +1309,22 @@ void frankenphp_register_server_vars(zval *track_vars_array,
   ZVAL_EMPTY_STRING(&zv);
   zend_hash_update_ind(ht, frankenphp_strings.auth_type, &zv);
   zend_hash_update_ind(ht, frankenphp_strings.remote_ident, &zv);
+
+  /* Worker identity in $_SERVER (HTTP and bg workers alike). The value is
+   * the user-facing worker name; pre-existing user code that only checks
+   * isset($_SERVER['FRANKENPHP_WORKER']) keeps working. */
+  if (vars.worker_name && vars.worker_name_len > 0) {
+    zval name_zv;
+    ZVAL_STRINGL(&name_zv, vars.worker_name, vars.worker_name_len);
+    zend_hash_str_update(ht, "FRANKENPHP_WORKER",
+                         sizeof("FRANKENPHP_WORKER") - 1, &name_zv);
+  }
+  if (vars.is_background_worker) {
+    zval bg_zv;
+    ZVAL_TRUE(&bg_zv);
+    zend_hash_str_update(ht, "FRANKENPHP_WORKER_BACKGROUND",
+                         sizeof("FRANKENPHP_WORKER_BACKGROUND") - 1, &bg_zv);
+  }
 }
 
 /** Create an immutable zend_string that lasts for the whole process **/
@@ -1262,6 +1552,12 @@ static void *php_thread(void *arg) {
         frankenphp_log_message("Request startup failed, thread is unhealthy",
                                LOG_ERR);
         zend_bailout();
+      }
+
+      /* php_request_startup re-arms max_execution_time; bg workers
+       * never enforce it, disarm again. */
+      if (is_background_worker) {
+        zend_unset_timeout();
       }
 
       zend_file_handle file_handle;

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -802,7 +802,6 @@ func resetGlobals() {
 	workers = nil
 	workersByName = nil
 	workersByPath = nil
-	backgroundLookups = nil
 	watcherIsEnabled = false
 	maxIdleTime = defaultMaxIdleTime
 	maxRequestsPerThread = 0

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -154,11 +154,27 @@ func Config() PHPConfig {
 	}
 }
 
-func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
+func calculateMaxThreads(opt *opt) (numWorkers int, err error) {
 	maxProcs := runtime.GOMAXPROCS(0) * 2
 	maxThreadsFromWorkers := 0
+	// Bg workers reserve their thread budget separately from HTTP
+	// workers so they don't double-count against the HTTP-worker
+	// admission check below; the bump is applied at the end.
+	reservedThreads := reserveBackgroundWorkerThreads(opt)
+	defer func() {
+		if err != nil {
+			return
+		}
+		opt.numThreads += reservedThreads
+		opt.maxThreads += reservedThreads
+		numWorkers += reservedThreads
+	}()
 
 	for i, w := range opt.workers {
+		if w.isBackgroundWorker {
+			continue
+		}
+
 		if w.num <= 0 {
 			// https://github.com/php/frankenphp/issues/126
 			opt.workers[i].num = maxProcs
@@ -786,6 +802,7 @@ func resetGlobals() {
 	workers = nil
 	workersByName = nil
 	workersByPath = nil
+	backgroundLookups = nil
 	watcherIsEnabled = false
 	maxIdleTime = defaultMaxIdleTime
 	maxRequestsPerThread = 0

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -235,6 +235,8 @@ void frankenphp_release_thread_for_kill(force_kill_slot slot);
 /* Background worker primitives. */
 int frankenphp_set_background_worker_and_get_stop_fd_write(void);
 void frankenphp_worker_close_fd(int fd);
+void frankenphp_copy_persistent_vars(zval *dst, void *persistent_ht);
+char *frankenphp_get_last_php_error(void);
 
 void register_extensions(zend_module_entry **m, int len);
 

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -116,6 +116,12 @@ typedef struct frankenphp_server_vars {
   zend_string *request_scheme;
   zend_string *ssl_protocol;
   zend_string *https;
+
+  /* Worker identity for $_SERVER. worker_name is m#-stripped Go-side,
+   * empty for non-worker requests. */
+  char *worker_name;
+  size_t worker_name_len;
+  bool is_background_worker;
 } frankenphp_server_vars;
 
 /**
@@ -225,6 +231,10 @@ size_t frankenphp_get_thread_memory_usage(uintptr_t thread_index);
  * handle). */
 void frankenphp_force_kill_thread(force_kill_slot slot);
 void frankenphp_release_thread_for_kill(force_kill_slot slot);
+
+/* Background worker primitives. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void);
+void frankenphp_worker_close_fd(int fd);
 
 void register_extensions(zend_module_entry **m, int len);
 

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -58,12 +58,12 @@ function frankenphp_log(string $message, int $level = 0, array $context = []): v
 /**
  * Declares a dependency on one or more background workers. Lazy-starts each
  * worker that isn't already running, then blocks until every named worker
- * has reached its main loop (signalled by its first call to
- * frankenphp_get_worker_handle()), aborts after exhausting its
- * max_consecutive_failures cap, or the timeout expires. Throws
- * RuntimeException if no background worker is configured for any given
- * name, if a worker fails to reach readiness within the timeout, or if a
- * worker aborts during boot.
+ * has reached combined readiness — meaning it has called both
+ * frankenphp_get_worker_handle() AND frankenphp_set_vars() at least once
+ * — aborts after exhausting its max_consecutive_failures cap, or the
+ * shared timeout expires. Throws RuntimeException if no background
+ * worker is configured for any given name, if a worker fails to reach
+ * readiness within the timeout, or if a worker aborts during boot.
  *
  * The array form rejects empty arrays (ValueError), non-string elements
  * (TypeError), empty strings, and duplicate names (ValueError) before
@@ -75,6 +75,19 @@ function frankenphp_log(string $message, int $level = 0, array $context = []): v
  *                            timeout. A value <= 0 raises ValueError.
  */
 function frankenphp_ensure_background_worker(string|array $name, ?float $timeout = null): void {}
+
+/**
+ * Publishes the given vars from a background worker. Only callable from a
+ * worker started with the `background` flag. Values must be null, scalars,
+ * arrays of allowed values, or enum cases.
+ */
+function frankenphp_set_vars(array $vars): void {}
+
+/**
+ * Reads the shared vars published by the named background worker. Throws if
+ * the worker is not declared, not running, or has not yet called set_vars.
+ */
+function frankenphp_get_vars(string $name): array {}
 
 /**
  * Returns the stop-signal stream for the current background worker. The

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -54,3 +54,33 @@ function mercure_publish(string|array $topics, string $data = '', bool $private 
  * array<string, any> $context Values of the array will be converted to the corresponding Go type (if supported by FrankenPHP) and added to the context of the structured logs using https://pkg.go.dev/log/slog#Attr
  */
 function frankenphp_log(string $message, int $level = 0, array $context = []): void {}
+
+/**
+ * Declares a dependency on one or more background workers. Lazy-starts each
+ * worker that isn't already running, then blocks until every named worker
+ * has reached its main loop (signalled by its first call to
+ * frankenphp_get_worker_handle()), aborts after exhausting its
+ * max_consecutive_failures cap, or the timeout expires. Throws
+ * RuntimeException if no background worker is configured for any given
+ * name, if a worker fails to reach readiness within the timeout, or if a
+ * worker aborts during boot.
+ *
+ * The array form rejects empty arrays (ValueError), non-string elements
+ * (TypeError), empty strings, and duplicate names (ValueError) before
+ * any worker is started.
+ *
+ * @param string|string[] $name
+ * @param float|null $timeout deadline in seconds. null (the default) falls
+ *                            back to FrankenPHP's internal default
+ *                            timeout. A value <= 0 raises ValueError.
+ */
+function frankenphp_ensure_background_worker(string|array $name, ?float $timeout = null): void {}
+
+/**
+ * Returns the stop-signal stream for the current background worker. The
+ * stream closes when FrankenPHP is draining the worker so the script can
+ * exit its loop gracefully. Only callable from inside a background worker.
+ *
+ * @return resource
+ */
+function frankenphp_get_worker_handle(): mixed {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 60f0d27c04f94d7b24c052e91ef294595a2bc421 */
+ * Stub hash: f90cea54c6a7c2b8559afa42abfd33066e764fd9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
@@ -41,6 +41,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_log, 0, 1, IS_VOID, 0
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, context, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_ensure_background_worker, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_MASK(0, name, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_get_worker_handle, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(headers_send);
@@ -49,7 +56,8 @@ ZEND_FUNCTION(frankenphp_request_headers);
 ZEND_FUNCTION(frankenphp_response_headers);
 ZEND_FUNCTION(mercure_publish);
 ZEND_FUNCTION(frankenphp_log);
-
+ZEND_FUNCTION(frankenphp_ensure_background_worker);
+ZEND_FUNCTION(frankenphp_get_worker_handle);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(frankenphp_handle_request, arginfo_frankenphp_handle_request)
@@ -63,6 +71,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FALIAS(apache_response_headers, frankenphp_response_headers, arginfo_apache_response_headers)
 	ZEND_FE(mercure_publish, arginfo_mercure_publish)
 	ZEND_FE(frankenphp_log, arginfo_frankenphp_log)
+	ZEND_FE(frankenphp_ensure_background_worker, arginfo_frankenphp_ensure_background_worker)
+	ZEND_FE(frankenphp_get_worker_handle, arginfo_frankenphp_get_worker_handle)
 	ZEND_FE_END
 };
 

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f90cea54c6a7c2b8559afa42abfd33066e764fd9 */
+ * Stub hash: bc8623068235bd40c5eb8a2675e59ad928fc6ea9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
@@ -46,6 +46,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_ensure_background_wor
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 1, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_set_vars, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, vars, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_get_vars, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_get_worker_handle, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
@@ -57,6 +65,8 @@ ZEND_FUNCTION(frankenphp_response_headers);
 ZEND_FUNCTION(mercure_publish);
 ZEND_FUNCTION(frankenphp_log);
 ZEND_FUNCTION(frankenphp_ensure_background_worker);
+ZEND_FUNCTION(frankenphp_set_vars);
+ZEND_FUNCTION(frankenphp_get_vars);
 ZEND_FUNCTION(frankenphp_get_worker_handle);
 
 static const zend_function_entry ext_functions[] = {
@@ -72,6 +82,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mercure_publish, arginfo_mercure_publish)
 	ZEND_FE(frankenphp_log, arginfo_frankenphp_log)
 	ZEND_FE(frankenphp_ensure_background_worker, arginfo_frankenphp_ensure_background_worker)
+	ZEND_FE(frankenphp_set_vars, arginfo_frankenphp_set_vars)
+	ZEND_FE(frankenphp_get_vars, arginfo_frankenphp_get_vars)
 	ZEND_FE(frankenphp_get_worker_handle, arginfo_frankenphp_get_worker_handle)
 	ZEND_FE_END
 };

--- a/options.go
+++ b/options.go
@@ -262,9 +262,8 @@ func WithWorkerOnServerShutdown(f func()) WorkerOption {
 
 // EXPERIMENTAL: WithWorkerBackground marks this worker as a background
 // (non-HTTP) worker. Background workers run outside the request cycle and
-// share the PHP runtime with HTTP threads but don't serve HTTP requests.
-// They expose a stop pipe via frankenphp_get_worker_handle() so PHP scripts
-// can park on stream_select and exit gracefully when FrankenPHP drains.
+// publish shared variables via frankenphp_set_vars for HTTP threads to read
+// via frankenphp_get_vars.
 func WithWorkerBackground() WorkerOption {
 	return func(w *workerOpt) error {
 		w.isBackgroundWorker = true

--- a/options.go
+++ b/options.go
@@ -50,6 +50,8 @@ type workerOpt struct {
 	onThreadShutdown       func(int)
 	onServerStartup        func()
 	onServerShutdown       func()
+	isBackgroundWorker     bool
+	scope                  Scope
 }
 
 // WithContext sets the main context to use.
@@ -253,6 +255,32 @@ func WithWorkerOnServerStartup(f func()) WorkerOption {
 func WithWorkerOnServerShutdown(f func()) WorkerOption {
 	return func(w *workerOpt) error {
 		w.onServerShutdown = f
+
+		return nil
+	}
+}
+
+// EXPERIMENTAL: WithWorkerBackground marks this worker as a background
+// (non-HTTP) worker. Background workers run outside the request cycle and
+// share the PHP runtime with HTTP threads but don't serve HTTP requests.
+// They expose a stop pipe via frankenphp_get_worker_handle() so PHP scripts
+// can park on stream_select and exit gracefully when FrankenPHP drains.
+func WithWorkerBackground() WorkerOption {
+	return func(w *workerOpt) error {
+		w.isBackgroundWorker = true
+
+		return nil
+	}
+}
+
+// EXPERIMENTAL: WithWorkerScope assigns this worker to a given scope.
+// Workers in the same scope share a background lookup; each php_server
+// block gets its own scope so workers with the same name in different
+// blocks don't collide. The zero value is the global/embed scope and is
+// the default.
+func WithWorkerScope(scope Scope) WorkerOption {
+	return func(w *workerOpt) error {
+		w.scope = scope
 
 		return nil
 	}

--- a/phpthread.go
+++ b/phpthread.go
@@ -47,6 +47,9 @@ type threadHandler interface {
 	// current handlers are no-ops; this is the seam later handler types use
 	// without having to modify drainWorkerThreads.
 	drain()
+	// scopedWorker returns the *worker this handler runs (HTTP / bg
+	// workers), or nil for non-worker handlers.
+	scopedWorker() *worker
 }
 
 func newPHPThread(threadIndex int) *phpThread {
@@ -105,6 +108,9 @@ func (thread *phpThread) shutdown() {
 		return
 	}
 
+	// Wake up handlers parked in a blocking C call (background workers'
+	// stream_select on the stop pipe). No-op for regular/worker handlers.
+	thread.handler.drain()
 	close(thread.drainChan)
 
 	// Arm force-kill after the grace period to wake any thread stuck in

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -154,6 +154,18 @@ func WithRequestLogger(logger *slog.Logger) RequestOption {
 	}
 }
 
+// WithRequestScope selects the scope for ensure() calls made from this
+// request. Web-server integrations (such as the Caddy module) can call
+// NextScope per independently-configured block to isolate its set of
+// background workers.
+func WithRequestScope(scope Scope) RequestOption {
+	return func(o *frankenPHPContext) error {
+		o.scope = scope
+
+		return nil
+	}
+}
+
 // WithWorkerName sets the worker that should handle the request
 func WithWorkerName(name string) RequestOption {
 	return func(o *frankenPHPContext) error {

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -154,10 +154,10 @@ func WithRequestLogger(logger *slog.Logger) RequestOption {
 	}
 }
 
-// WithRequestScope selects the scope for ensure() calls made from this
-// request. Web-server integrations (such as the Caddy module) can call
-// NextScope per independently-configured block to isolate its set of
-// background workers.
+// WithRequestScope selects the scope for ensure / get_vars calls made
+// from this request. Web-server integrations (such as the Caddy module)
+// can call NextScope per independently-configured block to isolate its
+// set of background workers.
 func WithRequestScope(scope Scope) RequestOption {
 	return func(o *frankenPHPContext) error {
 		o.scope = scope

--- a/scaling.go
+++ b/scaling.go
@@ -83,6 +83,19 @@ func addWorkerThread(worker *worker) (*phpThread, error) {
 	return thread, nil
 }
 
+// addBackgroundWorkerThread reserves an inactive thread and converts it
+// to a background worker thread bound to (worker, runtimeName, ready).
+// runtimeName is the worker's m#-prefixed identity for named workers and
+// pool members, or the user-facing name for catch-all instances.
+func addBackgroundWorkerThread(worker *worker, runtimeName string, ready *backgroundWorkerState) (*phpThread, error) {
+	thread := getInactivePHPThread()
+	if thread == nil {
+		return nil, ErrMaxThreadsReached
+	}
+	convertToBackgroundWorkerThread(thread, worker, runtimeName, ready)
+	return thread, nil
+}
+
 // scaleWorkerThread adds a worker PHP thread automatically
 func scaleWorkerThread(worker *worker, done chan struct{}, mstate *state.ThreadState) {
 	// probe CPU usage before acquiring the lock (avoids holding lock during 120ms sleep)

--- a/testdata/_executor.php
+++ b/testdata/_executor.php
@@ -1,7 +1,7 @@
 <?php
 
 $fn = require $_SERVER['SCRIPT_FILENAME'];
-if ('1' !== ($_SERVER['FRANKENPHP_WORKER'] ?? null)) {
+if (!isset($_SERVER['FRANKENPHP_WORKER'])) {
     $fn();
     exit(0);
 }

--- a/testdata/background-worker-cache-fixture.php
+++ b/testdata/background-worker-cache-fixture.php
@@ -1,0 +1,20 @@
+<?php
+
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Stable bg worker: publishes one snapshot and never updates.
+frankenphp_set_vars([
+    'marker' => 'cached-value',
+]);
+
+$stream = frankenphp_get_worker_handle();
+if ($stream !== null) {
+    $read = [$stream];
+    $write = null;
+    $except = null;
+    stream_select($read, $write, $except, null);
+}

--- a/testdata/background-worker-cache-identity.php
+++ b/testdata/background-worker-cache-identity.php
@@ -1,0 +1,14 @@
+<?php
+
+// Calls get_vars twice within one request. The cache guarantees pointer
+// identity: the two zvals should be === (same HashTable pointer) because
+// the underlying worker hasn't published a new version in between.
+// ensure() waits for the bg worker's first set_vars so eager-start races
+// don't surface before the cache path is exercised.
+frankenphp_ensure_background_worker('cache-worker');
+$first = frankenphp_get_vars('cache-worker');
+$second = frankenphp_get_vars('cache-worker');
+
+echo 'first=', isset($first['marker']) ? $first['marker'] : 'MISSING', "\n";
+echo 'second=', isset($second['marker']) ? $second['marker'] : 'MISSING', "\n";
+echo 'identical=', ($first === $second) ? 'true' : 'false', "\n";

--- a/testdata/bgworker/basic.php
+++ b/testdata/bgworker/basic.php
@@ -1,0 +1,20 @@
+<?php
+
+// Long-lived background worker: disable PHP max_execution_time so the
+// 30s default cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Touch the sentinel so the test can confirm the worker actually ran.
+if (!empty($_SERVER['BG_SENTINEL'])) {
+    @touch($_SERVER['BG_SENTINEL']);
+}
+
+// Park on the stop pipe until FrankenPHP drains us (drain closes the
+// write end, which lands as EOF on the read end).
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/batch-ensure.php
+++ b/testdata/bgworker/batch-ensure.php
@@ -1,8 +1,9 @@
 <?php
 
-// HTTP fixture: ensure three workers in a single batch call. Each
-// catch-all instance writes its own per-name sentinel under
-// $_SERVER['BG_SENTINEL_DIR'] (set via WithWorkerEnv at the bg worker
-// declaration). The HTTP response just confirms the call did not throw.
-frankenphp_ensure_background_worker(['batch-a', 'batch-b', 'batch-c']);
-echo "ok\n";
+// HTTP script that batches three ensures in one call and reads each.
+frankenphp_ensure_background_worker(['worker-a', 'worker-b', 'worker-c'], 5.0);
+
+foreach (['worker-a', 'worker-b', 'worker-c'] as $name) {
+    $vars = frankenphp_get_vars($name);
+    echo $name, '=', $vars['FRANKENPHP_WORKER'] ?? 'MISSING', "\n";
+}

--- a/testdata/bgworker/batch-ensure.php
+++ b/testdata/bgworker/batch-ensure.php
@@ -1,0 +1,8 @@
+<?php
+
+// HTTP fixture: ensure three workers in a single batch call. Each
+// catch-all instance writes its own per-name sentinel under
+// $_SERVER['BG_SENTINEL_DIR'] (set via WithWorkerEnv at the bg worker
+// declaration). The HTTP response just confirms the call did not throw.
+frankenphp_ensure_background_worker(['batch-a', 'batch-b', 'batch-c']);
+echo "ok\n";

--- a/testdata/bgworker/batch-errors.php
+++ b/testdata/bgworker/batch-errors.php
@@ -1,0 +1,30 @@
+<?php
+
+// HTTP fixture exercising input validation paths of the batch ensure().
+// The query string selects which scenario to trigger; the script catches
+// the resulting throwable and echoes its class so the test can assert the
+// expected error type without parsing PHP's error log.
+$mode = $_GET['mode'] ?? '';
+
+try {
+    switch ($mode) {
+        case 'empty':
+            frankenphp_ensure_background_worker([]);
+            break;
+        case 'nonstring':
+            frankenphp_ensure_background_worker(['ok-name', 42]);
+            break;
+        case 'duplicate':
+            frankenphp_ensure_background_worker(['dup', 'dup']);
+            break;
+        case 'empty-string':
+            frankenphp_ensure_background_worker(['', 'other']);
+            break;
+        default:
+            echo "no-mode\n";
+            return;
+    }
+    echo "no-throw\n";
+} catch (\Throwable $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}

--- a/testdata/bgworker/bg-flag.php
+++ b/testdata/bgworker/bg-flag.php
@@ -1,0 +1,20 @@
+<?php
+
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Write a sentinel containing var_export() of FRANKENPHP_WORKER_BACKGROUND
+// so the test can assert the exact value injected by C ($_SERVER flag).
+if (!empty($_SERVER['BG_SENTINEL'])) {
+    $value = $_SERVER['FRANKENPHP_WORKER_BACKGROUND'] ?? 'MISSING';
+    @file_put_contents($_SERVER['BG_SENTINEL'], var_export($value, true));
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/bg-flag.php
+++ b/testdata/bgworker/bg-flag.php
@@ -6,12 +6,12 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Write a sentinel containing var_export() of FRANKENPHP_WORKER_BACKGROUND
-// so the test can assert the exact value injected by C ($_SERVER flag).
-if (!empty($_SERVER['BG_SENTINEL'])) {
-    $value = $_SERVER['FRANKENPHP_WORKER_BACKGROUND'] ?? 'MISSING';
-    @file_put_contents($_SERVER['BG_SENTINEL'], var_export($value, true));
-}
+// Records both FRANKENPHP_WORKER_BACKGROUND and FRANKENPHP_WORKER
+// from $_SERVER so the test can confirm both are populated.
+frankenphp_set_vars([
+    'name' => $_SERVER['FRANKENPHP_WORKER'] ?? 'MISSING',
+    'is_background' => $_SERVER['FRANKENPHP_WORKER_BACKGROUND'] ?? 'MISSING',
+]);
 
 $stream = frankenphp_get_worker_handle();
 $read = [$stream];

--- a/testdata/bgworker/binary.php
+++ b/testdata/bgworker/binary.php
@@ -6,12 +6,14 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Minimal background worker: publishes a small vars set then parks on the
-// stop stream until FrankenPHP drains it.
+// Binary-safe fixture: publishes values with embedded NULs, multibyte
+// UTF-8, and an empty string so the reader can confirm the deep-copy
+// path preserves bytes verbatim (not truncated at the first \0, not
+// mangled through C string conversions).
 frankenphp_set_vars([
-    'message' => 'hello from background worker',
-    'count' => 42,
-    'ready_at' => microtime(true),
+    'BINARY' => "hello\x00world",
+    'UTF8' => "héllo wörld 🚀",
+    'EMPTY' => "",
 ]);
 
 $stream = frankenphp_get_worker_handle();

--- a/testdata/bgworker/boot-fail.php
+++ b/testdata/bgworker/boot-fail.php
@@ -1,0 +1,7 @@
+<?php
+
+// Bg worker fixture that throws on its very first line. Used by
+// TestEnsureBackgroundWorkerBootFailure to prove ensure() surfaces the
+// crash metadata (entrypoint, exit status, attempt count) when a worker
+// keeps crashing during boot before reaching the readiness boundary.
+throw new RuntimeException('intentional boot failure for test');

--- a/testdata/bgworker/boot-fail.php
+++ b/testdata/bgworker/boot-fail.php
@@ -1,7 +1,6 @@
 <?php
 
-// Bg worker fixture that throws on its very first line. Used by
-// TestEnsureBackgroundWorkerBootFailure to prove ensure() surfaces the
-// crash metadata (entrypoint, exit status, attempt count) when a worker
-// keeps crashing during boot before reaching the readiness boundary.
-throw new RuntimeException('intentional boot failure for test');
+// Bootstrap-failure worker: throws before ever calling frankenphp_set_vars.
+// Used by ensure() bootstrap-mode tests to verify the captured PHP error
+// surfaces in the timeout message.
+throw new RuntimeException("intentional boot failure for test");

--- a/testdata/bgworker/crash.php
+++ b/testdata/bgworker/crash.php
@@ -1,0 +1,29 @@
+<?php
+
+// Crash-and-recover fixture. On the first boot (no marker), creates the
+// marker and exit(1) so the bg worker thread observes a non-zero exit
+// status. On the second boot (marker present), touches a "restarted"
+// sentinel and parks on the stop pipe. The test asserts the restarted
+// sentinel appears, proving the crash-restart loop ran.
+set_time_limit(0);
+
+$marker = $_SERVER['BG_CRASH_MARKER'] ?? '';
+$restarted = $_SERVER['BG_RESTARTED_SENTINEL'] ?? '';
+
+if ($marker === '' || $restarted === '') {
+    // Misconfigured: don't loop forever on a missing env.
+    exit(2);
+}
+
+if (!file_exists($marker)) {
+    file_put_contents($marker, '1');
+    exit(1);
+}
+
+@touch($restarted);
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/crash.php
+++ b/testdata/bgworker/crash.php
@@ -1,29 +1,30 @@
 <?php
 
-// Crash-and-recover fixture. On the first boot (no marker), creates the
-// marker and exit(1) so the bg worker thread observes a non-zero exit
-// status. On the second boot (marker present), touches a "restarted"
-// sentinel and parks on the stop pipe. The test asserts the restarted
-// sentinel appears, proving the crash-restart loop ran.
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-$marker = $_SERVER['BG_CRASH_MARKER'] ?? '';
-$restarted = $_SERVER['BG_RESTARTED_SENTINEL'] ?? '';
-
-if ($marker === '' || $restarted === '') {
-    // Misconfigured: don't loop forever on a missing env.
-    exit(2);
-}
+// Crash-and-recover fixture. On the first boot (no marker), publishes
+// count=1 then exit(1). On the second boot (marker present), publishes
+// count=2 and parks on the stop stream. Tests that:
+//   - vars stay readable across the restart (persistent storage),
+//   - the worker is restarted automatically after the crash,
+//   - the post-restart publish overwrites the first snapshot.
+$marker = sys_get_temp_dir() . '/bg-worker-crash-' . getmypid();
 
 if (!file_exists($marker)) {
+    frankenphp_set_vars(['count' => 1, 'phase' => 'pre-crash']);
     file_put_contents($marker, '1');
     exit(1);
 }
 
-@touch($restarted);
+frankenphp_set_vars(['count' => 2, 'phase' => 'post-restart']);
 
 $stream = frankenphp_get_worker_handle();
 $read = [$stream];
 $write = null;
 $except = null;
 stream_select($read, $write, $except, null);
+@unlink($marker);

--- a/testdata/bgworker/eager-catchall.php
+++ b/testdata/bgworker/eager-catchall.php
@@ -1,0 +1,16 @@
+<?php
+
+// Touches BG_EAGER_SENTINEL once readiness is reached, then parks.
+// Drives the eager catch-all readiness test.
+set_time_limit(0);
+
+$sentinel = $_SERVER['BG_EAGER_SENTINEL'] ?? '';
+if ($sentinel !== '') {
+    @touch($sentinel);
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/ensure-from-handler.php
+++ b/testdata/bgworker/ensure-from-handler.php
@@ -1,0 +1,7 @@
+<?php
+
+// HTTP script that runs NOT inside a worker (non-worker mode) and calls
+// ensure() at request time. Exercises the tolerant runtime-mode path.
+frankenphp_ensure_background_worker('bg-lazy', 5.0);
+$vars = frankenphp_get_vars('bg-lazy');
+echo 'ensured-name=', $vars['FRANKENPHP_WORKER'] ?? 'MISSING', "\n";

--- a/testdata/bgworker/ensure-reader.php
+++ b/testdata/bgworker/ensure-reader.php
@@ -1,0 +1,9 @@
+<?php
+
+// HTTP script that ensures the bg worker first, then reads its vars.
+// Used to exercise the lazy-start path via frankenphp_ensure_background_worker.
+$name = $_GET['name'] ?? 'bg-lazy';
+frankenphp_ensure_background_worker($name, 5.0);
+$vars = frankenphp_get_vars($name);
+echo 'name=', $vars['FRANKENPHP_WORKER'] ?? 'MISSING', "\n";
+echo 'count=', $vars['count'] ?? 'MISSING', "\n";

--- a/testdata/bgworker/enum-only.php
+++ b/testdata/bgworker/enum-only.php
@@ -6,13 +6,16 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Minimal background worker: publishes a small vars set then parks on the
-// stop stream until FrankenPHP drains it.
-frankenphp_set_vars([
-    'message' => 'hello from background worker',
-    'count' => 42,
-    'ready_at' => microtime(true),
-]);
+// Enum-missing fixture: defines an enum that lives only in the bg worker
+// process image (the HTTP reader never loads this file), then publishes
+// a case. On the reader side the class is unknown, so the generational
+// deserializer must surface a LogicException instead of returning a
+// broken zval.
+enum WorkerOnlyEnum {
+    case Foo;
+}
+
+frankenphp_set_vars(['val' => WorkerOnlyEnum::Foo]);
 
 $stream = frankenphp_get_worker_handle();
 $read = [$stream];

--- a/testdata/bgworker/errors.php
+++ b/testdata/bgworker/errors.php
@@ -1,0 +1,25 @@
+<?php
+
+// Exercise error paths on get_vars / set_vars that don't depend on a
+// running worker thread.
+
+try {
+    frankenphp_get_vars('does-not-exist');
+    echo "FAIL missing worker\n";
+} catch (RuntimeException $e) {
+    echo "OK missing: ", $e->getMessage(), "\n";
+}
+
+try {
+    frankenphp_set_vars(['foo' => 'bar']);
+    echo "FAIL set_vars from non-background\n";
+} catch (RuntimeException $e) {
+    echo "OK reject-non-bg: ", $e->getMessage(), "\n";
+}
+
+try {
+    frankenphp_get_worker_handle();
+    echo "FAIL get_worker_handle from non-background\n";
+} catch (RuntimeException $e) {
+    echo "OK reject-handle: ", $e->getMessage(), "\n";
+}

--- a/testdata/bgworker/fail-then-succeed.php
+++ b/testdata/bgworker/fail-then-succeed.php
@@ -1,0 +1,29 @@
+<?php
+
+// Crashes on boots 1..BG_FAIL_UNTIL, then succeeds. Each boot writes a
+// boot<N> marker so the script counts attempts; success path writes a
+// "ready" sentinel.
+set_time_limit(0);
+
+$markerDir = $_SERVER['BG_MARKER_DIR'] ?? '';
+if ($markerDir === '') {
+    exit(2);
+}
+
+$attempt = 1;
+while (file_exists($markerDir . '/boot' . $attempt)) {
+    $attempt++;
+}
+@touch($markerDir . '/boot' . $attempt);
+
+$failUntil = (int)($_SERVER['BG_FAIL_UNTIL'] ?? '2');
+if ($attempt <= $failUntil) {
+    exit(1);
+}
+
+@touch($markerDir . '/ready');
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/fail-then-succeed.php
+++ b/testdata/bgworker/fail-then-succeed.php
@@ -22,6 +22,9 @@ if ($attempt <= $failUntil) {
 }
 
 @touch($markerDir . '/ready');
+// set_vars + get_worker_handle together close the readiness channel on
+// sidekicks; either alone is not sufficient.
+frankenphp_set_vars([]);
 $stream = frankenphp_get_worker_handle();
 $read = [$stream];
 $write = null;

--- a/testdata/bgworker/named.php
+++ b/testdata/bgworker/named.php
@@ -1,16 +1,22 @@
 <?php
 
 // Long-lived bg worker: disable PHP max_execution_time so the 30s default
-// cannot interrupt the stream_select park.
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Lazy-start fixture for ensure() tests. Touches a per-name sentinel under
-// $_SERVER['BG_SENTINEL_DIR'] so tests can confirm the right instance ran.
-// Catch-all instances see their declared name through FRANKENPHP_WORKER.
+// Lazy-start fixture for ensure() tests. Echoes its declared name through
+// FRANKENPHP_WORKER and publishes it via set_vars so tests can read it
+// back through frankenphp_get_vars.
 $name = $_SERVER['FRANKENPHP_WORKER'] ?? 'unknown';
 if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
     @touch($_SERVER['BG_SENTINEL_DIR'] . DIRECTORY_SEPARATOR . $name);
 }
+frankenphp_set_vars([
+    'FRANKENPHP_WORKER' => $name,
+    'count' => 1,
+]);
 
 $stream = frankenphp_get_worker_handle();
 $read = [$stream];

--- a/testdata/bgworker/named.php
+++ b/testdata/bgworker/named.php
@@ -1,0 +1,19 @@
+<?php
+
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park.
+set_time_limit(0);
+
+// Lazy-start fixture for ensure() tests. Touches a per-name sentinel under
+// $_SERVER['BG_SENTINEL_DIR'] so tests can confirm the right instance ran.
+// Catch-all instances see their declared name through FRANKENPHP_WORKER.
+$name = $_SERVER['FRANKENPHP_WORKER'] ?? 'unknown';
+if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
+    @touch($_SERVER['BG_SENTINEL_DIR'] . DIRECTORY_SEPARATOR . $name);
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/no-handle.php
+++ b/testdata/bgworker/no-handle.php
@@ -1,0 +1,9 @@
+<?php
+
+// Long-lived bg worker fixture that intentionally does NOT call
+// frankenphp_get_worker_handle(). Used by TestEnsureBackgroundWorkerTimeout
+// to prove ensure() times out when the readiness boundary is never crossed.
+// The 0 limit lets sleep() run as long as the test's drain takes.
+set_time_limit(0);
+
+sleep(60);

--- a/testdata/bgworker/pool.php
+++ b/testdata/bgworker/pool.php
@@ -1,0 +1,22 @@
+<?php
+
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Pool worker: num > 1 means multiple threads share this worker name.
+// Each thread runs in its own ZTS context, but getmypid() returns the
+// shared process pid. random_bytes() gives us a unique-per-thread
+// suffix so the test can count N distinct booted threads.
+if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
+    $path = $_SERVER['BG_SENTINEL_DIR'] . '/pool-' . bin2hex(random_bytes(8));
+    @touch($path);
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/pool.php
+++ b/testdata/bgworker/pool.php
@@ -7,9 +7,17 @@
 set_time_limit(0);
 
 // Pool worker: num > 1 means multiple threads share this worker name.
-// Each thread runs in its own ZTS context, but getmypid() returns the
-// shared process pid. random_bytes() gives us a unique-per-thread
-// suffix so the test can count N distinct booted threads.
+// Each thread runs in its own ZTS context but shares a single
+// backgroundWorkerState (via the worker name), so set_vars writes from
+// any pool thread are visible to readers.
+frankenphp_set_vars([
+    'name' => $_SERVER['FRANKENPHP_WORKER'] ?? 'unknown',
+    'pid' => getmypid(),
+]);
+
+// Per-thread sentinel (random suffix) lets tests count distinct booted
+// threads, which set_vars alone cannot show since the namespace is
+// per-worker-name not per-thread.
 if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
     $path = $_SERVER['BG_SENTINEL_DIR'] . '/pool-' . bin2hex(random_bytes(8));
     @touch($path);

--- a/testdata/bgworker/reader.php
+++ b/testdata/bgworker/reader.php
@@ -1,0 +1,8 @@
+<?php
+
+// HTTP script that reads the background worker's shared vars and echoes
+// them so the Go test can assert the round-trip.
+$vars = frankenphp_get_vars('bg-basic');
+echo 'message=', $vars['message'] ?? 'MISSING', "\n";
+echo 'count=', $vars['count'] ?? 'MISSING', "\n";
+echo 'has-ready-at=', isset($vars['ready_at']) ? '1' : '0', "\n";

--- a/testdata/bgworker/readiness-then-crash.php
+++ b/testdata/bgworker/readiness-then-crash.php
@@ -1,8 +1,10 @@
 <?php
 
-// Signals readiness via frankenphp_get_worker_handle(), then exits
-// non-zero. Drives the post-readiness crash-loop abort test.
+// Signals readiness via frankenphp_set_vars() + frankenphp_get_worker_handle()
+// (both are required to close the readiness channel on sidekicks), then
+// exits non-zero. Drives the post-readiness crash-loop abort test.
 set_time_limit(0);
 
+frankenphp_set_vars([]);
 frankenphp_get_worker_handle();
 exit(1);

--- a/testdata/bgworker/readiness-then-crash.php
+++ b/testdata/bgworker/readiness-then-crash.php
@@ -1,0 +1,8 @@
+<?php
+
+// Signals readiness via frankenphp_get_worker_handle(), then exits
+// non-zero. Drives the post-readiness crash-loop abort test.
+set_time_limit(0);
+
+frankenphp_get_worker_handle();
+exit(1);

--- a/testdata/bgworker/scope-a.php
+++ b/testdata/bgworker/scope-a.php
@@ -6,16 +6,14 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Minimal background worker: publishes a small vars set then parks on the
-// stop stream until FrankenPHP drains it.
 frankenphp_set_vars([
-    'message' => 'hello from background worker',
-    'count' => 42,
-    'ready_at' => microtime(true),
+    'scope' => 'A',
 ]);
 
 $stream = frankenphp_get_worker_handle();
-$read = [$stream];
-$write = null;
-$except = null;
-stream_select($read, $write, $except, null);
+if ($stream !== null) {
+    $read = [$stream];
+    $write = null;
+    $except = null;
+    stream_select($read, $write, $except, null);
+}

--- a/testdata/bgworker/scope-b.php
+++ b/testdata/bgworker/scope-b.php
@@ -6,16 +6,14 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Minimal background worker: publishes a small vars set then parks on the
-// stop stream until FrankenPHP drains it.
 frankenphp_set_vars([
-    'message' => 'hello from background worker',
-    'count' => 42,
-    'ready_at' => microtime(true),
+    'scope' => 'B',
 ]);
 
 $stream = frankenphp_get_worker_handle();
-$read = [$stream];
-$write = null;
-$except = null;
-stream_select($read, $write, $except, null);
+if ($stream !== null) {
+    $read = [$stream];
+    $write = null;
+    $except = null;
+    stream_select($read, $write, $except, null);
+}

--- a/testdata/bgworker/scope-reader.php
+++ b/testdata/bgworker/scope-reader.php
@@ -1,0 +1,9 @@
+<?php
+
+// Reads the "shared" worker's scope tag. Which worker this resolves to
+// depends on the request's BackgroundScope. ensure() waits for the
+// scoped worker to publish at least once, removing the race between
+// eager start (num=1) and the first request landing here.
+frankenphp_ensure_background_worker('shared');
+$vars = frankenphp_get_vars('shared');
+echo 'scope=', $vars['scope'] ?? 'MISSING', "\n";

--- a/testdata/bgworker/stream-probe.php
+++ b/testdata/bgworker/stream-probe.php
@@ -6,15 +6,16 @@
 // builds where that path does not fully disarm the timer.
 set_time_limit(0);
 
-// Minimal background worker: publishes a small vars set then parks on the
-// stop stream until FrankenPHP drains it.
+// Probes the signaling stream returned by frankenphp_get_worker_handle():
+// publishes its resource type and a basic metadata snapshot so the reader
+// can confirm it is a real PHP stream resource, not a bogus zval.
+$stream = frankenphp_get_worker_handle();
+
 frankenphp_set_vars([
-    'message' => 'hello from background worker',
-    'count' => 42,
-    'ready_at' => microtime(true),
+    'stream_type' => get_resource_type($stream),
+    'is_resource' => is_resource($stream),
 ]);
 
-$stream = frankenphp_get_worker_handle();
 $read = [$stream];
 $write = null;
 $except = null;

--- a/testdata/bgworker/stuck.php
+++ b/testdata/bgworker/stuck.php
@@ -1,0 +1,17 @@
+<?php
+
+// Intentionally stuck bg worker fixture: does NOT watch the stop pipe,
+// so handler.drain() closing the write end has no effect. The only way
+// to make RestartWorkers finish within the grace period is the
+// force-kill primitive (pthread_kill on Linux/FreeBSD). Used by
+// TestBackgroundWorkerRestartForceKillsStuckThread to prove the
+// force-kill path (not just the stop-pipe wake-up) is actually wired.
+set_time_limit(0);
+
+if (!empty($_SERVER['BG_SENTINEL'])) {
+    @touch($_SERVER['BG_SENTINEL']);
+}
+
+// sleep() is interruptible by SIGRTMIN+3 on Linux/FreeBSD; the test
+// skips platforms where neither mechanism can interrupt it.
+sleep(60);

--- a/testdata/bgworker/stuck.php
+++ b/testdata/bgworker/stuck.php
@@ -3,15 +3,19 @@
 // Intentionally stuck bg worker fixture: does NOT watch the stop pipe,
 // so handler.drain() closing the write end has no effect. The only way
 // to make RestartWorkers finish within the grace period is the
-// force-kill primitive (pthread_kill on Linux/FreeBSD). Used by
+// force-kill primitive (pthread_kill on Linux/FreeBSD,
+// CancelSynchronousIo on Windows). Used by
 // TestBackgroundWorkerRestartForceKillsStuckThread to prove the
 // force-kill path (not just the stop-pipe wake-up) is actually wired.
 set_time_limit(0);
 
-if (!empty($_SERVER['BG_SENTINEL'])) {
-    @touch($_SERVER['BG_SENTINEL']);
-}
+// Touch the worker handle so the combined readiness signal (handle +
+// set_vars) closes; the stream itself is intentionally ignored — the
+// point of this fixture is that we DON'T watch the stop pipe.
+frankenphp_get_worker_handle();
+frankenphp_set_vars(['ready' => 1]);
 
-// sleep() is interruptible by SIGRTMIN+3 on Linux/FreeBSD; the test
-// skips platforms where neither mechanism can interrupt it.
+// sleep() is interruptible by SIGRTMIN+3 on Linux/FreeBSD and by
+// alertable-wait APCs on Windows; the test skips platforms where
+// neither mechanism can interrupt it.
 sleep(60);

--- a/testdata/bgworker/types.php
+++ b/testdata/bgworker/types.php
@@ -1,0 +1,67 @@
+<?php
+
+// Long-lived bg worker: disable PHP max_execution_time so the 30s default
+// cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Type-validation fixture. Exercises every branch of the persistent-zval
+// helper from inside a bg worker: int values/keys, nested arrays, and
+// rejected types (objects, references). Aggregates the outcome into a
+// RESULTS string and publishes it along with an enum case so the reader
+// can verify enum round-trip.
+enum BgTestStatus {
+    case Active;
+    case Inactive;
+}
+
+$results = [];
+
+try {
+    frankenphp_set_vars(['KEY' => 123]);
+    $results[] = 'INT_VAL:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'INT_VAL:blocked';
+}
+
+try {
+    frankenphp_set_vars([0 => 'val']);
+    $results[] = 'INT_KEY:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'INT_KEY:blocked';
+}
+
+try {
+    frankenphp_set_vars(['nested' => ['a' => 1, 'b' => [true, null]]]);
+    $results[] = 'NESTED:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'NESTED:blocked';
+}
+
+try {
+    frankenphp_set_vars(['KEY' => new \stdClass()]);
+    $results[] = 'OBJECT:allowed';
+} catch (\ValueError $e) {
+    $results[] = 'OBJECT:blocked';
+}
+
+try {
+    $ref = 'hello';
+    $arr = ['KEY' => &$ref];
+    frankenphp_set_vars($arr);
+    $results[] = 'REFERENCE:allowed';
+} catch (\ValueError $e) {
+    $results[] = 'REFERENCE:blocked';
+}
+
+frankenphp_set_vars([
+    'status' => BgTestStatus::Active,
+    'RESULTS' => implode(',', $results),
+]);
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -1,0 +1,250 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/dunglas/frankenphp/internal/state"
+)
+
+// backgroundWorkerThread handles background worker scripts. Owns its own
+// lifecycle: boot, loop, optionally crash-restart with exponential backoff.
+// Background workers share the PHP runtime with HTTP threads but don't
+// serve HTTP requests. They expose a stop pipe (via
+// frankenphp_get_worker_handle) so PHP scripts can park on stream_select
+// and exit gracefully when FrankenPHP drains them.
+type backgroundWorkerThread struct {
+	state                  *state.ThreadState
+	thread                 *phpThread
+	worker                 *worker
+	dummyFrankenPHPContext *frankenPHPContext
+	dummyContext           context.Context
+	failureCount           int
+
+	// runtimeName is the worker identity (kept m#-prefixed for metric
+	// label consistency); setupScript trims it at the PHP boundary.
+	runtimeName string
+	// backgroundReady is this thread's readiness slot: worker.backgroundReady
+	// for named workers, worker.catchAllNames[runtimeName] for catch-all
+	// threads (so boot-failure / abort / markReady stay per-name).
+	backgroundReady *backgroundWorkerState
+
+	// stopFdWrite is this thread's stop-pipe write end (per-thread so pool
+	// workers drain independently); read end is exposed to PHP via
+	// frankenphp_get_worker_handle().
+	stopFdWrite atomic.Int32
+}
+
+func convertToBackgroundWorkerThread(thread *phpThread, worker *worker, runtimeName string, ready *backgroundWorkerState) {
+	handler := &backgroundWorkerThread{
+		state:           thread.state,
+		thread:          thread,
+		worker:          worker,
+		runtimeName:     runtimeName,
+		backgroundReady: ready,
+	}
+	handler.stopFdWrite.Store(-1)
+	thread.setHandler(handler)
+	worker.attachThread(thread)
+}
+
+func (handler *backgroundWorkerThread) scopedWorker() *worker { return handler.worker }
+
+func (handler *backgroundWorkerThread) name() string {
+	if handler.runtimeName != "" && handler.runtimeName != handler.worker.name {
+		return "Background Worker PHP Thread - " + handler.worker.fileName + " (" + handler.runtimeName + ")"
+	}
+	return "Background Worker PHP Thread - " + handler.worker.fileName
+}
+
+// isPostBoot samples the readiness channel non-blockingly so
+// afterScriptExecution can tell a boot crash (record bootFailureInfo) from
+// a post-boot crash (ensure() callers already saw success).
+func (handler *backgroundWorkerThread) isPostBoot() bool {
+	if handler.backgroundReady == nil {
+		return false
+	}
+	select {
+	case <-handler.backgroundReady.ready:
+		return true
+	default:
+		return false
+	}
+}
+
+func (handler *backgroundWorkerThread) frankenPHPContext() *frankenPHPContext {
+	return handler.dummyFrankenPHPContext
+}
+
+func (handler *backgroundWorkerThread) context() context.Context {
+	if handler.dummyContext != nil {
+		return handler.dummyContext
+	}
+	return globalCtx
+}
+
+// drain is called by drainWorkerThreads (and thread.shutdown) right before
+// drainChan is closed. We close the stop-pipe's write end so the PHP worker
+// script, which is typically parked in stream_select on the read end, wakes
+// up and can finish its loop gracefully. Per-thread fd so pool workers
+// drain their threads independently.
+func (handler *backgroundWorkerThread) drain() {
+	if fd := handler.stopFdWrite.Swap(-1); fd >= 0 {
+		C.frankenphp_worker_close_fd(C.int(fd))
+	}
+}
+
+func (handler *backgroundWorkerThread) beforeScriptExecution() string {
+	switch handler.state.Get() {
+	case state.TransitionRequested:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return handler.thread.transitionToNewHandler()
+	case state.Restarting:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.state.Set(state.Yielding)
+		handler.state.WaitFor(state.Ready, state.ShuttingDown)
+		return handler.beforeScriptExecution()
+	case state.Ready, state.TransitionComplete:
+		handler.thread.updateContext(true)
+		if handler.worker.onThreadReady != nil {
+			handler.worker.onThreadReady(handler.thread.threadIndex)
+		}
+
+		handler.setupScript()
+
+		return handler.worker.fileName
+	case state.ShuttingDown:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return ""
+	}
+
+	panic("unexpected state: " + handler.state.Name())
+}
+
+func (handler *backgroundWorkerThread) setupScript() {
+	if handler.runtimeName == "" {
+		handler.runtimeName = handler.worker.name
+	}
+	metrics.StartWorker(bgWorkerMetricName(handler.worker.scope, handler.runtimeName))
+
+	opts := append([]RequestOption(nil), handler.worker.requestOptions...)
+	handler.stopFdWrite.Store(int32(C.frankenphp_set_background_worker_and_get_stop_fd_write()))
+
+	fc, err := newDummyContext(
+		filepath.Base(handler.worker.fileName),
+		opts...,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.WithValue(globalCtx, contextKey, fc)
+
+	fc.worker = handler.worker
+	handler.dummyFrankenPHPContext = fc
+	handler.dummyContext = ctx
+
+	if globalLogger.Enabled(ctx, slog.LevelDebug) {
+		globalLogger.LogAttrs(ctx, slog.LevelDebug, "starting background worker", slog.String("worker", handler.runtimeName), slog.Int("thread", handler.thread.threadIndex))
+	}
+
+	handler.thread.state.Set(state.Ready)
+	fc.scriptFilename = handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
+	// frankenphp_worker_get_stop_fd_write transferred fd ownership to Go,
+	// so we must close on every exit path to avoid a leak.
+	if fd := handler.stopFdWrite.Swap(-1); fd >= 0 {
+		C.frankenphp_worker_close_fd(C.int(fd))
+	}
+	worker := handler.worker
+	runtimeName := handler.runtimeName
+	if runtimeName == "" {
+		runtimeName = worker.name
+	}
+	handler.dummyFrankenPHPContext = nil
+	handler.dummyContext = nil
+
+	// During Shutdown the drain's force-kill is armed against one slot; a
+	// freshly spawned pthread would re-enter the script and never exit.
+	if mainThread != nil && mainThread.state.Is(state.ShuttingDown) {
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	metricName := bgWorkerMetricName(worker.scope, runtimeName)
+
+	// Cooperative exit: re-run, reset backoff.
+	if exitStatus == 0 {
+		metrics.StopWorker(metricName, StopReasonRestart)
+
+		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting background worker", slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
+		}
+
+		handler.failureCount = 0
+		return
+	}
+
+	metrics.StopWorker(metricName, StopReasonCrash)
+
+	// Pre-readiness crash: stash metadata for a timing-out ensure(). Post-
+	// readiness crashes don't update this (the worker already signalled OK).
+	if !handler.isPostBoot() && handler.backgroundReady != nil {
+		handler.backgroundReady.bootFailure.Store(&bootFailureInfo{
+			entrypoint:   worker.fileName,
+			exitStatus:   exitStatus,
+			failureCount: handler.failureCount + 1,
+			// TODO(sidekicks): capture PG(last_error_message) here once
+			// the C-side helper lands in the set_vars/get_vars step.
+		})
+	}
+
+	// max_consecutive_failures cap. For single-instance bg workers,
+	// abort and release the slot so a future ensure() can lazy-spawn a
+	// fresh thread. Eager pools skip this: other pool threads may still
+	// be alive.
+	if worker.maxConsecutiveFailures >= 0 && handler.failureCount >= worker.maxConsecutiveFailures {
+		isSingleInstance := worker.bg.catchAllNames != nil || worker.num == 0
+		if isSingleInstance && handler.backgroundReady != nil {
+			handler.backgroundReady.abort(fmt.Errorf("background worker %s exceeded max_consecutive_failures (%d, last exit status %d)", worker.fileName, worker.maxConsecutiveFailures, exitStatus))
+			worker.invalidateBackgroundEntry(runtimeName)
+		}
+		if startupFailChan != nil && !watcherIsEnabled {
+			startupFailChan <- fmt.Errorf("too many consecutive failures: background worker %s keeps crashing", worker.fileName)
+			handler.thread.state.Set(state.ShuttingDown)
+			return
+		}
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "background worker exceeded max_consecutive_failures, stopping respawn", slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount))
+		}
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+		globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "background worker crashed, restarting", slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount), slog.Int("exit_status", exitStatus))
+	}
+
+	backoffDuration := time.Duration(handler.failureCount*handler.failureCount*100) * time.Millisecond
+	if backoffDuration > time.Second {
+		backoffDuration = time.Second
+	}
+	handler.failureCount++
+	time.Sleep(backoffDuration)
+}

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -7,33 +7,95 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/dunglas/frankenphp/internal/state"
 )
 
+// backgroundWorkerState carries a bg-worker instance's shared vars and
+// combined readiness signal. ready closes only when BOTH markHandle (from
+// frankenphp_get_worker_handle) and markVars (from frankenphp_set_vars)
+// have fired. mu serialises writer/reader access to varsPtr so the C side
+// can pfree the old pointer safely after set_vars returns.
+type backgroundWorkerState struct {
+	varsPtr     unsafe.Pointer // *C.HashTable in persistent memory
+	mu          sync.RWMutex
+	varsVersion atomic.Uint64
+
+	ready      chan struct{}
+	closeReady sync.Once
+	hasHandle  atomic.Bool
+	hasVars    atomic.Bool
+
+	// aborted unblocks ensure() waiters when the start sequence is
+	// abandoned before reaching ready.
+	aborted   chan struct{}
+	abortOnce sync.Once
+	abortErr  error
+
+	// bootFailure carries a pre-readiness crash so a timing-out ensure()
+	// can surface it.
+	bootFailure atomic.Pointer[bootFailureInfo]
+}
+
+func newBackgroundWorkerState() *backgroundWorkerState {
+	return &backgroundWorkerState{
+		ready:   make(chan struct{}),
+		aborted: make(chan struct{}),
+	}
+}
+
+// markHandle / markVars fire on the first frankenphp_get_worker_handle()
+// and frankenphp_set_vars() calls respectively. ready closes once both
+// have fired. Both are idempotent.
+func (sk *backgroundWorkerState) markHandle() {
+	sk.hasHandle.Store(true)
+	sk.tryCloseReady()
+}
+
+func (sk *backgroundWorkerState) markVars() {
+	sk.hasVars.Store(true)
+	sk.tryCloseReady()
+}
+
+func (sk *backgroundWorkerState) tryCloseReady() {
+	if sk.hasHandle.Load() && sk.hasVars.Load() {
+		sk.closeReady.Do(func() { close(sk.ready) })
+	}
+}
+
+// abort wakes ensure() waiters when the start sequence is abandoned.
+// Idempotent.
+func (sk *backgroundWorkerState) abort(err error) {
+	sk.abortOnce.Do(func() {
+		sk.abortErr = err
+		close(sk.aborted)
+	})
+}
+
 // backgroundWorkerThread handles background worker scripts. Owns its own
-// lifecycle: boot, loop, optionally crash-restart with exponential backoff.
-// Background workers share the PHP runtime with HTTP threads but don't
-// serve HTTP requests. They expose a stop pipe (via
-// frankenphp_get_worker_handle) so PHP scripts can park on stream_select
-// and exit gracefully when FrankenPHP drains them.
+// lifecycle: boot, publish vars, loop, optionally crash-restart with
+// exponential backoff.
 type backgroundWorkerThread struct {
 	state                  *state.ThreadState
 	thread                 *phpThread
 	worker                 *worker
 	dummyFrankenPHPContext *frankenPHPContext
 	dummyContext           context.Context
+	isBootingScript        bool
 	failureCount           int
 
 	// runtimeName is the worker identity (kept m#-prefixed for metric
 	// label consistency); setupScript trims it at the PHP boundary.
 	runtimeName string
-	// backgroundReady is this thread's readiness slot: worker.backgroundReady
-	// for named workers, worker.catchAllNames[runtimeName] for catch-all
-	// threads (so boot-failure / abort / markReady stay per-name).
-	backgroundReady *backgroundWorkerState
+	// backgroundWorker is this thread's state slot (combined readiness +
+	// shared vars): worker.bg.ready for named workers,
+	// worker.bg.catchAllNames[runtimeName] for catch-all threads (so
+	// boot-failure / abort / markHandle / markVars stay per-name).
+	backgroundWorker *backgroundWorkerState
 
 	// stopFdWrite is this thread's stop-pipe write end (per-thread so pool
 	// workers drain independently); read end is exposed to PHP via
@@ -41,13 +103,13 @@ type backgroundWorkerThread struct {
 	stopFdWrite atomic.Int32
 }
 
-func convertToBackgroundWorkerThread(thread *phpThread, worker *worker, runtimeName string, ready *backgroundWorkerState) {
+func convertToBackgroundWorkerThread(thread *phpThread, worker *worker, runtimeName string, sk *backgroundWorkerState) {
 	handler := &backgroundWorkerThread{
-		state:           thread.state,
-		thread:          thread,
-		worker:          worker,
-		runtimeName:     runtimeName,
-		backgroundReady: ready,
+		state:            thread.state,
+		thread:           thread,
+		worker:           worker,
+		runtimeName:      runtimeName,
+		backgroundWorker: sk,
 	}
 	handler.stopFdWrite.Store(-1)
 	thread.setHandler(handler)
@@ -63,15 +125,15 @@ func (handler *backgroundWorkerThread) name() string {
 	return "Background Worker PHP Thread - " + handler.worker.fileName
 }
 
-// isPostBoot samples the readiness channel non-blockingly so
-// afterScriptExecution can tell a boot crash (record bootFailureInfo) from
-// a post-boot crash (ensure() callers already saw success).
+// isPostBoot samples the combined readiness channel (handle + set_vars)
+// non-blockingly so afterScriptExecution can tell a boot crash from a
+// post-boot crash.
 func (handler *backgroundWorkerThread) isPostBoot() bool {
-	if handler.backgroundReady == nil {
+	if handler.backgroundWorker == nil {
 		return false
 	}
 	select {
-	case <-handler.backgroundReady.ready:
+	case <-handler.backgroundWorker.ready:
 		return true
 	default:
 		return false
@@ -139,6 +201,9 @@ func (handler *backgroundWorkerThread) setupScript() {
 	if handler.runtimeName == "" {
 		handler.runtimeName = handler.worker.name
 	}
+	if handler.backgroundWorker == nil {
+		handler.backgroundWorker = handler.worker.bg.ready
+	}
 	metrics.StartWorker(bgWorkerMetricName(handler.worker.scope, handler.runtimeName))
 
 	opts := append([]RequestOption(nil), handler.worker.requestOptions...)
@@ -157,6 +222,7 @@ func (handler *backgroundWorkerThread) setupScript() {
 	fc.worker = handler.worker
 	handler.dummyFrankenPHPContext = fc
 	handler.dummyContext = ctx
+	handler.isBootingScript = true
 
 	if globalLogger.Enabled(ctx, slog.LevelDebug) {
 		globalLogger.LogAttrs(ctx, slog.LevelDebug, "starting background worker", slog.String("worker", handler.runtimeName), slog.Int("thread", handler.thread.threadIndex))
@@ -189,29 +255,38 @@ func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
 
 	metricName := bgWorkerMetricName(worker.scope, runtimeName)
 
-	// Cooperative exit: re-run, reset backoff.
-	if exitStatus == 0 {
+	// Cooperative exit: re-run.
+	if exitStatus == 0 && !handler.isBootingScript {
 		metrics.StopWorker(metricName, StopReasonRestart)
 
 		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
 			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting background worker", slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
 		}
 
-		handler.failureCount = 0
 		return
 	}
 
-	metrics.StopWorker(metricName, StopReasonCrash)
+	if handler.isBootingScript {
+		metrics.StopWorker(metricName, StopReasonBootFailure)
+	} else {
+		metrics.StopWorker(metricName, StopReasonCrash)
+	}
 
-	// Pre-readiness crash: stash metadata for a timing-out ensure(). Post-
-	// readiness crashes don't update this (the worker already signalled OK).
-	if !handler.isPostBoot() && handler.backgroundReady != nil {
-		handler.backgroundReady.bootFailure.Store(&bootFailureInfo{
+	// Pre-readiness crash: capture metadata (including PG(last_error_*)
+	// grabbed C-side before php_request_shutdown clears it) for a timing-
+	// out ensure(). Post-readiness crashes don't update this (the worker
+	// already signalled OK).
+	if handler.isBootingScript && !handler.isPostBoot() && handler.backgroundWorker != nil {
+		var phpError string
+		if cErr := C.frankenphp_get_last_php_error(); cErr != nil {
+			phpError = C.GoString(cErr)
+			C.free(unsafe.Pointer(cErr))
+		}
+		handler.backgroundWorker.bootFailure.Store(&bootFailureInfo{
 			entrypoint:   worker.fileName,
 			exitStatus:   exitStatus,
 			failureCount: handler.failureCount + 1,
-			// TODO(sidekicks): capture PG(last_error_message) here once
-			// the C-side helper lands in the set_vars/get_vars step.
+			phpError:     phpError,
 		})
 	}
 
@@ -221,12 +296,12 @@ func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
 	// be alive.
 	if worker.maxConsecutiveFailures >= 0 && handler.failureCount >= worker.maxConsecutiveFailures {
 		isSingleInstance := worker.bg.catchAllNames != nil || worker.num == 0
-		if isSingleInstance && handler.backgroundReady != nil {
-			handler.backgroundReady.abort(fmt.Errorf("background worker %s exceeded max_consecutive_failures (%d, last exit status %d)", worker.fileName, worker.maxConsecutiveFailures, exitStatus))
+		if isSingleInstance && handler.backgroundWorker != nil {
+			handler.backgroundWorker.abort(fmt.Errorf("background worker %s exceeded max_consecutive_failures (%d, last exit status %d)", worker.fileName, worker.maxConsecutiveFailures, exitStatus))
 			worker.invalidateBackgroundEntry(runtimeName)
 		}
 		if startupFailChan != nil && !watcherIsEnabled {
-			startupFailChan <- fmt.Errorf("too many consecutive failures: background worker %s keeps crashing", worker.fileName)
+			startupFailChan <- fmt.Errorf("too many consecutive failures: background worker %s has not reached frankenphp_set_vars()", worker.fileName)
 			handler.thread.state.Set(state.ShuttingDown)
 			return
 		}
@@ -238,7 +313,11 @@ func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
 	}
 
 	if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
-		globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "background worker crashed, restarting", slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount), slog.Int("exit_status", exitStatus))
+		msg := "background worker crashed, restarting"
+		if handler.isBootingScript {
+			msg = "background worker boot failed, restarting"
+		}
+		globalLogger.LogAttrs(globalCtx, slog.LevelWarn, msg, slog.String("worker", runtimeName), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount), slog.Int("exit_status", exitStatus))
 	}
 
 	backoffDuration := time.Duration(handler.failureCount*handler.failureCount*100) * time.Millisecond
@@ -247,4 +326,24 @@ func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
 	}
 	handler.failureCount++
 	time.Sleep(backoffDuration)
+}
+
+// markBackgroundReady fires on the first set_vars after each (re)boot:
+// clears the boot-failure record and marks the vars half of the combined
+// readiness signal. failureCount is intentionally NOT reset here — a
+// worker that reaches readiness and then crashes must still trip the
+// max_consecutive_failures cap; only cooperative exit (exit 0) zeroes
+// the counter. Idempotent within a boot.
+func (handler *backgroundWorkerThread) markBackgroundReady() {
+	if !handler.isBootingScript {
+		return
+	}
+
+	handler.isBootingScript = false
+	if handler.backgroundWorker != nil {
+		handler.backgroundWorker.bootFailure.Store(nil)
+		handler.backgroundWorker.markVars()
+	}
+
+	metrics.ReadyWorker(bgWorkerMetricName(handler.worker.scope, handler.runtimeName))
 }

--- a/threadinactive.go
+++ b/threadinactive.go
@@ -60,3 +60,5 @@ func (handler *inactiveThread) name() string {
 }
 
 func (handler *inactiveThread) drain() {}
+
+func (handler *inactiveThread) scopedWorker() *worker { return nil }

--- a/threadregular.go
+++ b/threadregular.go
@@ -85,6 +85,8 @@ func (handler *regularThread) name() string {
 
 func (handler *regularThread) drain() {}
 
+func (handler *regularThread) scopedWorker() *worker { return nil }
+
 func (handler *regularThread) waitForRequest() string {
 	// max_requests reached: restart the thread to clean up all ZTS state
 	if maxRequestsPerThread > 0 && handler.requestCount >= maxRequestsPerThread {

--- a/threadtasks_test.go
+++ b/threadtasks_test.go
@@ -81,6 +81,8 @@ func (handler *taskThread) name() string {
 
 func (handler *taskThread) drain() {}
 
+func (handler *taskThread) scopedWorker() *worker { return nil }
+
 func (handler *taskThread) waitForTasks() {
 	for {
 		select {

--- a/threadworker.go
+++ b/threadworker.go
@@ -105,6 +105,8 @@ func (handler *workerThread) name() string {
 	return "Worker PHP Thread - " + handler.worker.fileName
 }
 
+func (handler *workerThread) scopedWorker() *worker { return handler.worker }
+
 func (handler *workerThread) drain() {}
 
 func setupWorkerScript(handler *workerThread, worker *worker) {

--- a/worker.go
+++ b/worker.go
@@ -33,6 +33,10 @@ type worker struct {
 	onThreadReady          func(int)
 	onThreadShutdown       func(int)
 	queuedRequests         atomic.Int32
+	scope                  Scope
+	// bg, if non-nil, marks this as a background (non-HTTP) worker and
+	// holds its bg-specific lifecycle state.
+	bg *backgroundWorkerExtras
 }
 
 var (
@@ -57,18 +61,35 @@ func initWorkers(opt []workerOpt) error {
 	workersByName = make(map[string]*worker, len(opt))
 	workersByPath = make(map[string]*worker, len(opt))
 
-	for _, o := range opt {
+	declared := make([]*worker, len(opt))
+	for i, o := range opt {
 		w, err := newWorker(o)
 		if err != nil {
 			return err
 		}
 
 		totalThreadsToStart += w.num
+		declared[i] = w
 		workers = append(workers, w)
-		workersByName[w.name] = w
+		// Background workers are resolved per-scope via backgroundLookups
+		// so the same user-facing name can appear in multiple scopes
+		// without colliding in the global workersByName map.
+		if w.bg == nil {
+			workersByName[w.name] = w
+		}
 		if w.allowPathMatching {
 			workersByPath[w.fileName] = w
 		}
+	}
+
+	// Build the per-scope lookups (named + catch-all per scope). Each
+	// php_server block gets its own scope; the global/embed scope is 0.
+	// Each declaration registers in its scope's lookup so lazy-start
+	// siblings inherit the template options.
+	var err error
+	backgroundLookups, err = buildBackgroundWorkerLookups(declared, opt)
+	if err != nil {
+		return err
 	}
 
 	startupFailChan = make(chan error, totalThreadsToStart)
@@ -76,7 +97,11 @@ func initWorkers(opt []workerOpt) error {
 	for _, w := range workers {
 		for i := 0; i < w.num; i++ {
 			thread := getInactivePHPThread()
-			convertToWorkerThread(thread, w)
+			if w.bg != nil {
+				convertToBackgroundWorkerThread(thread, w, w.name, w.bg.ready)
+			} else {
+				convertToWorkerThread(thread, w)
+			}
 
 			workersReady.Go(func() {
 				thread.state.WaitFor(state.Ready, state.ShuttingDown, state.Done)
@@ -121,21 +146,32 @@ func newWorker(o workerOpt) (*worker, error) {
 	}
 
 	// workers that have a name starting with "m#" are module workers
-	// they can only be matched by their name, not by their path
-	allowPathMatching := !strings.HasPrefix(o.name, "m#")
+	// they can only be matched by their name, not by their path.
+	// Background workers are matched only by name, never by path, since
+	// they don't handle HTTP requests.
+	allowPathMatching := !strings.HasPrefix(o.name, "m#") && !o.isBackgroundWorker
 
-	if w := workersByPath[absFileName]; w != nil && allowPathMatching {
-		return w, fmt.Errorf("two workers cannot have the same filename: %q", absFileName)
-	}
-	if w := workersByName[o.name]; w != nil {
-		return w, fmt.Errorf("two workers cannot have the same name: %q", o.name)
+	// Background workers are matched only by name, never by path. Multiple
+	// named bg workers can share an entrypoint file; uniqueness is enforced
+	// per-scope via backgroundLookups, not at the global path level.
+	if !o.isBackgroundWorker {
+		if w := workersByPath[absFileName]; w != nil && allowPathMatching {
+			return w, fmt.Errorf("two workers cannot have the same filename: %q", absFileName)
+		}
+		// Background workers are resolved through per-scope lookups, not the
+		// global workersByName map; the same user-facing name can appear in
+		// multiple php_server scopes without collision.
+		if w := workersByName[o.name]; w != nil {
+			return w, fmt.Errorf("two workers cannot have the same name: %q", o.name)
+		}
 	}
 
 	if o.env == nil {
-		o.env = make(PreparedEnv, 1)
+		o.env = make(PreparedEnv)
 	}
 
-	o.env["FRANKENPHP_WORKER\x00"] = "1"
+	// $_SERVER['FRANKENPHP_WORKER'] is populated downstream from
+	// fc.worker.name via frankenphp_register_server_vars.
 	w := &worker{
 		name:                   o.name,
 		fileName:               absFileName,
@@ -148,10 +184,17 @@ func newWorker(o workerOpt) (*worker, error) {
 		maxConsecutiveFailures: o.maxConsecutiveFailures,
 		onThreadReady:          o.onThreadReady,
 		onThreadShutdown:       o.onThreadShutdown,
+		scope:                  o.scope,
+	}
+	if o.isBackgroundWorker {
+		w.bg = &backgroundWorkerExtras{ready: newBackgroundWorkerState()}
 	}
 
 	w.configureMercure(&o)
 
+	// o.env is shared by reference across instances; treat it as
+	// read-only after init. Deep-clone if per-instance env is ever
+	// needed.
 	w.requestOptions = append(
 		w.requestOptions,
 		WithRequestDocumentRoot(filepath.Dir(o.fileName), false),
@@ -172,9 +215,16 @@ var drainGracePeriod = 30 * time.Second
 // Blocks until every drained thread yields. Force-kill is armed after a
 // grace period to wake threads parked in blocking syscalls (sleep, I/O).
 func DrainWorkers() {
+	// Defensive RLock paired with RestartWorkers' scalingMu.Lock to
+	// guard against future runtime mutators of the workers slice.
+	scalingMu.RLock()
+	defer scalingMu.RUnlock()
 	_ = drainWorkerThreads()
 }
 
+// drainWorkerThreads walks the global workers slice. The caller must
+// ensure no concurrent mutation of the slice (either hold scalingMu or
+// be called from a context where scaling is paused).
 func drainWorkerThreads() (drainedThreads []*phpThread) {
 	var ready sync.WaitGroup
 
@@ -253,6 +303,27 @@ func (worker *worker) attachThread(thread *phpThread) {
 	worker.threadMutex.Lock()
 	worker.threads = append(worker.threads, thread)
 	worker.threadMutex.Unlock()
+}
+
+// invalidateBackgroundEntry releases the registry slot held by a bg
+// worker exiting on max_consecutive_failures so a future ensure() can
+// lazy-spawn a fresh thread. Single-instance only (catch-all instances,
+// lazy named).
+func (worker *worker) invalidateBackgroundEntry(name string) {
+	bg := worker.bg
+	if bg.catchAllNames != nil {
+		bg.catchAllMu.Lock()
+		delete(bg.catchAllNames, name)
+		bg.catchAllMu.Unlock()
+		return
+	}
+	if worker.num == 0 {
+		// Fresh slot so the retry isn't poisoned by the prior abort.
+		bg.lazyMu.Lock()
+		bg.ready = newBackgroundWorkerState()
+		bg.lazyStarted = false
+		bg.lazyMu.Unlock()
+	}
 }
 
 func (worker *worker) detachThread(thread *phpThread) {

--- a/worker.go
+++ b/worker.go
@@ -190,6 +190,10 @@ func newWorker(o workerOpt) (*worker, error) {
 		w.bg = &backgroundWorkerExtras{ready: newBackgroundWorkerState()}
 	}
 
+	// backgroundWorker state is reserved lazily via the registry at
+	// thread-setup time, not here; lazy-start callers set it directly
+	// and eager inits go through setupScript's sync.Once.
+
 	w.configureMercure(&o)
 
 	// o.env is shared by reference across instances; treat it as


### PR DESCRIPTION
> [!NOTE]
> Description updated to reflect the latest pushes. API names and semantics are final pending review; see the thread for the back-and-forth that led here.

## Summary

Background workers are long-running PHP workers that run outside the HTTP cycle. They observe their environment (Redis, DB, filesystem, etc.) and publish variables that HTTP threads (workers or classic requests) read per-request, enabling real-time reconfiguration without restarts or polling.

### PHP API

Four functions:

- **`frankenphp_ensure_background_worker(string|array $name, float $timeout = 30.0): void`** — declares a dependency on one or more background workers. Lazy-starts them if needed, blocks until each has called `set_vars()` at least once or the timeout expires. Two behaviors depending on caller:
  - **HTTP worker bootstrap** (before `frankenphp_handle_request`): fail-fast. Any boot failure throws immediately with the captured details instead of waiting for the backoff cycle. Use for strict dependency declaration at boot.
  - **Everywhere else** (inside `frankenphp_handle_request`, classic request-per-process): tolerant lazy-start. First caller pays the startup cost; later callers see the worker already reserved. Processes only start workers they actually exercise.
- **`frankenphp_set_vars(array $vars): void`** — publishes vars from a background worker script (persistent memory, cross-thread). Skips all work when data is unchanged (`===` check).
- **`frankenphp_get_vars(string $name): array`** — pure read. Returns the latest published vars. Throws if the worker isn't running or hasn't called `set_vars()` yet. Generational cache: repeated calls within a single HTTP request return the same array instance (`===` is O(1)).
- **`frankenphp_get_worker_handle(): resource`** — readable stream for shutdown signaling. Closed on shutdown (EOF).

In CLI mode (`frankenphp php-cli`), none of these functions are exposed (MINIT-level hiding via `zend_hash_str_del`). `function_exists()` returns `false`, so library code can degrade gracefully.

### Caddyfile configuration

```caddyfile
php_server {
    # HTTP worker (unchanged)
    worker public/index.php { num 4 }

    # Named background worker (auto-started if num >= 1)
    worker bin/worker.php {
        background
        name config-watcher
        num 1
    }

    # Catch-all for lazy-started names
    worker bin/worker.php {
        background
    }
}
```

- `background` marks a worker as non-HTTP
- `name` specifies an exact worker name; workers without `name` are catch-all for lazy-started names
- Not declaring a catch-all forbids lazy-started ones
- `max_threads` on catch-all sets a safety cap for lazy-started instances (defaults to 16)
- `max_consecutive_failures` defaults to 6 (same as HTTP workers)
- `max_execution_time` automatically disabled for background workers
- Each `php_server` block has its own isolated scope (opaque `BackgroundScope` type managed by `frankenphp.NextBackgroundWorkerScope()`)

### Shutdown

On restart/shutdown, the signaling stream is closed. Workers detect this via `fgets()` returning `false` (EOF). Workers have a 5-second grace period. In-flight `ensure_background_worker` calls unblock on `globalCtx.Done()` instead of waiting out their timeout.

After the grace period, a best-effort force-kill is attempted:
- **Linux ZTS**: arms PHP's own `max_execution_time` timer cross-thread via `timer_settime(EG(max_execution_timer_timer))`
- **Windows**: `CancelSynchronousIo` + `QueueUserAPC` interrupts blocking I/O and alertable waits
- **macOS**: no per-thread mechanism available; stuck threads are abandoned

During the restart window, `get_vars` returns the last published data (stale but available, kept in persistent memory across restarts). A warning is logged on crash.

### Boot-failure reporting

When a background worker fails before calling `set_vars`, `ensure_background_worker` throws a `RuntimeException` with the captured details: worker name, resolved entrypoint path, exit status, number of attempts, and the last PHP error (message, file, line) captured from `PG(last_error_*)`.

### Forward compatibility

The signaling stream is forward-compatible with the [PHP 8.6 poll API RFC](https://wiki.php.net/rfc/poll_api). `Poll::addReadable` accepts stream resources directly; code written today with `stream_select` will work on 8.6 with `Poll`, no API change needed.

### Architecture

- Per-`php_server` scope isolation via opaque `BackgroundScope` type. Internal registry is unexported.
- Dedicated `backgroundWorkerThread` handler implementing `threadHandler` interface, decoupled from HTTP worker code paths.
- `drain()` closes the signaling stream (EOF) for clean shutdown signaling.
- Persistent memory (`pemalloc`) with `RWMutex` for safe cross-thread sharing.
- `set_vars` skip: uses PHP's `===` (`zend_is_identical`) to detect unchanged data, skips validation, persistent copy, write lock, and version bump.
- Generational cache: per-thread version check skips lock + copy when data hasn't changed.
- Opcache immutable array zero-copy fast path (`IS_ARRAY_IMMUTABLE`).
- Interned string optimizations (`ZSTR_IS_INTERNED`): skip copy/free for shared-memory strings.
- Rich type support: null, scalars, arrays (nested), enums.
- Crash recovery with exponential backoff and automatic restart.
- `ensure_background_worker` accepts a batch of names with a shared deadline; fail-fast in bootstrap mode reports the failing worker's details.
- `$_SERVER['FRANKENPHP_WORKER_NAME']` set for background workers.
- `$_SERVER['FRANKENPHP_WORKER_BACKGROUND']` set for all workers (`true`/`false`).

### Example

```php
// Background worker: polls Redis every 5s
$stream = frankenphp_get_worker_handle();
$redis = new Redis();
$redis->connect('127.0.0.1');

while (true) {
    frankenphp_set_vars([
        'maintenance' => (bool) $redis->get('maintenance_mode'),
        'feature_flags' => json_decode($redis->get('features'), true),
    ]);
    $r = [$stream]; $w = $e = [];
    if (false === @stream_select($r, $w, $e, 5)) { break; }
    if ($r && false === fgets($stream)) { break; } // EOF = stop
}
```

```php
// HTTP worker
frankenphp_ensure_background_worker('config-watcher'); // bootstrap: fail-fast

while (frankenphp_handle_request(function () {
    $config = frankenphp_get_vars('config-watcher'); // pure read
    if ($config['maintenance']) {
        return new Response('Down for maintenance', 503);
    }
    // ...
})) { gc_collect_cycles(); }
```

```php
// Classic non-worker mode
frankenphp_ensure_background_worker('config-watcher'); // tolerant lazy-start
$config = frankenphp_get_vars('config-watcher');
```

### Test coverage

Unit tests, integration tests, and one Caddy integration test covering: bootstrap fail-fast, runtime tolerant lazy-start, multi-name ensure, get_vars pure read, set_vars validation (types, objects, refs), CLI function hiding, enum support, binary-safe strings, multiple entrypoints, crash-restart reclassification, boot-failure rich errors, signaling stream, worker restart lifecycle, named auto-start with `m#` prefix, edge cases (empty name, negative timeout, timeout=0).

All tests pass on PHP 8.2, 8.3, 8.4, and 8.5 with `-race`. Zero memory leaks on PHP debug builds.

### Documentation

Full docs at `docs/background-workers.md`.