### PR TITLE
feat: add task API for bidirectional background worker communication

### DIFF
--- a/background_worker.go
+++ b/background_worker.go
@@ -163,6 +163,8 @@ func (registry *backgroundWorkerRegistry) reserve(name string) (*backgroundWorke
 
 	bgw := &backgroundWorkerState{
 		ready: make(chan struct{}),
+		tasks: make(chan *taskRequest, 1), // buffer=1: backpressure with signaling
+		dead:  make(chan struct{}),
 	}
 	registry.workers[name] = bgw
 
@@ -176,6 +178,9 @@ func (registry *backgroundWorkerRegistry) remove(name string, bgw *backgroundWor
 	if registry.workers[name] == bgw {
 		delete(registry.workers, name)
 	}
+
+	// Signal waiting senders that this worker is gone
+	bgw.deadOnce.Do(func() { close(bgw.dead) })
 }
 
 func startBackgroundWorker(thread *phpThread, bgWorkerName string) error {
@@ -225,6 +230,7 @@ func startBackgroundWorkerWithRegistry(registry *backgroundWorkerRegistry, bgWor
 	worker.isBackgroundWorker = true
 	worker.backgroundWorker = bgw
 	worker.backgroundRegistry = registry
+	bgw.fds = &worker.backgroundFds
 
 	for i := 0; i < numThreads; i++ {
 		bgWorkerThread := getInactivePHPThread()

--- a/background_worker.go
+++ b/background_worker.go
@@ -1,0 +1,391 @@
+package frankenphp
+
+// #include <stdint.h>
+// #include "frankenphp.h"
+import "C"
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+var backgroundScopeCounter atomic.Uint64
+
+// NextBackgroundWorkerScope returns a unique scope ID for background worker isolation.
+// Each php_server block should call this once during provisioning.
+func NextBackgroundWorkerScope() string {
+	return fmt.Sprintf("php_server_%d", backgroundScopeCounter.Add(1))
+}
+
+// defaultMaxBackgroundWorkers is the default safety cap for catch-all background workers.
+const defaultMaxBackgroundWorkers = 16
+
+// backgroundLookups maps scope IDs to their background worker lookups.
+// Each php_server block gets its own scope. The global frankenphp block
+// uses the empty string as its scope ID.
+var backgroundLookups map[string]*backgroundWorkerLookup
+
+// backgroundWorkerLookup maps worker names to registries, enabling multiple entrypoint files.
+type backgroundWorkerLookup struct {
+	byName   map[string]*backgroundWorkerRegistry
+	catchAll *backgroundWorkerRegistry
+}
+
+func newBackgroundWorkerLookup() *backgroundWorkerLookup {
+	return &backgroundWorkerLookup{
+		byName: make(map[string]*backgroundWorkerRegistry),
+	}
+}
+
+func (l *backgroundWorkerLookup) AddNamed(name string, registry *backgroundWorkerRegistry) {
+	l.byName[name] = registry
+}
+
+func (l *backgroundWorkerLookup) SetCatchAll(registry *backgroundWorkerRegistry) {
+	l.catchAll = registry
+}
+
+// Resolve returns the registry for the given name, falling back to catch-all.
+func (l *backgroundWorkerLookup) Resolve(name string) *backgroundWorkerRegistry {
+	if r, ok := l.byName[name]; ok {
+		return r
+	}
+	return l.catchAll
+}
+
+type backgroundWorkerRegistry struct {
+	entrypoint     string
+	num            int      // threads per background worker (0 = lazy-start with 1 thread)
+	maxWorkers     int      // max lazy-started instances (0 = unlimited)
+	autoStartNames []string // names to start at boot when num >= 1
+	mu             sync.Mutex
+	workers        map[string]*backgroundWorkerState
+}
+
+func newBackgroundWorkerRegistry(entrypoint string) *backgroundWorkerRegistry {
+	return &backgroundWorkerRegistry{
+		entrypoint: entrypoint,
+		workers:    make(map[string]*backgroundWorkerState),
+	}
+}
+
+func (registry *backgroundWorkerRegistry) MaxThreads() int {
+	if registry.num > 0 {
+		return registry.num
+	}
+	return 1
+}
+
+func (registry *backgroundWorkerRegistry) SetNum(num int) {
+	registry.num = num
+}
+
+func (registry *backgroundWorkerRegistry) AddAutoStartNames(names ...string) {
+	registry.autoStartNames = append(registry.autoStartNames, names...)
+}
+
+func (registry *backgroundWorkerRegistry) SetMaxWorkers(max int) {
+	registry.maxWorkers = max
+}
+
+// buildBackgroundWorkerLookups constructs per-scope background worker lookups
+// from worker options. Each scope (php_server block) gets its own lookup.
+func buildBackgroundWorkerLookups(workers []*worker, opts []workerOpt) map[string]*backgroundWorkerLookup {
+	lookups := make(map[string]*backgroundWorkerLookup)
+	scopeRegistries := make(map[string]map[string]*backgroundWorkerRegistry)
+
+	for i, o := range opts {
+		if !o.isBackgroundWorker {
+			continue
+		}
+
+		scope := o.backgroundScope
+		lookup, ok := lookups[scope]
+		if !ok {
+			lookup = newBackgroundWorkerLookup()
+			lookups[scope] = lookup
+			scopeRegistries[scope] = make(map[string]*backgroundWorkerRegistry)
+		}
+
+		entrypoint := o.fileName
+		registry, ok := scopeRegistries[scope][entrypoint]
+		if !ok {
+			registry = newBackgroundWorkerRegistry(entrypoint)
+			scopeRegistries[scope][entrypoint] = registry
+		}
+
+		workers[i].backgroundScope = scope
+
+		w := workers[i]
+		phpName := strings.TrimPrefix(w.name, "m#")
+		if phpName != "" && phpName != w.fileName {
+			// Named background worker
+			if o.num > 0 {
+				registry.AddAutoStartNames(phpName)
+				registry.SetNum(o.num)
+			}
+			lookup.AddNamed(phpName, registry)
+		} else {
+			// Catch-all background worker; maxThreads > 1 means user set it explicitly
+			maxW := defaultMaxBackgroundWorkers
+			if o.maxThreads > 1 {
+				maxW = o.maxThreads
+			}
+			registry.SetMaxWorkers(maxW)
+			lookup.SetCatchAll(registry)
+		}
+
+		w.backgroundRegistry = registry
+	}
+
+	if len(lookups) == 0 {
+		return nil
+	}
+
+	return lookups
+}
+
+func (registry *backgroundWorkerRegistry) reserve(name string) (*backgroundWorkerState, bool, error) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if bgw := registry.workers[name]; bgw != nil {
+		return bgw, true, nil
+	}
+
+	if registry.maxWorkers > 0 && len(registry.workers) >= registry.maxWorkers {
+		return nil, false, fmt.Errorf("cannot start background worker %q: limit of %d reached - increase max_threads on the catch-all background worker or declare it as a named worker", name, registry.maxWorkers)
+	}
+
+	bgw := &backgroundWorkerState{
+		ready: make(chan struct{}),
+	}
+	registry.workers[name] = bgw
+
+	return bgw, false, nil
+}
+
+func (registry *backgroundWorkerRegistry) remove(name string, bgw *backgroundWorkerState) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if registry.workers[name] == bgw {
+		delete(registry.workers, name)
+	}
+}
+
+func startBackgroundWorker(thread *phpThread, bgWorkerName string) error {
+	if bgWorkerName == "" {
+		return fmt.Errorf("background worker name must not be empty")
+	}
+
+	lookup := getLookup(thread)
+	if lookup == nil {
+		return fmt.Errorf("no background worker configured in this php_server")
+	}
+
+	registry := lookup.Resolve(bgWorkerName)
+	if registry == nil || registry.entrypoint == "" {
+		return fmt.Errorf("no background worker configured in this php_server")
+	}
+
+	return startBackgroundWorkerWithRegistry(registry, bgWorkerName)
+}
+
+func startBackgroundWorkerWithRegistry(registry *backgroundWorkerRegistry, bgWorkerName string) error {
+	bgw, exists, err := registry.reserve(bgWorkerName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	numThreads := registry.MaxThreads()
+
+	worker, err := newWorker(workerOpt{
+		name:                   bgWorkerName,
+		fileName:               registry.entrypoint,
+		num:                    numThreads,
+		isBackgroundWorker:     true,
+		env:                    PrepareEnv(nil),
+		watch:                  []string{},
+		maxConsecutiveFailures: -1,
+	})
+	if err != nil {
+		registry.remove(bgWorkerName, bgw)
+
+		return fmt.Errorf("failed to create background worker: %w", err)
+	}
+
+	worker.isBackgroundWorker = true
+	worker.backgroundWorker = bgw
+	worker.backgroundRegistry = registry
+
+	for i := 0; i < numThreads; i++ {
+		bgWorkerThread := getInactivePHPThread()
+		if bgWorkerThread == nil {
+			if i == 0 {
+				registry.remove(bgWorkerName, bgw)
+			}
+
+			return fmt.Errorf("no available PHP thread for background worker (increase max_threads)")
+		}
+
+		scalingMu.Lock()
+		workers = append(workers, worker)
+		scalingMu.Unlock()
+
+		convertToBackgroundWorkerThread(bgWorkerThread, worker)
+	}
+
+	if globalLogger.Enabled(globalCtx, slog.LevelInfo) {
+		globalLogger.LogAttrs(globalCtx, slog.LevelInfo, "background worker started", slog.String("name", bgWorkerName), slog.Int("threads", numThreads))
+	}
+
+	return nil
+}
+
+func getLookup(thread *phpThread) *backgroundWorkerLookup {
+	if handler, ok := thread.handler.(*workerThread); ok && handler.worker.backgroundLookup != nil {
+		return handler.worker.backgroundLookup
+	}
+	if handler, ok := thread.handler.(*backgroundWorkerThread); ok && handler.worker.backgroundLookup != nil {
+		return handler.worker.backgroundLookup
+	}
+	// Non-worker requests: resolve scope from context
+	if fc, ok := fromContext(thread.context()); ok && fc.backgroundScope != "" {
+		if backgroundLookups != nil {
+			return backgroundLookups[fc.backgroundScope]
+		}
+	}
+	// Fall back to global scope
+	if backgroundLookups != nil {
+		return backgroundLookups[""]
+	}
+
+	return nil
+}
+
+// go_frankenphp_worker_get_vars starts background workers if needed, waits for them
+// to be ready, takes read locks, copies vars via C helper, and releases locks.
+// All locking/unlocking happens within this single Go call.
+//
+// callerVersions/outVersions: if callerVersions is non-nil and all versions match,
+// the copy is skipped entirely (returns 1). outVersions receives current versions.
+//
+//export go_frankenphp_worker_get_vars
+func go_frankenphp_worker_get_vars(threadIndex C.uintptr_t, names **C.char, nameLens *C.size_t, nameCount C.int, timeoutMs C.int, returnValue *C.zval, callerVersions *C.uint64_t, outVersions *C.uint64_t) *C.char {
+	thread := phpThreads[threadIndex]
+	lookup := getLookup(thread)
+	if lookup == nil {
+		return C.CString("no background worker configured in this php_server")
+	}
+
+	n := int(nameCount)
+	nameSlice := unsafe.Slice(names, n)
+	nameLenSlice := unsafe.Slice(nameLens, n)
+
+	sks := make([]*backgroundWorkerState, n)
+	goNames := make([]string, n)
+	for i := 0; i < n; i++ {
+		goNames[i] = C.GoStringN(nameSlice[i], C.int(nameLenSlice[i]))
+
+		// Start background worker if not already running
+		if err := startBackgroundWorker(thread, goNames[i]); err != nil {
+			return C.CString(err.Error())
+		}
+
+		registry := lookup.Resolve(goNames[i])
+		if registry == nil {
+			return C.CString("background worker not found: " + goNames[i])
+		}
+		registry.mu.Lock()
+		sks[i] = registry.workers[goNames[i]]
+		registry.mu.Unlock()
+		if sks[i] == nil {
+			return C.CString("background worker not found: " + goNames[i])
+		}
+	}
+
+	// Wait for all workers to be ready (shared deadline across all workers)
+	deadline := time.After(time.Duration(timeoutMs) * time.Millisecond)
+	for i, sk := range sks {
+		select {
+		case <-sk.ready:
+			// background worker has called set_vars
+		case <-deadline:
+			return C.CString(fmt.Sprintf("timeout waiting for background worker: %s", goNames[i]))
+		}
+	}
+
+	// Fast path: if all caller versions match, skip lock + copy entirely.
+	// Read each version once and write to outVersions for the C side to compare.
+	if callerVersions != nil && outVersions != nil {
+		callerVSlice := unsafe.Slice(callerVersions, n)
+		outVSlice := unsafe.Slice(outVersions, n)
+		allMatch := true
+		for i, sk := range sks {
+			v := sk.varsVersion.Load()
+			outVSlice[i] = C.uint64_t(v)
+			if uint64(callerVSlice[i]) != v {
+				allMatch = false
+			}
+		}
+		if allMatch {
+			return nil // C side sees out == caller, uses cached value
+		}
+	}
+
+	// Take all read locks, collect pointers, copy via C helper, then release
+	ptrs := make([]unsafe.Pointer, n)
+	for i, sk := range sks {
+		sk.mu.RLock()
+		ptrs[i] = sk.varsPtr
+	}
+
+	C.frankenphp_worker_copy_vars(returnValue, C.int(n), names, nameLens, (*unsafe.Pointer)(unsafe.Pointer(&ptrs[0])))
+
+	// Write versions while locks are still held
+	if outVersions != nil {
+		outVSlice := unsafe.Slice(outVersions, n)
+		for i, sk := range sks {
+			outVSlice[i] = C.uint64_t(sk.varsVersion.Load())
+		}
+	}
+
+	for _, sk := range sks {
+		sk.mu.RUnlock()
+	}
+
+	return nil
+}
+
+//export go_frankenphp_worker_set_vars
+func go_frankenphp_worker_set_vars(threadIndex C.uintptr_t, varsPtr unsafe.Pointer, oldPtr *unsafe.Pointer) *C.char {
+	thread := phpThreads[threadIndex]
+
+	bgHandler, ok := thread.handler.(*backgroundWorkerThread)
+	if !ok || bgHandler.worker.backgroundWorker == nil {
+		return C.CString("frankenphp_worker_set_vars() can only be called from a background worker")
+	}
+
+	sk := bgHandler.worker.backgroundWorker
+
+	sk.mu.Lock()
+	*oldPtr = sk.varsPtr
+	sk.varsPtr = varsPtr
+	sk.varsVersion.Add(1)
+	sk.mu.Unlock()
+
+	sk.readyOnce.Do(func() {
+		bgHandler.markBackgroundReady()
+		close(sk.ready)
+	})
+
+	return nil
+}

--- a/background_worker_task.go
+++ b/background_worker_task.go
@@ -1,0 +1,377 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// drainPendingTasks closes all queued tasks so waiting senders get EOF.
+// Called when the background worker exits.
+func (s *backgroundWorkerState) drainPendingTasks() {
+	for {
+		select {
+		case task := <-s.tasks:
+			task.crashDrain()
+		default:
+			return
+		}
+	}
+}
+
+// taskRequest represents a task sent from an HTTP worker to a background worker.
+type taskRequest struct {
+	id          int            // registered once in task_send, shared by both sides
+	payload     unsafe.Pointer // persistent C HashTable, owned by sender
+	fifo        *taskFIFO      // bounded FIFO for results/progress
+	pipeFds     [2]int         // [0]=read (sender), [1]=write (background worker)
+	cancelled   atomic.Bool    // set when sender cancels before background worker picks up
+	closedSides atomic.Int32   // 0->1 by first closer, 1->2 triggers freeTask
+}
+
+// retire increments closedSides. When both sides have closed, frees the task slot.
+func (t *taskRequest) retire() {
+	if t.closedSides.Add(1) == 2 {
+		freeTask(t.id)
+	}
+}
+
+// closeBackgroundWorker is called when the background worker fcloses the task stream (clean completion).
+func (t *taskRequest) closeBackgroundWorker() {
+	t.fifo.close()
+	C.frankenphp_worker_close_fd(C.int(t.pipeFds[1]))
+	t.retire()
+}
+
+// abortBackgroundWorker is called when the background worker exits without closing the task stream.
+func (t *taskRequest) abortBackgroundWorker() {
+	t.fifo.abortClose()
+	C.frankenphp_worker_close_fd(C.int(t.pipeFds[1]))
+	t.retire()
+}
+
+// closeSender is called when the sender fcloses the task stream.
+func (t *taskRequest) closeSender() {
+	t.cancelled.Store(true)
+	t.fifo.drainAndFree()
+	t.retire()
+}
+
+// cancelBeforeDelivery is called in task_receive when a cancelled task is dequeued.
+func (t *taskRequest) cancelBeforeDelivery() {
+	C.frankenphp_worker_close_fd(C.int(t.pipeFds[1]))
+	C.frankenphp_worker_free_persistent_ht(t.payload)
+	freeTask(t.id)
+}
+
+// crashDrain is called by drainPendingTasks for queued tasks when the background worker exits.
+func (t *taskRequest) crashDrain() {
+	t.fifo.abortClose()
+	C.frankenphp_worker_close_fd(C.int(t.pipeFds[1]))
+	C.frankenphp_worker_free_persistent_ht(t.payload)
+	t.retire()
+}
+
+// taskFIFO is a bounded FIFO queue for task updates with backpressure.
+type taskFIFO struct {
+	items    []unsafe.Pointer // persistent C HashTables
+	mu       sync.Mutex
+	notFull  *sync.Cond
+	notEmpty *sync.Cond
+	max      int
+	closed   bool
+	aborted  bool // true if closed because the background worker exited without fclose
+}
+
+func newTaskFIFO(max int) *taskFIFO {
+	f := &taskFIFO{max: max}
+	f.notFull = sync.NewCond(&f.mu)
+	f.notEmpty = sync.NewCond(&f.mu)
+	return f
+}
+
+func (f *taskFIFO) push(item unsafe.Pointer) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for len(f.items) >= f.max && !f.closed {
+		f.notFull.Wait()
+	}
+	if f.closed {
+		return false
+	}
+	f.items = append(f.items, item)
+	f.notEmpty.Signal()
+	return true
+}
+
+// pop returns (item, true, false) on success, (nil, false, false) on clean close,
+// or (nil, false, true) if the FIFO was aborted (background worker exited without fclose).
+func (f *taskFIFO) pop() (unsafe.Pointer, bool, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for len(f.items) == 0 && !f.closed {
+		f.notEmpty.Wait()
+	}
+	if len(f.items) == 0 {
+		return nil, false, f.aborted
+	}
+	item := f.items[0]
+	f.items = f.items[1:]
+	f.notFull.Signal()
+	return item, true, false
+}
+
+func (f *taskFIFO) close() {
+	f.mu.Lock()
+	f.closed = true
+	f.notFull.Broadcast()
+	f.notEmpty.Broadcast()
+	f.mu.Unlock()
+}
+
+func (f *taskFIFO) abortClose() {
+	f.mu.Lock()
+	f.closed = true
+	f.aborted = true
+	f.notFull.Broadcast()
+	f.notEmpty.Broadcast()
+	f.mu.Unlock()
+}
+
+// drainAndFree closes the FIFO and frees all remaining persistent items.
+func (f *taskFIFO) drainAndFree() {
+	f.close()
+	f.mu.Lock()
+	items := f.items
+	f.items = nil
+	f.mu.Unlock()
+	for _, item := range items {
+		C.frankenphp_worker_free_persistent_ht(item)
+	}
+}
+
+// Task management: tasks are identified by an opaque ID (index into a global slice).
+// This avoids the problem of mapping file descriptors back to task state.
+var (
+	tasksMu    sync.Mutex
+	tasksSlice []*taskRequest
+	tasksFree  []int
+)
+
+func registerTask(t *taskRequest) int {
+	tasksMu.Lock()
+	defer tasksMu.Unlock()
+	if len(tasksFree) > 0 {
+		id := tasksFree[len(tasksFree)-1]
+		tasksFree = tasksFree[:len(tasksFree)-1]
+		tasksSlice[id] = t
+		return id
+	}
+	tasksSlice = append(tasksSlice, t)
+	return len(tasksSlice) - 1
+}
+
+func getTask(id int) *taskRequest {
+	tasksMu.Lock()
+	defer tasksMu.Unlock()
+	if id < 0 || id >= len(tasksSlice) {
+		return nil
+	}
+	return tasksSlice[id]
+}
+
+func freeTask(id int) {
+	tasksMu.Lock()
+	defer tasksMu.Unlock()
+	if id >= 0 && id < len(tasksSlice) {
+		tasksSlice[id] = nil
+		tasksFree = append(tasksFree, id)
+	}
+}
+
+//export go_frankenphp_worker_task_send
+func go_frankenphp_worker_task_send(threadIndex C.uintptr_t, name *C.char, nameLen C.size_t, payload unsafe.Pointer, timeoutMs C.int, outTaskId *C.int, outReadFd *C.int) *C.char {
+	bgWorkerName := C.GoStringN(name, C.int(nameLen))
+
+	thread := phpThreads[threadIndex]
+	if err := startBackgroundWorker(thread, bgWorkerName); err != nil {
+		return C.CString(err.Error())
+	}
+
+	lookup := getLookup(thread)
+	if lookup == nil {
+		return C.CString("no background worker configured in this php_server")
+	}
+
+	registry := lookup.Resolve(bgWorkerName)
+	if registry == nil {
+		return C.CString("background worker not found: " + bgWorkerName)
+	}
+
+	registry.mu.Lock()
+	sk := registry.workers[bgWorkerName]
+	registry.mu.Unlock()
+	if sk == nil {
+		return C.CString("background worker not found: " + bgWorkerName)
+	}
+
+	// Create pipe for result stream (C helper handles platform differences)
+	var pipeFds [2]C.int
+	pipeFds[0] = -1
+	pipeFds[1] = -1
+	C.frankenphp_worker_create_pipe(&pipeFds[0])
+	if pipeFds[0] < 0 {
+		return C.CString("failed to create task pipe")
+	}
+
+	task := &taskRequest{
+		payload: payload,
+		fifo:    newTaskFIFO(16),
+		pipeFds: [2]int{int(pipeFds[0]), int(pipeFds[1])},
+	}
+
+	taskId := registerTask(task)
+	task.id = taskId
+
+	// Block until the task is enqueued (buffer=1 provides backpressure),
+	// the worker dies, or the timeout expires. The sender blocks here if
+	// the previous task hasn't been picked up by task_receive yet.
+	timeout := time.Duration(timeoutMs) * time.Millisecond
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case sk.tasks <- task:
+		// enqueued - now signal the receiver via "task\n" on the signaling stream
+	case <-sk.dead:
+		freeTask(taskId)
+		C.frankenphp_worker_close_fd(pipeFds[0])
+		C.frankenphp_worker_close_fd(pipeFds[1])
+		return C.CString(fmt.Sprintf("background worker %q exited before receiving the task", bgWorkerName))
+	case <-timer.C:
+		freeTask(taskId)
+		C.frankenphp_worker_close_fd(pipeFds[0])
+		C.frankenphp_worker_close_fd(pipeFds[1])
+		return C.CString(fmt.Sprintf("timeout waiting for background worker %q to accept task", bgWorkerName))
+	}
+
+	// Signal all background worker threads via "task\n" - wakes up stream_select
+	if sk.fds != nil {
+		sk.fds.writeAll(func(fd int32) {
+			C.frankenphp_worker_write_task_signal(C.int(fd))
+		})
+	}
+
+	*outTaskId = C.int(taskId)
+	*outReadFd = pipeFds[0]
+
+	return nil
+}
+
+//export go_frankenphp_worker_task_receive
+func go_frankenphp_worker_task_receive(threadIndex C.uintptr_t, outPayload *unsafe.Pointer, outTaskId *C.int) C.int {
+	thread := phpThreads[threadIndex]
+	handler, ok := thread.handler.(*backgroundWorkerThread)
+	if !ok || handler.worker.backgroundWorker == nil {
+		return -1 // error: not a background worker
+	}
+
+	sk := handler.worker.backgroundWorker
+
+	// Non-blocking: return immediately if no task available.
+	// The PHP side uses stream_select on the signaling stream to wait for
+	// "task\n", then calls task_receive. Returns false on spurious signals.
+	select {
+	case task, ok := <-sk.tasks:
+		if !ok {
+			return 0 // channel closed, shutting down
+		}
+		if task.cancelled.Load() {
+			task.cancelBeforeDelivery()
+			return 0 // cancelled before delivery
+		}
+		handler.currentTask = task
+		*outPayload = task.payload
+		*outTaskId = C.int(task.id)
+		return 1 // success
+	default:
+		return 0 // no task available (spurious signal or fan-out contention)
+	}
+}
+
+//export go_frankenphp_worker_task_update
+func go_frankenphp_worker_task_update(taskId C.int, data unsafe.Pointer) *C.char {
+	task := getTask(int(taskId))
+	if task == nil {
+		return C.CString("invalid task ID")
+	}
+
+	if !task.fifo.push(data) {
+		return C.CString("task closed")
+	}
+
+	// Write 1 byte to pipe to wake up sender's stream_select
+	C.frankenphp_worker_pipe_nudge(C.int(task.pipeFds[1]))
+
+	return nil
+}
+
+// go_frankenphp_worker_task_close is called when the background worker's task stream is closed.
+// This fires on both explicit fclose() and implicit resource cleanup during script exit.
+// Marks the task as cleanly closed.
+//
+//export go_frankenphp_worker_task_close
+func go_frankenphp_worker_task_close(threadIndex C.uintptr_t, taskId C.int) {
+	task := getTask(int(taskId))
+	if task == nil {
+		return
+	}
+
+	task.closeBackgroundWorker()
+}
+
+// go_frankenphp_worker_task_cancel is called when the sender fcloses the task stream.
+// Drains the FIFO and retires the sender side.
+//
+//export go_frankenphp_worker_task_cancel
+func go_frankenphp_worker_task_cancel(taskId C.int) {
+	task := getTask(int(taskId))
+	if task == nil {
+		return
+	}
+
+	task.closeSender()
+}
+
+//export go_frankenphp_worker_task_read
+func go_frankenphp_worker_task_read(taskId C.int, outData *unsafe.Pointer) C.int {
+	task := getTask(int(taskId))
+	if task == nil {
+		return -1
+	}
+
+	// If outData is nil, caller just wants to drain remaining items (pipe EOF path).
+	// Don't retire here - task_cancel (stream close handler) is the sole sender-side retire.
+	if outData == nil {
+		task.fifo.drainAndFree()
+		if task.fifo.aborted {
+			return -2 // background worker exited without closing the task
+		}
+		return -1
+	}
+
+	data, ok, aborted := task.fifo.pop()
+	if !ok {
+		if aborted {
+			return -2 // background worker exited without closing the task
+		}
+		return -1 // FIFO closed and empty - clean EOF
+	}
+
+	*outData = data
+	return 0
+}

--- a/background_worker_test.go
+++ b/background_worker_test.go
@@ -1,0 +1,125 @@
+package frankenphp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type backgroundWorkerTestMetrics struct {
+	readyCalls int
+	stopCalls  []StopReason
+}
+
+func (m *backgroundWorkerTestMetrics) StartWorker(string) {}
+
+func (m *backgroundWorkerTestMetrics) ReadyWorker(string) {
+	m.readyCalls++
+}
+
+func (m *backgroundWorkerTestMetrics) StopWorker(_ string, reason StopReason) {
+	m.stopCalls = append(m.stopCalls, reason)
+}
+
+func (m *backgroundWorkerTestMetrics) TotalWorkers(string, int) {}
+
+func (m *backgroundWorkerTestMetrics) TotalThreads(int) {}
+
+func (m *backgroundWorkerTestMetrics) StartRequest() {}
+
+func (m *backgroundWorkerTestMetrics) StopRequest() {}
+
+func (m *backgroundWorkerTestMetrics) StopWorkerRequest(string, time.Duration) {}
+
+func (m *backgroundWorkerTestMetrics) StartWorkerRequest(string) {}
+
+func (m *backgroundWorkerTestMetrics) Shutdown() {}
+
+func (m *backgroundWorkerTestMetrics) QueuedWorkerRequest(string) {}
+
+func (m *backgroundWorkerTestMetrics) DequeuedWorkerRequest(string) {}
+
+func (m *backgroundWorkerTestMetrics) QueuedRequest() {}
+
+func (m *backgroundWorkerTestMetrics) DequeuedRequest() {}
+
+func TestStartBackgroundWorkerFailureIsRetryable(t *testing.T) {
+	lookup := newBackgroundWorkerLookup()
+	lookup.catchAll = newBackgroundWorkerRegistry(testDataPath + "/background-worker-with-argv.php")
+	backgroundLookups = map[string]*backgroundWorkerLookup{"": lookup}
+	thread := newPHPThread(0)
+	thread.state.Set(state.Ready)
+	thread.handler = &workerThread{
+		thread: thread,
+		worker: &worker{backgroundLookup: lookup},
+	}
+	phpThreads = []*phpThread{thread}
+	t.Cleanup(func() {
+		phpThreads = nil
+	})
+
+	registry := lookup.Resolve("retryable-background-worker")
+
+	err := startBackgroundWorker(thread, "retryable-background-worker")
+	require.EqualError(t, err, "no available PHP thread for background worker (increase max_threads)")
+	assert.Empty(t, registry.workers)
+
+	err = startBackgroundWorker(thread, "retryable-background-worker")
+	require.EqualError(t, err, "no available PHP thread for background worker (increase max_threads)")
+	assert.Empty(t, registry.workers)
+}
+
+func TestBackgroundWorkerSetVarsMarksWorkerReady(t *testing.T) {
+	originalMetrics := metrics
+	testMetrics := &backgroundWorkerTestMetrics{}
+	metrics = testMetrics
+	t.Cleanup(func() {
+		metrics = originalMetrics
+	})
+
+	handler := &backgroundWorkerThread{
+		thread:          newPHPThread(0),
+		worker:          &worker{name: "background-worker", fileName: "background-worker.php", maxConsecutiveFailures: -1},
+		isBootingScript: true,
+	}
+
+	handler.markBackgroundReady()
+	handler.markBackgroundReady()
+
+	assert.False(t, handler.isBootingScript)
+	assert.Equal(t, 0, handler.failureCount)
+	assert.Equal(t, 1, testMetrics.readyCalls)
+}
+
+func TestBackgroundWorkerBootFailureStaysBootFailureUntilReady(t *testing.T) {
+	originalMetrics := metrics
+	testMetrics := &backgroundWorkerTestMetrics{}
+	metrics = testMetrics
+	t.Cleanup(func() {
+		metrics = originalMetrics
+	})
+
+	handler := &backgroundWorkerThread{
+		thread: newPHPThread(0),
+		worker: &worker{
+			name:                   "background-worker",
+			fileName:               "background-worker.php",
+			maxConsecutiveFailures: -1,
+		},
+		isBootingScript: true,
+	}
+
+	handler.afterScriptExecution(1)
+	require.Len(t, testMetrics.stopCalls, 1)
+	assert.Equal(t, StopReason(StopReasonBootFailure), testMetrics.stopCalls[0])
+
+	testMetrics.stopCalls = nil
+	handler.isBootingScript = true
+	handler.markBackgroundReady()
+	handler.afterScriptExecution(1)
+	require.Len(t, testMetrics.stopCalls, 1)
+	assert.Equal(t, StopReason(StopReasonCrash), testMetrics.stopCalls[0])
+}

--- a/bg_worker_vars.h
+++ b/bg_worker_vars.h
@@ -259,4 +259,104 @@ static void bg_worker_request_copy_zval(zval *dst, zval *src) {
     break;
   }
 }
+
+/* Move a persistent zval tree into request memory, freeing persistent data
+ * in one pass. Combines bg_worker_request_copy_zval +
+ * bg_worker_free_persistent_zval. */
+static void bg_worker_move_zval(zval *dst, zval *src) {
+  switch (Z_TYPE_P(src)) {
+  case IS_NULL:
+  case IS_FALSE:
+  case IS_TRUE:
+    ZVAL_COPY_VALUE(dst, src);
+    break;
+  case IS_LONG:
+    ZVAL_LONG(dst, Z_LVAL_P(src));
+    break;
+  case IS_DOUBLE:
+    ZVAL_DOUBLE(dst, Z_DVAL_P(src));
+    break;
+  case IS_STRING:
+    if (ZSTR_IS_INTERNED(Z_STR_P(src))) {
+      ZVAL_STR(dst, Z_STR_P(src)); /* zero-copy, no free */
+    } else {
+      ZVAL_STRINGL(dst, Z_STRVAL_P(src), Z_STRLEN_P(src));
+      zend_string_free(Z_STR_P(src));
+    }
+    break;
+  case IS_PTR: {
+    bg_worker_enum_t *e = (bg_worker_enum_t *)Z_PTR_P(src);
+    zend_class_entry *ce = zend_lookup_class(e->class_name);
+    if (!ce || !(ce->ce_flags & ZEND_ACC_ENUM)) {
+      zend_throw_exception_ex(spl_ce_LogicException, 0,
+                              "Background worker enum class \"%s\" not found",
+                              ZSTR_VAL(e->class_name));
+      ZVAL_NULL(dst);
+    } else {
+      zend_object *enum_obj =
+          zend_enum_get_case_cstr(ce, ZSTR_VAL(e->case_name));
+      if (!enum_obj) {
+        zend_throw_exception_ex(
+            spl_ce_LogicException, 0,
+            "Background worker enum case \"%s::%s\" not found",
+            ZSTR_VAL(e->class_name), ZSTR_VAL(e->case_name));
+        ZVAL_NULL(dst);
+      } else {
+        ZVAL_OBJ_COPY(dst, enum_obj);
+      }
+    }
+    if (!ZSTR_IS_INTERNED(e->class_name))
+      zend_string_free(e->class_name);
+    if (!ZSTR_IS_INTERNED(e->case_name))
+      zend_string_free(e->case_name);
+    pefree(e, 1);
+    break;
+  }
+  case IS_ARRAY: {
+    HashTable *src_ht = Z_ARRVAL_P(src);
+    array_init_size(dst, zend_hash_num_elements(src_ht));
+    HashTable *dst_ht = Z_ARRVAL_P(dst);
+
+    zend_string *key;
+    zend_ulong idx;
+    zval *val;
+    bool move_failed = false;
+    ZEND_HASH_FOREACH_KEY_VAL(src_ht, idx, key, val) {
+      if (move_failed) {
+        /* Free remaining persistent entries that were not moved */
+        bg_worker_free_persistent_zval(val);
+        continue;
+      }
+      zval rval;
+      bg_worker_move_zval(&rval, val);
+      if (EG(exception)) {
+        zval_ptr_dtor(&rval);
+        move_failed = true;
+        continue;
+      }
+      if (key) {
+        if (ZSTR_IS_INTERNED(key)) {
+          zend_hash_add_new(dst_ht, key, &rval);
+        } else {
+          zend_string *rkey =
+              zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 0);
+          ZSTR_H(rkey) = ZSTR_H(key);
+          zend_hash_add_new(dst_ht, rkey, &rval);
+          zend_string_release(rkey);
+        }
+      } else {
+        zend_hash_index_add_new(dst_ht, idx, &rval);
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+    zend_hash_destroy(src_ht);
+    pefree(src_ht, 1);
+    break;
+  }
+  default:
+    ZVAL_NULL(dst);
+    break;
+  }
+}
+
 #endif /* BG_WORKER_VARS_H */

--- a/bg_worker_vars.h
+++ b/bg_worker_vars.h
@@ -1,0 +1,262 @@
+/* bg_worker_vars.h - Persistent zval helpers for background worker variables.
+ *
+ * Handles validation, deep-copy to/from persistent memory, immutable array
+ * detection, interned string optimization, and enum serialization.
+ *
+ * Included by frankenphp.c - not a standalone compilation unit. */
+
+#ifndef BG_WORKER_VARS_H
+#define BG_WORKER_VARS_H
+
+typedef struct {
+  zend_string *class_name;
+  zend_string *case_name;
+} bg_worker_enum_t;
+
+/* Forward declarations */
+static void bg_worker_free_persistent_zval(zval *z);
+
+static void bg_worker_request_copy_zval(zval *dst, zval *src);
+
+/* Check if a HashTable is an opcache immutable array - safe to share
+ * across threads without copying. */
+static bool bg_worker_is_immutable(HashTable *ht) {
+  return (GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) != 0;
+}
+
+/* Free a stored vars pointer only if it's a persistent copy (not immutable). */
+static void bg_worker_free_stored_vars(void *ptr) {
+  if (ptr != NULL) {
+    HashTable *ht = (HashTable *)ptr;
+    if (!bg_worker_is_immutable(ht)) {
+      zval z;
+      ZVAL_ARR(&z, ht);
+      bg_worker_free_persistent_zval(&z);
+    }
+  }
+}
+
+/* Copy or reference a stored vars pointer to request memory.
+ * Immutable arrays are returned as zero-copy references. */
+static void bg_worker_read_stored_vars(zval *dst, void *ptr) {
+  HashTable *ht = (HashTable *)ptr;
+  if (bg_worker_is_immutable(ht)) {
+    ZVAL_ARR(dst, ht); /* zero-copy: immutable = safe to share */
+  } else {
+    zval src;
+    ZVAL_ARR(&src, ht);
+    bg_worker_request_copy_zval(dst, &src);
+  }
+}
+
+/* Validate that a zval tree contains only scalars, arrays, and enums */
+static bool bg_worker_validate_zval(zval *z) {
+  switch (Z_TYPE_P(z)) {
+  case IS_NULL:
+  case IS_FALSE:
+  case IS_TRUE:
+  case IS_LONG:
+  case IS_DOUBLE:
+  case IS_STRING:
+    return true;
+  case IS_OBJECT:
+    return (Z_OBJCE_P(z)->ce_flags & ZEND_ACC_ENUM) != 0;
+  case IS_ARRAY: {
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(z), val) {
+      if (!bg_worker_validate_zval(val))
+        return false;
+    }
+    ZEND_HASH_FOREACH_END();
+    return true;
+  }
+  default:
+    return false;
+  }
+}
+
+/* Deep-copy a zval into persistent memory */
+static void bg_worker_persist_zval(zval *dst, zval *src) {
+  switch (Z_TYPE_P(src)) {
+  case IS_NULL:
+  case IS_FALSE:
+  case IS_TRUE:
+    ZVAL_COPY_VALUE(dst, src);
+    break;
+  case IS_LONG:
+    ZVAL_LONG(dst, Z_LVAL_P(src));
+    break;
+  case IS_DOUBLE:
+    ZVAL_DOUBLE(dst, Z_DVAL_P(src));
+    break;
+  case IS_STRING: {
+    zend_string *s = Z_STR_P(src);
+    if (ZSTR_IS_INTERNED(s)) {
+      ZVAL_STR(dst, s); /* interned = shared memory, no copy needed */
+    } else {
+      ZVAL_NEW_STR(dst, zend_string_init(ZSTR_VAL(s), ZSTR_LEN(s), 1));
+    }
+    break;
+  }
+  case IS_OBJECT: {
+    /* Must be an enum (validated earlier) */
+    zend_class_entry *ce = Z_OBJCE_P(src);
+    bg_worker_enum_t *e = pemalloc(sizeof(bg_worker_enum_t), 1);
+    e->class_name =
+        ZSTR_IS_INTERNED(ce->name)
+            ? ce->name
+            : zend_string_init(ZSTR_VAL(ce->name), ZSTR_LEN(ce->name), 1);
+    zval *case_name_zval = zend_enum_fetch_case_name(Z_OBJ_P(src));
+    zend_string *case_str = Z_STR_P(case_name_zval);
+    e->case_name =
+        ZSTR_IS_INTERNED(case_str)
+            ? case_str
+            : zend_string_init(ZSTR_VAL(case_str), ZSTR_LEN(case_str), 1);
+    ZVAL_PTR(dst, e);
+    break;
+  }
+  case IS_ARRAY: {
+    HashTable *src_ht = Z_ARRVAL_P(src);
+    HashTable *dst_ht = pemalloc(sizeof(HashTable), 1);
+    zend_hash_init(dst_ht, zend_hash_num_elements(src_ht), NULL, NULL, 1);
+    ZVAL_ARR(dst, dst_ht);
+
+    zend_string *key;
+    zend_ulong idx;
+    zval *val;
+    ZEND_HASH_FOREACH_KEY_VAL(src_ht, idx, key, val) {
+      zval pval;
+      bg_worker_persist_zval(&pval, val);
+      if (key) {
+        if (ZSTR_IS_INTERNED(key)) {
+          zend_hash_add_new(dst_ht, key, &pval);
+        } else {
+          zend_string *pkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 1);
+          zend_hash_add_new(dst_ht, pkey, &pval);
+          zend_string_release(pkey);
+        }
+      } else {
+        zend_hash_index_add_new(dst_ht, idx, &pval);
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+    break;
+  }
+  default:
+    ZVAL_NULL(dst);
+    break;
+  }
+}
+
+/* Deep-free a persistent zval tree */
+static void bg_worker_free_persistent_zval(zval *z) {
+  switch (Z_TYPE_P(z)) {
+  case IS_STRING:
+    if (!ZSTR_IS_INTERNED(Z_STR_P(z))) {
+      zend_string_free(Z_STR_P(z));
+    }
+    break;
+  case IS_PTR: {
+    bg_worker_enum_t *e = (bg_worker_enum_t *)Z_PTR_P(z);
+    if (!ZSTR_IS_INTERNED(e->class_name))
+      zend_string_free(e->class_name);
+    if (!ZSTR_IS_INTERNED(e->case_name))
+      zend_string_free(e->case_name);
+    pefree(e, 1);
+    break;
+  }
+  case IS_ARRAY: {
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(z), val) {
+      bg_worker_free_persistent_zval(val);
+    }
+    ZEND_HASH_FOREACH_END();
+    zend_hash_destroy(Z_ARRVAL_P(z));
+    pefree(Z_ARRVAL_P(z), 1);
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+/* Deep-copy a persistent zval tree into request memory */
+static void bg_worker_request_copy_zval(zval *dst, zval *src) {
+  switch (Z_TYPE_P(src)) {
+  case IS_NULL:
+  case IS_FALSE:
+  case IS_TRUE:
+    ZVAL_COPY_VALUE(dst, src);
+    break;
+  case IS_LONG:
+    ZVAL_LONG(dst, Z_LVAL_P(src));
+    break;
+  case IS_DOUBLE:
+    ZVAL_DOUBLE(dst, Z_DVAL_P(src));
+    break;
+  case IS_STRING:
+    if (ZSTR_IS_INTERNED(Z_STR_P(src))) {
+      ZVAL_STR(dst, Z_STR_P(src));
+    } else {
+      ZVAL_STRINGL(dst, Z_STRVAL_P(src), Z_STRLEN_P(src));
+    }
+    break;
+  case IS_PTR: {
+    bg_worker_enum_t *e = (bg_worker_enum_t *)Z_PTR_P(src);
+    zend_class_entry *ce = zend_lookup_class(e->class_name);
+    if (!ce || !(ce->ce_flags & ZEND_ACC_ENUM)) {
+      zend_throw_exception_ex(spl_ce_LogicException, 0,
+                              "Background worker enum class \"%s\" not found",
+                              ZSTR_VAL(e->class_name));
+      ZVAL_NULL(dst);
+      break;
+    }
+    zend_object *enum_obj = zend_enum_get_case_cstr(ce, ZSTR_VAL(e->case_name));
+    if (!enum_obj) {
+      zend_throw_exception_ex(
+          spl_ce_LogicException, 0,
+          "Background worker enum case \"%s::%s\" not found",
+          ZSTR_VAL(e->class_name), ZSTR_VAL(e->case_name));
+      ZVAL_NULL(dst);
+      break;
+    }
+    ZVAL_OBJ_COPY(dst, enum_obj);
+    break;
+  }
+  case IS_ARRAY: {
+    HashTable *src_ht = Z_ARRVAL_P(src);
+    array_init_size(dst, zend_hash_num_elements(src_ht));
+    HashTable *dst_ht = Z_ARRVAL_P(dst);
+
+    zend_string *key;
+    zend_ulong idx;
+    zval *val;
+    ZEND_HASH_FOREACH_KEY_VAL(src_ht, idx, key, val) {
+      zval rval;
+      bg_worker_request_copy_zval(&rval, val);
+      if (EG(exception)) {
+        zval_ptr_dtor(&rval);
+        break;
+      }
+      if (key) {
+        if (ZSTR_IS_INTERNED(key)) {
+          zend_hash_add_new(dst_ht, key, &rval);
+        } else {
+          zend_string *rkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 0);
+          ZSTR_H(rkey) = ZSTR_H(key);
+          zend_hash_add_new(dst_ht, rkey, &rval);
+          zend_string_release(rkey);
+        }
+      } else {
+        zend_hash_index_add_new(dst_ht, idx, &rval);
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+    break;
+  }
+  default:
+    ZVAL_NULL(dst);
+    break;
+  }
+}
+#endif /* BG_WORKER_VARS_H */

--- a/caddy/app.go
+++ b/caddy/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dunglas/frankenphp/internal/fastabs"
 )
 
+
 var (
 	options   []frankenphp.Option
 	optionsMU sync.RWMutex
@@ -163,6 +164,10 @@ func (f *FrankenPHPApp) Start() error {
 			frankenphp.WithWorkerMaxThreads(w.MaxThreads),
 			frankenphp.WithWorkerRequestOptions(w.requestOptions...),
 		)
+
+		if w.Background {
+			w.options = append(w.options, frankenphp.WithWorkerBackground())
+		}
 
 		f.opts = append(f.opts, frankenphp.WithWorkers(w.Name, repl.ReplaceKnown(w.FileName, ""), w.Num, w.options...))
 	}

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -166,6 +166,31 @@ func TestWorker(t *testing.T) {
 	wg.Wait()
 }
 
+func TestBackgroundWorkerCaddy(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	initServer(t, tester, `
+		{
+			skip_install_trust
+			admin localhost:2999
+			http_port `+testPort+`
+			https_port 9443
+		}
+
+		localhost:`+testPort+` {
+			root ../testdata
+			php_server {
+				worker ../testdata/background-worker-caddy-entrypoint.php {
+					background
+					name caddy-bg-worker
+					num 1
+				}
+			}
+		}
+		`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:"+testPort+"/background-worker-caddy-reader.php", http.StatusOK, "hello from background worker")
+}
+
 func TestGlobalAndModuleWorker(t *testing.T) {
 	var wg sync.WaitGroup
 	testPortNum, _ := strconv.Atoi(testPort)

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -51,6 +51,7 @@ type FrankenPHPModule struct {
 	preparedEnvNeedsReplacement bool
 	logger                      *slog.Logger
 	requestOptions              []frankenphp.RequestOption
+	backgroundScope             string
 }
 
 // CaddyModule returns the Caddy module information.
@@ -78,6 +79,12 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 
 	f.assignMercureHub(ctx)
 
+	// Each php_server block gets its own scope for background worker isolation.
+	// Only set once - Caddy may call Provision multiple times.
+	if f.backgroundScope == "" {
+		f.backgroundScope = frankenphp.NextBackgroundWorkerScope()
+	}
+
 	loggerOpt := frankenphp.WithRequestLogger(f.logger)
 	for i, wc := range f.Workers {
 		// make the file path absolute from the public directory
@@ -92,6 +99,7 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 		}
 
 		wc.requestOptions = append(wc.requestOptions, loggerOpt)
+		wc.options = append(wc.options, frankenphp.WithWorkerBackgroundScope(f.backgroundScope))
 		f.Workers[i] = wc
 	}
 
@@ -241,6 +249,7 @@ func (f *FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 			opts,
 			frankenphp.WithOriginalRequest(new(ctx.Value(caddyhttp.OriginalRequestCtxKey).(http.Request))),
 			frankenphp.WithWorkerName(workerName),
+			frankenphp.WithRequestBackgroundScope(f.backgroundScope),
 		)...,
 	)
 
@@ -317,8 +326,12 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	}
 
 	// Check if a worker with this filename already exists in this module
+	// Background workers are excluded (they share filenames by design)
 	fileNames := make(map[string]struct{}, len(f.Workers))
 	for _, w := range f.Workers {
+		if w.Background {
+			continue
+		}
 		if _, ok := fileNames[w.FileName]; ok {
 			return fmt.Errorf(`workers in a single "php" or "php_server" block must not have duplicate filenames: %q`, w.FileName)
 		}

--- a/caddy/workerconfig.go
+++ b/caddy/workerconfig.go
@@ -41,7 +41,8 @@ type workerConfig struct {
 	MatchPath []string `json:"match_path,omitempty"`
 	// MaxConsecutiveFailures sets the maximum number of consecutive failures before panicking (defaults to 6, set to -1 to never panick)
 	MaxConsecutiveFailures int `json:"max_consecutive_failures,omitempty"`
-
+	// Background marks this worker as a background worker (non-HTTP)
+	Background         bool `json:"background,omitempty"`
 	options        []frankenphp.WorkerOption
 	requestOptions []frankenphp.RequestOption
 	absFileName    string
@@ -123,9 +124,13 @@ func unmarshalWorker(d *caddyfile.Dispenser) (workerConfig, error) {
 				wc.Watch = append(wc.Watch, patterns...)
 			}
 		case "match":
-			// provision the path so it's identical to Caddy match rules
+			if wc.Background {
+				return wc, d.Err(`"match" is not supported for background workers, use "name" instead`)
+			}
+			args := d.RemainingArgs()
+			// For HTTP workers, provision as Caddy path matchers
 			// see: https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/matchers.go
-			caddyMatchPath := (caddyhttp.MatchPath)(d.RemainingArgs())
+			caddyMatchPath := (caddyhttp.MatchPath)(args)
 			if err := caddyMatchPath.Provision(caddy.Context{}); err != nil {
 				return wc, d.WrapErr(err)
 			}
@@ -145,13 +150,27 @@ func unmarshalWorker(d *caddyfile.Dispenser) (workerConfig, error) {
 			}
 
 			wc.MaxConsecutiveFailures = v
+		case "background":
+			wc.Background = true
 		default:
-			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads", v)
+			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads, background", v)
 		}
 	}
 
 	if wc.FileName == "" {
 		return wc, d.Err(`the "file" argument must be specified`)
+	}
+
+	if wc.Background {
+		// Validate background worker constraints
+		if wc.Num > 1 {
+			return wc, d.Err(`"num" > 1 is not yet supported for background workers`)
+		}
+		if wc.MaxThreads > 1 {
+			return wc, d.Err(`"max_threads" > 1 is not yet supported for background workers`)
+		}
+		// MaxConsecutiveFailures defaults to 6 (same as HTTP workers)
+		// via defaultMaxConsecutiveFailures in options.go
 	}
 
 	if frankenphp.EmbeddedAppPath != "" && filepath.IsLocal(wc.FileName) {
@@ -174,6 +193,11 @@ func (wc *workerConfig) inheritEnv(env map[string]string) {
 }
 
 func (wc *workerConfig) matchesPath(r *http.Request, documentRoot string) bool {
+	// background workers don't handle HTTP requests
+	if wc.Background {
+		return false
+	}
+
 	// try to match against a pattern if one is assigned
 	if len(wc.MatchPath) != 0 {
 		return (caddyhttp.MatchPath)(wc.MatchPath).Match(r)

--- a/context.go
+++ b/context.go
@@ -23,6 +23,7 @@ type frankenPHPContext struct {
 	request         *http.Request
 	originalRequest *http.Request
 	worker          *worker
+	backgroundScope string
 
 	docURI         string
 	pathInfo       string

--- a/docs/background-workers.md
+++ b/docs/background-workers.md
@@ -35,7 +35,7 @@ example.com {
 }
 ```
 
-- **Named** (with `name`): lazy-started on first `get_vars()` call, or auto-started at boot if `num 1` is set.
+- **Named** (with `name`): lazy-started on first `get_vars()` call, or auto-started at boot if `num 1` is set. Use `num` to run multiple threads for parallel task processing.
 - **Catch-all** (no `name`): also lazy-started. Use `max_threads` to cap how many can be created (defaults to 16). Not declaring a catch-all forbids unlisted names.
 - Each `php_server` block has its own isolated scope - two blocks can use the same worker names without conflict.
 - `max_consecutive_failures`, `env`, and `watch` work the same as HTTP workers.
@@ -74,6 +74,7 @@ Supported types: `null`, `bool`, `int`, `float`, `string`, `array` (nested), and
 ### `frankenphp_worker_get_signaling_stream(): resource`
 
 Returns a readable stream for receiving signals from FrankenPHP.
+Signals: `"stop\n"` (shutdown/restart), `"task\n"` (task available, see Task API below).
 Use `stream_select()` to wait between iterations instead of `sleep()`:
 
 ```php
@@ -94,6 +95,72 @@ function background_worker_should_stop(float $timeout = 0): bool
 > [!WARNING]
 > Avoid `sleep()` or `usleep()` in background workers - they block at the C level and cannot be interrupted.
 > Use `stream_select()` with the signaling stream instead.
+
+### Task API
+
+While `set_vars`/`get_vars` pushes config from background workers to HTTP workers,
+tasks enable the reverse: HTTP workers send work to background workers and stream results back.
+
+#### `frankenphp_worker_task_send(string $name, array $payload, float $timeout = 30.0): resource`
+
+Sends a task to a named background worker. Returns a readable stream for receiving results.
+
+- `$payload` follows the same type constraints as `set_vars`: `null`, scalars, arrays, enums. No objects or resources.
+- Blocks until a background worker thread picks up the task
+- The returned stream wakes up on each `task_update()` - use with `stream_select()` or `fgets()`
+- `fclose()` the stream to cancel the task or acknowledge completion
+- Throws `RuntimeException` on timeout or if the background worker exits
+
+#### `frankenphp_worker_task_receive(): ?array`
+
+Called from a background worker. Dequeues a pending task. Returns `[$stream, $payload]` or `null`.
+
+- Non-blocking: call it after receiving `"task\n"` on the signaling stream
+- `$stream`: writable stream - send results back via `task_update()`
+- `$payload`: the array sent by the HTTP worker
+- `fclose($stream)` when processing is complete
+
+#### `frankenphp_worker_task_update(resource $stream, array $data): void`
+
+Sends a result or progress update from the background worker to the sender.
+
+#### `frankenphp_worker_task_read(resource $stream): ?array`
+
+Reads the next update on the sender's side. Returns `null` when the background worker closes the stream cleanly.
+Throws `RuntimeException` if the background worker exited without completing the task.
+
+#### Example
+
+```php
+// Background worker: process tasks
+$signaling = frankenphp_worker_get_signaling_stream();
+
+while (true) {
+    $r = [$signaling];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    if ("stop\n" === $signal = fgets($signaling)) {
+        break;
+    }
+
+    if ("task\n" === $signal && [$stream, $payload] = frankenphp_worker_task_receive()) {
+        frankenphp_worker_task_update($stream, ['result' => process($payload)]);
+        fclose($stream);
+    }
+}
+```
+
+```php
+// HTTP worker: send a task and read the result
+$stream = frankenphp_worker_task_send('image-resizer', ['file' => 'photo.jpg']);
+$result = frankenphp_worker_task_read($stream);
+fclose($stream);
+```
+
+With `num 2` or more, multiple background threads share the same task queue - tasks are distributed automatically.
 
 ## Example
 

--- a/docs/background-workers.md
+++ b/docs/background-workers.md
@@ -1,0 +1,204 @@
+# Background Workers
+
+Background workers are long-running PHP scripts that run outside the HTTP request cycle.
+They observe their environment and publish configuration that HTTP [workers](worker.md) can read in real time.
+
+## How It Works
+
+1. A background worker runs its own event loop (subscribe to Redis, watch files, poll an API...)
+2. It calls `frankenphp_worker_set_vars()` to publish a snapshot of key-value pairs
+3. HTTP workers call `frankenphp_worker_get_vars()` to read the latest snapshot
+4. The first `get_vars()` call blocks until the background worker has published - no startup race condition
+
+## Configuration
+
+Add `worker` directives with `background` to your [`php_server` or `php` block](config.md#caddyfile-config):
+
+```caddyfile
+example.com {
+    php_server {
+        # Named background workers
+        worker /app/bin/console {
+            background
+            name config-watcher
+        }
+        worker /app/bin/console {
+            background
+            name feature-flags
+        }
+
+        # Catch-all - handles any unlisted name via get_vars()
+        worker /app/bin/console {
+            background
+        }
+    }
+}
+```
+
+- **Named** (with `name`): lazy-started on first `get_vars()` call, or auto-started at boot if `num 1` is set.
+- **Catch-all** (no `name`): also lazy-started. Use `max_threads` to cap how many can be created (defaults to 16). Not declaring a catch-all forbids unlisted names.
+- Each `php_server` block has its own isolated scope - two blocks can use the same worker names without conflict.
+- `max_consecutive_failures`, `env`, and `watch` work the same as HTTP workers.
+
+## PHP API
+
+### `frankenphp_worker_get_vars(string|array $name, float $timeout = 30.0): array`
+
+Starts a background worker (at-most-once) and returns its published variables.
+
+```php
+$redis = frankenphp_worker_get_vars('redis-watcher');
+// ['MASTER_HOST' => '10.0.0.1', 'MASTER_PORT' => 6379]
+
+$all = frankenphp_worker_get_vars(['redis-watcher', 'feature-flags']);
+// ['redis-watcher' => [...], 'feature-flags' => [...]]
+```
+
+- First call blocks until the background worker calls `set_vars()` or the timeout expires
+- Subsequent calls return the latest snapshot immediately
+- Within a single HTTP request, repeated calls with the same name return the same cached array - `===` comparisons are O(1)
+- Throws `RuntimeException` on timeout, missing entrypoint, or background worker crash
+- Works in both worker and non-worker mode
+
+### `frankenphp_worker_set_vars(array $vars): void`
+
+Publishes a snapshot of key-value pairs from inside a background worker.
+Each call **replaces** the entire snapshot atomically.
+If the new value is identical (`===`) to the previous one, the call is a no-op.
+
+Supported types: `null`, `bool`, `int`, `float`, `string`, `array` (nested), and **enums**.
+
+- Throws `RuntimeException` if not called from a background worker context
+- Throws `ValueError` if values contain objects, resources, or references
+
+### `frankenphp_worker_get_signaling_stream(): resource`
+
+Returns a readable stream for receiving signals from FrankenPHP.
+Use `stream_select()` to wait between iterations instead of `sleep()`:
+
+```php
+function background_worker_should_stop(float $timeout = 0): bool
+{
+    static $signalingStream;
+    $signalingStream ??= frankenphp_worker_get_signaling_stream();
+    $s = (int) $timeout;
+
+    return match (@stream_select(...[[$signalingStream], [], [], $s, (int) (($timeout - $s) * 1e6)])) {
+        0 => false, // timeout - keep going
+        false => true, // pipe closed - stop
+        default => "stop\n" === fgets($signalingStream),
+    };
+}
+```
+
+> [!WARNING]
+> Avoid `sleep()` or `usleep()` in background workers - they block at the C level and cannot be interrupted.
+> Use `stream_select()` with the signaling stream instead.
+
+## Example
+
+### Simple polling worker
+
+```php
+<?php
+// bin/console (dispatches based on worker name)
+
+$command = $_SERVER['FRANKENPHP_WORKER_NAME'] ?? '';
+
+match ($command) {
+    'config-watcher' => run_config_watcher(),
+    'feature-flags' => run_feature_flags(),
+    default => throw new \RuntimeException("Unknown background worker: $command"),
+};
+
+function run_config_watcher(): void
+{
+    $redis = new Redis();
+    $redis->pconnect('127.0.0.1');
+
+    do {
+        frankenphp_worker_set_vars([
+            'maintenance' => (bool) $redis->get('maintenance_mode'),
+            'feature_flags' => json_decode($redis->get('features'), true),
+        ]);
+    } while (!background_worker_should_stop(5)); // check every 5s
+}
+```
+
+### Event-driven worker (amphp)
+
+For real-time subscriptions (Redis pub/sub, SSE, WebSocket), use an async library
+to integrate the signaling stream into the event loop:
+
+```php
+function run_redis_watcher(): void
+{
+    $signalingStream = frankenphp_worker_get_signaling_stream();
+    $sentinel = Amp\Redis\createRedisClient('tcp://sentinel-host:26379');
+
+    $subscription = $sentinel->subscribe('+switch-master');
+
+    Amp\async(function () use ($subscription) {
+        foreach ($subscription as $message) {
+            [$name, $oldIp, $oldPort, $newIp, $newPort] = explode(' ', $message);
+            frankenphp_worker_set_vars([
+                'MASTER_HOST' => $newIp,
+                'MASTER_PORT' => (int) $newPort,
+            ]);
+        }
+    });
+
+    $master = $sentinel->rawCommand('SENTINEL', 'get-master-addr-by-name', 'mymaster');
+    frankenphp_worker_set_vars([
+        'MASTER_HOST' => $master[0],
+        'MASTER_PORT' => (int) $master[1],
+    ]);
+
+    Amp\EventLoop::onReadable($signalingStream, function ($id) use ($signalingStream) {
+        if ("stop\n" === fgets($signalingStream)) {
+            Amp\EventLoop::cancel($id);
+        }
+    });
+    Amp\EventLoop::run();
+}
+```
+
+### HTTP Worker
+
+```php
+<?php
+// public/index.php
+
+$app = new App();
+$app->boot();
+
+while (frankenphp_handle_request(function () use ($app) {
+    $config = frankenphp_worker_get_vars('config-watcher');
+
+    $_SERVER += ['APP_REDIS_HOST' => $config['MASTER_HOST'], 'APP_REDIS_PORT' => $config['MASTER_PORT']];
+    $app->handle($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);
+})) {
+    gc_collect_cycles();
+}
+```
+
+### Graceful Degradation
+
+```php
+if (function_exists('frankenphp_worker_get_vars')) {
+    $config = frankenphp_worker_get_vars('config-watcher');
+} else {
+    $config = ['MASTER_HOST' => getenv('REDIS_HOST') ?: '127.0.0.1'];
+}
+```
+
+## Runtime Behavior
+
+- Background workers get dedicated threads - they don't reduce HTTP capacity
+- `max_execution_time` is automatically disabled
+- Shebangs (`#!/usr/bin/env php`) are silently skipped
+- `$_SERVER['FRANKENPHP_WORKER_NAME']` is set for all workers (HTTP and background)
+- `$_SERVER['FRANKENPHP_WORKER_BACKGROUND']` is `true` for background workers, `false` for HTTP workers
+- `$_SERVER['argv']` = `[entrypoint, name]` in background workers (for `bin/console` compatibility)
+- Crash recovery with automatic restart and exponential backoff. During the restart window, `get_vars` returns the last published data (stale but available). A warning is logged on crash (`background worker exited, restarting`).
+- On shutdown/restart: `"stop\n"` is sent on the signaling stream. Workers have 5 seconds to exit. Stuck workers are force-killed on Linux and Windows.

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1,6 +1,7 @@
 #include "frankenphp.h"
 #include <SAPI.h>
 #include <Zend/zend_alloc.h>
+#include <Zend/zend_enum.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_interfaces.h>
 #include <errno.h>
@@ -13,6 +14,7 @@
 #include <php.h>
 #ifdef PHP_WIN32
 #include <config.w32.h>
+#include <io.h>
 #else
 #include <php_config.h>
 #endif
@@ -85,13 +87,233 @@ HashTable *main_thread_env = NULL;
 
 __thread uintptr_t thread_index;
 __thread bool is_worker_thread = false;
+__thread char *worker_name = NULL;
+__thread bool is_background_worker = false;
+__thread int worker_stop_fds[2] = {-1, -1};
+__thread php_stream *worker_signaling_stream = NULL;
+__thread zval last_set_vars_zval; /* IS_UNDEF when unset (TLS zero-init) */
 __thread HashTable *sandboxed_env = NULL;
+
+/* Best-effort force-kill for stuck background workers after grace period.
+ * - Linux ZTS: arm PHP's per-thread timer -> "max execution time" fatal
+ * - Windows: CancelSynchronousIo + QueueUserAPC -> interrupts I/O and sleeps
+ * - macOS/other: no-op (threads abandoned, exit when blocking call returns) */
+static int force_kill_num_threads = 0;
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+static timer_t *thread_php_timers = NULL;
+static bool *thread_php_timer_saved = NULL;
+#elif defined(PHP_WIN32)
+static HANDLE *thread_handles = NULL;
+static bool *thread_handle_saved = NULL;
+static void CALLBACK frankenphp_noop_apc(ULONG_PTR param) { (void)param; }
+#endif
+
+void frankenphp_init_force_kill(int num_threads) {
+  force_kill_num_threads = num_threads;
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+  thread_php_timers = calloc(num_threads, sizeof(timer_t));
+  thread_php_timer_saved = calloc(num_threads, sizeof(bool));
+#elif defined(PHP_WIN32)
+  thread_handles = calloc(num_threads, sizeof(HANDLE));
+  thread_handle_saved = calloc(num_threads, sizeof(bool));
+#endif
+}
+
+void frankenphp_save_php_timer(uintptr_t idx) {
+  if (idx >= (uintptr_t)force_kill_num_threads) {
+    return;
+  }
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+  if (thread_php_timers && EG(pid)) {
+    thread_php_timers[idx] = EG(max_execution_timer_timer);
+    thread_php_timer_saved[idx] = true;
+  }
+#elif defined(PHP_WIN32)
+  if (thread_handles) {
+    DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+                    GetCurrentProcess(), &thread_handles[idx], 0, FALSE,
+                    DUPLICATE_SAME_ACCESS);
+    thread_handle_saved[idx] = true;
+  }
+#endif
+  (void)idx;
+}
+
+void frankenphp_force_kill_thread(uintptr_t idx) {
+  if (idx >= (uintptr_t)force_kill_num_threads) {
+    return;
+  }
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+  if (thread_php_timers && thread_php_timer_saved[idx]) {
+    struct itimerspec its;
+    its.it_value.tv_sec = 0;
+    its.it_value.tv_nsec = 1;
+    its.it_interval.tv_sec = 0;
+    its.it_interval.tv_nsec = 0;
+    timer_settime(thread_php_timers[idx], 0, &its, NULL);
+  }
+#elif defined(PHP_WIN32)
+  if (thread_handles && thread_handle_saved[idx]) {
+    CancelSynchronousIo(thread_handles[idx]);
+    QueueUserAPC((PAPCFUNC)frankenphp_noop_apc, thread_handles[idx], 0);
+  }
+#endif
+  (void)idx;
+}
+
+void frankenphp_destroy_force_kill(void) {
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+  if (thread_php_timers) {
+    free(thread_php_timers);
+    thread_php_timers = NULL;
+  }
+  if (thread_php_timer_saved) {
+    free(thread_php_timer_saved);
+    thread_php_timer_saved = NULL;
+  }
+#elif defined(PHP_WIN32)
+  if (thread_handles) {
+    for (int i = 0; i < force_kill_num_threads; i++) {
+      if (thread_handle_saved && thread_handle_saved[i]) {
+        CloseHandle(thread_handles[i]);
+      }
+    }
+    free(thread_handles);
+    thread_handles = NULL;
+  }
+  if (thread_handle_saved) {
+    free(thread_handle_saved);
+    thread_handle_saved = NULL;
+  }
+#endif
+  force_kill_num_threads = 0;
+}
+
+/* Per-thread cache for get_vars results.
+ * Maps worker name (string) -> {version, cached_zval}.
+ * When the version matches, the cached zval is returned with a refcount bump,
+ * giving the same HashTable pointer -> === comparisons are O(1). */
+typedef struct {
+  uint64_t version;
+  zval value;
+} bg_worker_vars_cache_entry;
+__thread HashTable *worker_vars_cache = NULL;
+
+static void frankenphp_worker_close_stop_fds(void) {
+  if (worker_stop_fds[0] >= 0) {
+#ifdef PHP_WIN32
+    _close(worker_stop_fds[0]);
+#else
+    close(worker_stop_fds[0]);
+#endif
+    worker_stop_fds[0] = -1;
+  }
+
+  if (worker_stop_fds[1] >= 0) {
+#ifdef PHP_WIN32
+    _close(worker_stop_fds[1]);
+#else
+    close(worker_stop_fds[1]);
+#endif
+    worker_stop_fds[1] = -1;
+  }
+}
+
+static int frankenphp_worker_open_stop_pipe(void) {
+#ifdef PHP_WIN32
+  return _pipe(worker_stop_fds, 4096, _O_BINARY);
+#else
+  return pipe(worker_stop_fds);
+#endif
+}
+
+static int frankenphp_worker_dup_fd(int fd) {
+#ifdef PHP_WIN32
+  return _dup(fd);
+#else
+  return dup(fd);
+#endif
+}
 
 void frankenphp_update_local_thread_context(bool is_worker) {
   is_worker_thread = is_worker;
 
   /* workers should keep running if the user aborts the connection */
   PG(ignore_user_abort) = is_worker ? 1 : original_user_abort_setting;
+}
+
+static void bg_worker_vars_cache_dtor(zval *zv) {
+  bg_worker_vars_cache_entry *entry = Z_PTR_P(zv);
+  zval_ptr_dtor(&entry->value);
+  free(entry);
+}
+
+static void bg_worker_vars_cache_reset(void) {
+  if (worker_vars_cache) {
+    zend_hash_destroy(worker_vars_cache);
+    free(worker_vars_cache);
+    worker_vars_cache = NULL;
+  }
+}
+
+void frankenphp_set_worker_name(char *name, bool background) {
+  free(worker_name);
+  if (name) {
+    size_t len = strlen(name) + 1;
+    worker_name = malloc(len);
+    memcpy(worker_name, name, len);
+  } else {
+    worker_name = NULL;
+  }
+  is_background_worker = background;
+  if (!background) {
+    return;
+  }
+  worker_signaling_stream = NULL;
+  if (Z_TYPE(last_set_vars_zval) != IS_UNDEF) {
+    zval_ptr_dtor(&last_set_vars_zval);
+    ZVAL_UNDEF(&last_set_vars_zval);
+  }
+  zend_unset_timeout();
+
+  /* Create a pipe for stop signaling */
+  frankenphp_worker_close_stop_fds();
+  if (frankenphp_worker_open_stop_pipe() != 0) {
+    worker_stop_fds[0] = -1;
+    worker_stop_fds[1] = -1;
+  }
+}
+
+int frankenphp_worker_get_stop_fd_write(void) { return worker_stop_fds[1]; }
+
+static int bg_worker_pipe_write_impl(int fd, const char *buf, int len) {
+  if (fd < 0) {
+    return -1;
+  }
+
+#ifdef PHP_WIN32
+  return _write(fd, buf, len);
+#else
+  return (int)write(fd, buf, len);
+#endif
+}
+
+int frankenphp_worker_write_stop_fd(int fd) {
+  return bg_worker_pipe_write_impl(fd, "stop\n", 5);
+}
+
+int frankenphp_worker_write_task_signal(int fd) {
+  return bg_worker_pipe_write_impl(fd, "task\n", 5);
+}
+
+void frankenphp_worker_close_fd(int fd) {
+  if (fd >= 0) {
+#ifdef PHP_WIN32
+    _close(fd);
+#else
+    close(fd);
+#endif
+  }
 }
 
 static void frankenphp_update_request_context() {
@@ -539,11 +761,14 @@ PHP_FUNCTION(frankenphp_handle_request) {
   Z_PARAM_FUNC(fci, fcc)
   ZEND_PARSE_PARAMETERS_END();
 
-  if (!is_worker_thread) {
-    /* not a worker, throw an error */
+  if (!is_worker_thread || is_background_worker) {
     zend_throw_exception(
         spl_ce_RuntimeException,
-        "frankenphp_handle_request() called while not in worker mode", 0);
+        is_background_worker
+            ? "frankenphp_handle_request() cannot be called from a background "
+              "worker"
+            : "frankenphp_handle_request() called while not in worker mode",
+        0);
     RETURN_THROWS();
   }
 
@@ -601,6 +826,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
     }
   }
 
+  bg_worker_vars_cache_reset();
   frankenphp_worker_request_shutdown();
   go_frankenphp_finish_worker_request(thread_index, callback_ret);
   if (result.r1 != NULL) {
@@ -611,6 +837,263 @@ PHP_FUNCTION(frankenphp_handle_request) {
   }
 
   RETURN_TRUE;
+}
+
+/* Persistent zval helpers: validation, deep-copy, immutable detection, enums */
+#include "bg_worker_vars.h"
+
+PHP_FUNCTION(frankenphp_worker_set_vars) {
+  zval *vars_array = NULL;
+
+  ZEND_PARSE_PARAMETERS_START(1, 1);
+  Z_PARAM_ARRAY(vars_array);
+  ZEND_PARSE_PARAMETERS_END();
+
+  /* Skip if the new value is identical to the last one.
+   * Always update the cache so the next comparison can use pointer equality. */
+  if (Z_TYPE(last_set_vars_zval) != IS_UNDEF &&
+      zend_is_identical(vars_array, &last_set_vars_zval)) {
+    zval_ptr_dtor(&last_set_vars_zval);
+    ZVAL_COPY(&last_set_vars_zval, vars_array);
+    return;
+  }
+
+  HashTable *ht = Z_ARRVAL_P(vars_array);
+
+  if (bg_worker_is_immutable(ht)) {
+    /* Fast path: immutable arrays are already in shared memory.
+     * No validation needed (immutable arrays contain only safe types).
+     * No deep-copy needed. */
+    void *old = NULL;
+    char *error = go_frankenphp_worker_set_vars(thread_index, ht, &old);
+    if (error) {
+      zend_throw_exception(spl_ce_RuntimeException, error, 0);
+      free(error);
+      RETURN_THROWS();
+    }
+    bg_worker_free_stored_vars(old);
+  } else {
+    /* Slow path: validate, deep-copy to persistent memory */
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+      if (!bg_worker_validate_zval(val)) {
+        zend_value_error("Values must be null, scalars, arrays, or enums; "
+                         "objects and resources are not allowed");
+        RETURN_THROWS();
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    zval persistent;
+    bg_worker_persist_zval(&persistent, vars_array);
+
+    void *old = NULL;
+    char *error =
+        go_frankenphp_worker_set_vars(thread_index, Z_ARRVAL(persistent), &old);
+    if (error) {
+      bg_worker_free_persistent_zval(&persistent);
+      zend_throw_exception(spl_ce_RuntimeException, error, 0);
+      free(error);
+      RETURN_THROWS();
+    }
+    bg_worker_free_stored_vars(old);
+  }
+
+  /* Cache the new value for next comparison */
+  if (Z_TYPE(last_set_vars_zval) != IS_UNDEF) {
+    zval_ptr_dtor(&last_set_vars_zval);
+  }
+  ZVAL_COPY(&last_set_vars_zval, vars_array);
+}
+
+/* Copy vars from persistent storage into a PHP zval.
+ * For count == 1: copies directly into dst.
+ * For count > 1: creates a keyed array in dst.
+ * Returns true on success, false if an exception occurred. */
+bool frankenphp_worker_copy_vars(zval *dst, int count, char **names,
+                                 size_t *name_lens, void **ptrs) {
+  if (count == 1) {
+    if (ptrs[0]) {
+      bg_worker_read_stored_vars(dst, ptrs[0]);
+    } else {
+      array_init(dst);
+    }
+    return !EG(exception);
+  }
+
+  array_init(dst);
+  for (int i = 0; i < count; i++) {
+    zval worker_vars;
+    if (ptrs[i]) {
+      bg_worker_read_stored_vars(&worker_vars, ptrs[i]);
+      if (EG(exception)) {
+        zval_ptr_dtor(&worker_vars);
+        return false;
+      }
+    } else {
+      array_init(&worker_vars);
+    }
+    add_assoc_zval_ex(dst, names[i], name_lens[i], &worker_vars);
+  }
+  return true;
+}
+
+PHP_FUNCTION(frankenphp_worker_get_vars) {
+  zval *names = NULL;
+  double timeout = 30.0;
+
+  ZEND_PARSE_PARAMETERS_START(1, 2);
+  Z_PARAM_ZVAL(names);
+  Z_PARAM_OPTIONAL
+  Z_PARAM_DOUBLE(timeout);
+  ZEND_PARSE_PARAMETERS_END();
+
+  if (timeout < 0) {
+    zend_value_error("Timeout must not be negative");
+    RETURN_THROWS();
+  }
+  int timeout_ms = (int)(timeout * 1000);
+
+  if (Z_TYPE_P(names) == IS_STRING) {
+    if (Z_STRLEN_P(names) == 0) {
+      zend_value_error("Background worker name must not be empty");
+      RETURN_THROWS();
+    }
+
+    char *name_ptr = Z_STRVAL_P(names);
+    size_t name_len_val = Z_STRLEN_P(names);
+
+    /* Check per-request cache */
+    uint64_t caller_version = 0;
+    uint64_t out_version = 0;
+    bg_worker_vars_cache_entry *cached = NULL;
+    if (worker_vars_cache) {
+      zval *entry_zv =
+          zend_hash_str_find(worker_vars_cache, name_ptr, name_len_val);
+      if (entry_zv) {
+        cached = Z_PTR_P(entry_zv);
+        caller_version = cached->version;
+      }
+    }
+
+    char *error = go_frankenphp_worker_get_vars(
+        thread_index, &name_ptr, &name_len_val, 1, timeout_ms, return_value,
+        cached ? &caller_version : NULL, &out_version);
+    if (error) {
+      zend_throw_exception(spl_ce_RuntimeException, error, 0);
+      free(error);
+      RETURN_THROWS();
+    }
+    if (EG(exception)) {
+      RETURN_THROWS();
+    }
+
+    /* Cache hit: Go skipped the copy because version matched */
+    if (cached && out_version == caller_version) {
+      ZVAL_COPY(return_value, &cached->value);
+      return;
+    }
+
+    /* Cache miss: store the new result */
+    if (!worker_vars_cache) {
+      worker_vars_cache = malloc(sizeof(HashTable));
+      zend_hash_init(worker_vars_cache, 4, NULL, bg_worker_vars_cache_dtor, 1);
+    }
+    bg_worker_vars_cache_entry *entry = malloc(sizeof(*entry));
+    entry->version = out_version;
+    ZVAL_COPY(&entry->value, return_value);
+    zval entry_zv;
+    ZVAL_PTR(&entry_zv, entry);
+    zend_hash_str_update(worker_vars_cache, name_ptr, name_len_val, &entry_zv);
+
+    return;
+  }
+
+  if (Z_TYPE_P(names) != IS_ARRAY) {
+    zend_type_error("Argument #1 ($name) must be of type string|array, %s "
+                    "given",
+                    zend_zval_type_name(names));
+    RETURN_THROWS();
+  }
+
+  HashTable *ht = Z_ARRVAL_P(names);
+  zval *val;
+
+  ZEND_HASH_FOREACH_VAL(ht, val) {
+    if (Z_TYPE_P(val) != IS_STRING || Z_STRLEN_P(val) == 0) {
+      zend_value_error("All background worker names must be non-empty strings");
+      RETURN_THROWS();
+    }
+  }
+  ZEND_HASH_FOREACH_END();
+
+  int name_count = zend_hash_num_elements(ht);
+  char **name_ptrs = malloc(sizeof(char *) * name_count);
+  size_t *name_lens_arr = malloc(sizeof(size_t) * name_count);
+  int idx = 0;
+  ZEND_HASH_FOREACH_VAL(ht, val) {
+    name_ptrs[idx] = Z_STRVAL_P(val);
+    name_lens_arr[idx] = Z_STRLEN_P(val);
+    idx++;
+  }
+  ZEND_HASH_FOREACH_END();
+
+  char *error = go_frankenphp_worker_get_vars(
+      thread_index, name_ptrs, name_lens_arr, name_count, timeout_ms,
+      return_value, NULL, NULL);
+  free(name_ptrs);
+  free(name_lens_arr);
+  if (error) {
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
+}
+
+PHP_FUNCTION(frankenphp_worker_get_signaling_stream) {
+  ZEND_PARSE_PARAMETERS_NONE();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_worker_get_signaling_stream() can only "
+                         "be called from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  /* Return the cached stream if already created */
+  if (worker_signaling_stream != NULL) {
+    php_stream_to_zval(worker_signaling_stream, return_value);
+    GC_ADDREF(Z_COUNTED_P(return_value));
+    return;
+  }
+
+  if (worker_stop_fds[0] < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create background worker stop pipe", 0);
+    RETURN_THROWS();
+  }
+
+  int fd = frankenphp_worker_dup_fd(worker_stop_fds[0]);
+  if (fd < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to dup background worker stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  php_stream *stream = php_stream_fopen_from_fd(fd, "rb", NULL);
+  if (!stream) {
+    frankenphp_worker_close_fd(fd);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create stream from stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  worker_signaling_stream = stream;
+  php_stream_to_zval(stream, return_value);
+
+  /* Keep an extra ref so PHP can't destroy the stream while TLS caches it */
+  GC_ADDREF(Z_COUNTED_P(return_value));
 }
 
 PHP_FUNCTION(headers_send) {
@@ -1059,6 +1542,9 @@ static void *php_thread(void *arg) {
 #endif
 #endif
 
+  /* Save PHP's timer handle for best-effort force-kill after grace period */
+  frankenphp_save_php_timer(thread_index);
+
   bool thread_is_healthy = true;
   bool has_attempted_shutdown = false;
 
@@ -1078,6 +1564,44 @@ static void *php_thread(void *arg) {
         zend_bailout();
       }
 
+      /* Background worker setup: inject $_SERVER vars, skip shebang, disable
+       * timeout */
+      if (is_background_worker) {
+        CG(skip_shebang) = 1;
+        zend_unset_timeout();
+
+        zend_is_auto_global_str("_SERVER", sizeof("_SERVER") - 1);
+        zval *server = &PG(http_globals)[TRACK_VARS_SERVER];
+        if (server && Z_TYPE_P(server) == IS_ARRAY) {
+          if (worker_name != NULL) {
+            zval name_zval;
+            ZVAL_STRING(&name_zval, worker_name);
+            zend_hash_str_update(Z_ARRVAL_P(server), "FRANKENPHP_WORKER_NAME",
+                                 sizeof("FRANKENPHP_WORKER_NAME") - 1,
+                                 &name_zval);
+
+            zval bg_zval;
+            ZVAL_TRUE(&bg_zval);
+            zend_hash_str_update(
+                Z_ARRVAL_P(server), "FRANKENPHP_WORKER_BACKGROUND",
+                sizeof("FRANKENPHP_WORKER_BACKGROUND") - 1, &bg_zval);
+
+            zval argv_array;
+            array_init(&argv_array);
+            add_next_index_string(&argv_array, scriptName);
+            add_next_index_string(&argv_array, worker_name);
+
+            zval argc_zval;
+            ZVAL_LONG(&argc_zval, 2);
+
+            zend_hash_str_update(Z_ARRVAL_P(server), "argv", sizeof("argv") - 1,
+                                 &argv_array);
+            zend_hash_str_update(Z_ARRVAL_P(server), "argc", sizeof("argc") - 1,
+                                 &argc_zval);
+          }
+        }
+      }
+
       zend_file_handle file_handle;
       zend_stream_init_filename(&file_handle, scriptName);
 
@@ -1094,6 +1618,13 @@ static void *php_thread(void *arg) {
                        zend_memory_usage(0), __ATOMIC_RELAXED);
 
       has_attempted_shutdown = true;
+
+      /* Clean up background worker caches before request shutdown */
+      bg_worker_vars_cache_reset();
+      if (Z_TYPE(last_set_vars_zval) != IS_UNDEF) {
+        zval_ptr_dtor(&last_set_vars_zval);
+        ZVAL_UNDEF(&last_set_vars_zval);
+      }
 
       /* shutdown the request, potential bailout to zend_catch */
       php_request_shutdown((void *)0);
@@ -1129,6 +1660,8 @@ static void *php_thread(void *arg) {
 #ifdef ZTS
   ts_free_thread();
 #endif
+
+  frankenphp_worker_close_stop_fds();
 
   /* Thread is healthy, signal to Go that the thread has shut down */
   if (thread_is_healthy) {
@@ -1276,6 +1809,98 @@ bool frankenphp_new_php_thread(uintptr_t thread_index) {
   }
   pthread_detach(thread);
   return true;
+}
+
+static int frankenphp_request_startup() {
+  frankenphp_update_request_context();
+  if (php_request_startup() == SUCCESS) {
+    return SUCCESS;
+  }
+
+  php_request_shutdown((void *)0);
+  frankenphp_free_request_context();
+
+  return FAILURE;
+}
+
+int frankenphp_execute_script(char *file_name) {
+  if (frankenphp_request_startup() == FAILURE) {
+
+    return FAILURE;
+  }
+
+  int status = SUCCESS;
+
+  zend_file_handle file_handle;
+  zend_stream_init_filename(&file_handle, file_name);
+
+  file_handle.primary_script = 1;
+
+  if (worker_name != NULL) {
+    zend_is_auto_global_str("_SERVER", sizeof("_SERVER") - 1);
+    zval *server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (server && Z_TYPE_P(server) == IS_ARRAY) {
+      zval name_zval;
+      ZVAL_STRING(&name_zval, worker_name);
+      zend_hash_str_update(Z_ARRVAL_P(server), "FRANKENPHP_WORKER_NAME",
+                           sizeof("FRANKENPHP_WORKER_NAME") - 1, &name_zval);
+
+      zval bg_zval;
+      ZVAL_BOOL(&bg_zval, is_background_worker);
+      zend_hash_str_update(Z_ARRVAL_P(server), "FRANKENPHP_WORKER_BACKGROUND",
+                           sizeof("FRANKENPHP_WORKER_BACKGROUND") - 1,
+                           &bg_zval);
+    }
+  }
+
+  if (is_background_worker) {
+    CG(skip_shebang) = 1;
+
+    /* Background workers run indefinitely - disable max_execution_time */
+    zend_set_timeout(0, 0);
+
+    zval *server = &PG(http_globals)[TRACK_VARS_SERVER];
+    if (server && Z_TYPE_P(server) == IS_ARRAY) {
+      zval argv_array;
+      array_init(&argv_array);
+      add_next_index_string(&argv_array, file_name);
+      add_next_index_string(&argv_array, worker_name);
+
+      zval argc_zval;
+      ZVAL_LONG(&argc_zval, 2);
+
+      zend_hash_str_update(Z_ARRVAL_P(server), "argv", sizeof("argv") - 1,
+                           &argv_array);
+      zend_hash_str_update(Z_ARRVAL_P(server), "argc", sizeof("argc") - 1,
+                           &argc_zval);
+    }
+  }
+
+  zend_first_try {
+    EG(exit_status) = 0;
+    php_execute_script(&file_handle);
+    status = EG(exit_status);
+  }
+  zend_catch { status = EG(exit_status); }
+  zend_end_try();
+
+  zend_destroy_file_handle(&file_handle);
+
+  /* Reset the sandboxed environment if it is in use */
+  if (sandboxed_env != NULL) {
+    zend_hash_release(sandboxed_env);
+    sandboxed_env = NULL;
+  }
+
+  bg_worker_vars_cache_reset();
+  if (Z_TYPE(last_set_vars_zval) != IS_UNDEF) {
+    zval_ptr_dtor(&last_set_vars_zval);
+    ZVAL_UNDEF(&last_set_vars_zval);
+  }
+  php_request_shutdown((void *)0);
+  frankenphp_free_request_context();
+
+  return status;
 }
 
 /* Use global variables to store CLI arguments to prevent useless allocations */

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -306,6 +306,18 @@ int frankenphp_worker_write_task_signal(int fd) {
   return bg_worker_pipe_write_impl(fd, "task\n", 5);
 }
 
+int frankenphp_worker_pipe_nudge(int fd) {
+  return bg_worker_pipe_write_impl(fd, "\n", 1);
+}
+
+int frankenphp_worker_create_pipe(int *fds) {
+#ifdef PHP_WIN32
+  return _pipe(fds, 4096, _O_BINARY);
+#else
+  return pipe(fds);
+#endif
+}
+
 void frankenphp_worker_close_fd(int fd) {
   if (fd >= 0) {
 #ifdef PHP_WIN32
@@ -842,6 +854,11 @@ PHP_FUNCTION(frankenphp_handle_request) {
 /* Persistent zval helpers: validation, deep-copy, immutable detection, enums */
 #include "bg_worker_vars.h"
 
+/* Go-callable wrapper to free a persistent HashTable (used by task cleanup) */
+void frankenphp_worker_free_persistent_ht(void *ptr) {
+  bg_worker_free_stored_vars(ptr);
+}
+
 PHP_FUNCTION(frankenphp_worker_set_vars) {
   zval *vars_array = NULL;
 
@@ -1094,6 +1111,408 @@ PHP_FUNCTION(frankenphp_worker_get_signaling_stream) {
 
   /* Keep an extra ref so PHP can't destroy the stream while TLS caches it */
   GC_ADDREF(Z_COUNTED_P(return_value));
+}
+
+/* Custom stream ops for background worker task (sender/read side) */
+typedef struct {
+  int task_id;
+  int read_fd;
+} bg_worker_task_sender_data;
+
+static ssize_t bg_worker_task_sender_write(php_stream *stream, const char *buf,
+                                           size_t count) {
+  return -1; /* read-only stream */
+}
+
+static ssize_t bg_worker_task_sender_read(php_stream *stream, char *buf,
+                                          size_t count) {
+  bg_worker_task_sender_data *data =
+      (bg_worker_task_sender_data *)stream->abstract;
+  if (!data || data->read_fd < 0)
+    return -1;
+#ifdef PHP_WIN32
+  return _read(data->read_fd, buf, (unsigned int)count);
+#else
+  return read(data->read_fd, buf, count);
+#endif
+}
+
+static int bg_worker_task_sender_close(php_stream *stream, int close_handle) {
+  bg_worker_task_sender_data *data =
+      (bg_worker_task_sender_data *)stream->abstract;
+  if (data) {
+    go_frankenphp_worker_task_cancel(data->task_id);
+    frankenphp_worker_close_fd(data->read_fd);
+    free(data);
+    stream->abstract = NULL;
+  }
+  return 0;
+}
+
+static int bg_worker_task_sender_cast(php_stream *stream, int castas,
+                                      void **ret) {
+  bg_worker_task_sender_data *data =
+      (bg_worker_task_sender_data *)stream->abstract;
+  if (!data)
+    return FAILURE;
+
+  switch (castas) {
+  case PHP_STREAM_AS_FD:
+  case PHP_STREAM_AS_SOCKETD:
+    if (ret)
+      *(int *)ret = data->read_fd;
+    return SUCCESS;
+  default:
+    return FAILURE;
+  }
+}
+
+static const php_stream_ops bg_worker_task_sender_ops = {
+    bg_worker_task_sender_write, /* write */
+    bg_worker_task_sender_read,  /* read */
+    bg_worker_task_sender_close, /* close */
+    NULL,                        /* flush */
+    "bg_worker_task_sender",     /* label */
+    NULL,                        /* seek */
+    bg_worker_task_sender_cast,  /* cast */
+    NULL,                        /* stat */
+    NULL,                        /* set_option */
+};
+
+PHP_FUNCTION(frankenphp_worker_task_send) {
+  char *name = NULL;
+  size_t name_len = 0;
+  zval *payload = NULL;
+  double timeout = 30.0;
+
+  ZEND_PARSE_PARAMETERS_START(2, 3);
+  Z_PARAM_STRING(name, name_len);
+  Z_PARAM_ARRAY(payload);
+  Z_PARAM_OPTIONAL;
+  Z_PARAM_DOUBLE(timeout);
+  ZEND_PARSE_PARAMETERS_END();
+
+  if (name_len == 0) {
+    zend_value_error("Background worker name must not be empty");
+    RETURN_THROWS();
+  }
+
+  HashTable *payload_ht;
+  bool payload_immutable = bg_worker_is_immutable(Z_ARRVAL_P(payload));
+
+  if (payload_immutable) {
+    payload_ht = Z_ARRVAL_P(payload);
+  } else {
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(payload), val) {
+      if (!bg_worker_validate_zval(val)) {
+        zend_value_error("Task payload values must be null, scalars, arrays, "
+                         "or enums; objects and resources are not allowed");
+        RETURN_THROWS();
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    zval persistent_payload;
+    bg_worker_persist_zval(&persistent_payload, payload);
+    payload_ht = Z_ARRVAL(persistent_payload);
+  }
+
+  int task_id = -1;
+  int read_fd = -1;
+  int timeout_ms = (int)(timeout * 1000);
+  if (timeout_ms < 0) {
+    timeout_ms = 0;
+  }
+  char *error = go_frankenphp_worker_task_send(
+      thread_index, name, name_len, payload_ht, timeout_ms, &task_id, &read_fd);
+  if (error) {
+    if (!payload_immutable) {
+      zval z;
+      ZVAL_ARR(&z, payload_ht);
+      bg_worker_free_persistent_zval(&z);
+    }
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
+
+  /* Create a custom sender stream */
+  bg_worker_task_sender_data *sdata =
+      malloc(sizeof(bg_worker_task_sender_data));
+  sdata->task_id = task_id;
+  sdata->read_fd = read_fd;
+
+  php_stream *stream =
+      php_stream_alloc(&bg_worker_task_sender_ops, sdata, NULL, "rb");
+  if (!stream) {
+    free(sdata);
+    go_frankenphp_worker_task_cancel(task_id);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create task stream", 0);
+    RETURN_THROWS();
+  }
+
+  zval task_id_zval;
+  ZVAL_LONG(&task_id_zval, task_id);
+  stream->wrapperdata = task_id_zval;
+
+  php_stream_to_zval(stream, return_value);
+}
+
+PHP_FUNCTION(frankenphp_worker_task_read) {
+  zval *stream_zval = NULL;
+
+  ZEND_PARSE_PARAMETERS_START(1, 1);
+  Z_PARAM_RESOURCE(stream_zval);
+  ZEND_PARSE_PARAMETERS_END();
+
+  php_stream *stream = NULL;
+  php_stream_from_zval_no_verify(stream, stream_zval);
+  if (!stream || stream->ops != &bg_worker_task_sender_ops) {
+    zend_value_error(
+        "Argument #1 must be a task stream from frankenphp_worker_task_send()");
+    RETURN_THROWS();
+  }
+
+  if (!stream->abstract) {
+    RETURN_NULL(); /* stream already closed */
+  }
+
+  int task_id = (int)Z_LVAL(stream->wrapperdata);
+
+  /* Consume the signal byte from the pipe */
+  char buf[1];
+  if (php_stream_read(stream, buf, 1) <= 0) {
+    /* Pipe EOF - drain remaining FIFO items */
+    int eof_result = go_frankenphp_worker_task_read(task_id, NULL);
+    if (eof_result == -2) {
+      zend_throw_exception(spl_ce_RuntimeException,
+                           "background worker exited without completing the task",
+                           0);
+      RETURN_THROWS();
+    }
+    RETURN_NULL();
+  }
+
+  void *data = NULL;
+  int result = go_frankenphp_worker_task_read(task_id, &data);
+  if (result == -2) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "background worker exited without completing the task", 0);
+    RETURN_THROWS();
+  }
+  if (result < 0 || data == NULL) {
+    RETURN_NULL();
+  }
+
+  HashTable *data_ht = (HashTable *)data;
+  if (bg_worker_is_immutable(data_ht)) {
+    ZVAL_ARR(return_value, data_ht);
+  } else {
+    zval src;
+    ZVAL_ARR(&src, data_ht);
+    bg_worker_move_zval(return_value, &src);
+  }
+}
+
+/* Custom stream ops for background worker task (receiver/write side) */
+typedef struct {
+  int task_id;
+  int write_fd;
+} bg_worker_task_stream_data;
+
+static ssize_t bg_worker_task_write(php_stream *stream, const char *buf,
+                                    size_t count) {
+  return -1; /* writing is done via task_update, not stream write */
+}
+
+static ssize_t bg_worker_task_read(php_stream *stream, char *buf,
+                                   size_t count) {
+  return -1; /* write-only stream */
+}
+
+static int bg_worker_task_close(php_stream *stream, int close_handle) {
+  bg_worker_task_stream_data *data =
+      (bg_worker_task_stream_data *)stream->abstract;
+  if (data) {
+    /* During explicit fclose(): clean close. During request shutdown
+     * (exit/crash): skip - afterScriptExecution handles cleanup. */
+    if (!(EG(flags) & EG_FLAGS_IN_SHUTDOWN)) {
+      go_frankenphp_worker_task_close(thread_index, data->task_id);
+    }
+    free(data);
+    stream->abstract = NULL;
+  }
+  return 0;
+}
+
+static int bg_worker_task_cast(php_stream *stream, int castas, void **ret) {
+  bg_worker_task_stream_data *data =
+      (bg_worker_task_stream_data *)stream->abstract;
+  if (!data)
+    return FAILURE;
+
+  switch (castas) {
+  case PHP_STREAM_AS_FD:
+  case PHP_STREAM_AS_SOCKETD:
+    if (ret)
+      *(int *)ret = data->write_fd;
+    return SUCCESS;
+  default:
+    return FAILURE;
+  }
+}
+
+static const php_stream_ops bg_worker_task_stream_ops = {
+    bg_worker_task_write, /* write */
+    bg_worker_task_read,  /* read */
+    bg_worker_task_close, /* close */
+    NULL,                 /* flush */
+    "bg_worker_task",     /* label */
+    NULL,                 /* seek */
+    bg_worker_task_cast,  /* cast */
+    NULL,                 /* stat */
+    NULL,                 /* set_option */
+};
+
+PHP_FUNCTION(frankenphp_worker_task_receive) {
+  ZEND_PARSE_PARAMETERS_NONE();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_worker_task_receive() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  void *payload = NULL;
+  int task_id = -1;
+  int result =
+      go_frankenphp_worker_task_receive(thread_index, &payload, &task_id);
+  if (result < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_worker_task_receive() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+  if (result == 0) {
+    RETURN_NULL();
+  }
+
+  /* Create a custom task stream (write side) */
+  bg_worker_task_stream_data *sdata =
+      malloc(sizeof(bg_worker_task_stream_data));
+  sdata->task_id = task_id;
+  sdata->write_fd = -1; /* set by Go via pipe */
+
+  php_stream *stream =
+      php_stream_alloc(&bg_worker_task_stream_ops, sdata, NULL, "wb");
+  if (!stream) {
+    free(sdata);
+    go_frankenphp_worker_task_close(thread_index, task_id);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create task stream", 0);
+    RETURN_THROWS();
+  }
+
+  /* Store task_id in wrapperdata for task_update */
+  zval task_id_zval;
+  ZVAL_LONG(&task_id_zval, task_id);
+  stream->wrapperdata = task_id_zval;
+
+  /* Return [stream, payload] */
+  array_init(return_value);
+
+  zval stream_zval;
+  php_stream_to_zval(stream, &stream_zval);
+  add_next_index_zval(return_value, &stream_zval);
+
+  zval payload_zval;
+  if (payload) {
+    HashTable *pht = (HashTable *)payload;
+    if (bg_worker_is_immutable(pht)) {
+      ZVAL_ARR(&payload_zval, pht);
+    } else {
+      zval src;
+      ZVAL_ARR(&src, pht);
+      bg_worker_move_zval(&payload_zval, &src);
+    }
+  } else {
+    array_init(&payload_zval);
+  }
+  add_next_index_zval(return_value, &payload_zval);
+}
+
+PHP_FUNCTION(frankenphp_worker_task_update) {
+  zval *stream_zval = NULL;
+  zval *data = NULL;
+
+  ZEND_PARSE_PARAMETERS_START(2, 2);
+  Z_PARAM_RESOURCE(stream_zval);
+  Z_PARAM_ARRAY(data);
+  ZEND_PARSE_PARAMETERS_END();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_worker_task_update() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  php_stream *stream = NULL;
+  php_stream_from_zval_no_verify(stream, stream_zval);
+  if (!stream || stream->ops != &bg_worker_task_stream_ops) {
+    zend_value_error("Argument #1 must be a task stream from "
+                     "frankenphp_worker_task_receive()");
+    RETURN_THROWS();
+  }
+
+  if (!stream->abstract) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "task stream is already closed", 0);
+    RETURN_THROWS();
+  }
+
+  int task_id = (int)Z_LVAL(stream->wrapperdata);
+
+  HashTable *update_ht;
+  bool update_immutable = bg_worker_is_immutable(Z_ARRVAL_P(data));
+
+  if (update_immutable) {
+    update_ht = Z_ARRVAL_P(data);
+  } else {
+    /* Validate data */
+    zval *val;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(data), val) {
+      if (!bg_worker_validate_zval(val)) {
+        zend_value_error(
+            "Task update values must be null, scalars, arrays, or enums");
+        RETURN_THROWS();
+      }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    /* Deep-copy to persistent memory */
+    zval persistent;
+    bg_worker_persist_zval(&persistent, data);
+    update_ht = Z_ARRVAL(persistent);
+  }
+
+  char *error = go_frankenphp_worker_task_update(task_id, update_ht);
+  if (error) {
+    if (!update_immutable) {
+      zval z;
+      ZVAL_ARR(&z, update_ht);
+      bg_worker_free_persistent_zval(&z);
+    }
+    zend_throw_exception(spl_ce_RuntimeException, error, 0);
+    free(error);
+    RETURN_THROWS();
+  }
 }
 
 PHP_FUNCTION(headers_send) {

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -48,6 +48,7 @@ var (
 	ErrMainThreadCreation = errors.New("error creating the main thread")
 	ErrScriptExecution    = errors.New("error during PHP script execution")
 	ErrNotRunning         = errors.New("FrankenPHP is not running. For proper configuration visit: https://frankenphp.dev/docs/config/#caddyfile-config")
+	ErrNotHTTPWorker      = errors.New("worker is not an HTTP worker")
 
 	ErrInvalidRequestPath         = ErrRejected{"invalid request path", http.StatusBadRequest}
 	ErrInvalidContentLengthHeader = ErrRejected{"invalid Content-Length header", http.StatusBadRequest}
@@ -156,8 +157,23 @@ func Config() PHPConfig {
 func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
 	maxProcs := runtime.GOMAXPROCS(0) * 2
 	maxThreadsFromWorkers := 0
+	reservedThreads := 0
 
 	for i, w := range opt.workers {
+		if w.isBackgroundWorker {
+			// Reserve at least 1 thread for each background worker
+			if w.maxThreads == 0 && w.num == 0 {
+				opt.workers[i].maxThreads = 1
+			}
+			extra := w.num
+			if extra < 1 {
+				extra = 1
+			}
+			reservedThreads += extra
+			numWorkers += extra
+			continue
+		}
+
 		if w.num <= 0 {
 			// https://github.com/php/frankenphp/issues/126
 			opt.workers[i].num = maxProcs
@@ -199,6 +215,8 @@ func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
 			return 0, fmt.Errorf("num_threads (%d) must be greater than the number of worker threads (%d)", opt.numThreads, numWorkers)
 		}
 
+		opt.numThreads += reservedThreads
+		opt.maxThreads += reservedThreads
 		return numWorkers, nil
 	}
 
@@ -208,6 +226,8 @@ func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
 			return 0, fmt.Errorf("max_threads (%d) must be greater than the number of worker threads (%d)", opt.maxThreads, numWorkers)
 		}
 
+		opt.numThreads += reservedThreads
+		opt.maxThreads += reservedThreads
 		return numWorkers, nil
 	}
 
@@ -220,6 +240,8 @@ func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
 		}
 		opt.maxThreads = opt.numThreads
 
+		opt.numThreads += reservedThreads
+		opt.maxThreads += reservedThreads
 		return numWorkers, nil
 	}
 
@@ -232,6 +254,8 @@ func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
 		return 0, fmt.Errorf("max_threads (%d) must be greater than or equal to num_threads (%d)", opt.maxThreads, opt.numThreads)
 	}
 
+	opt.numThreads += reservedThreads
+	opt.maxThreads += reservedThreads
 	return numWorkers, nil
 }
 
@@ -414,6 +438,9 @@ func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error 
 
 	// Detect if a worker is available to handle this request
 	if fc.worker != nil {
+		if fc.worker.isBackgroundWorker {
+			return ErrNotHTTPWorker
+		}
 		return fc.worker.handleRequest(ch)
 	}
 

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -174,8 +174,11 @@ void frankenphp_set_worker_name(char *name, bool background);
 int frankenphp_worker_get_stop_fd_write(void);
 int frankenphp_worker_write_stop_fd(int fd);
 int frankenphp_worker_write_task_signal(int fd);
+int frankenphp_worker_pipe_nudge(int fd);
+void frankenphp_worker_free_persistent_ht(void *ptr);
 bool frankenphp_worker_copy_vars(zval *dst, int count, char **names,
                                  size_t *name_lens, void **ptrs);
+int frankenphp_worker_create_pipe(int *fds);
 void frankenphp_worker_close_fd(int fd);
 int frankenphp_execute_script_cli(char *script, int argc, char **argv,
                                   bool eval);

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -170,7 +170,13 @@ bool frankenphp_new_php_thread(uintptr_t thread_index);
 
 bool frankenphp_shutdown_dummy_request(void);
 void frankenphp_update_local_thread_context(bool is_worker);
-
+void frankenphp_set_worker_name(char *name, bool background);
+int frankenphp_worker_get_stop_fd_write(void);
+int frankenphp_worker_write_stop_fd(int fd);
+int frankenphp_worker_write_task_signal(int fd);
+bool frankenphp_worker_copy_vars(zval *dst, int count, char **names,
+                                 size_t *name_lens, void **ptrs);
+void frankenphp_worker_close_fd(int fd);
 int frankenphp_execute_script_cli(char *script, int argc, char **argv,
                                   bool eval);
 
@@ -194,5 +200,10 @@ void frankenphp_destroy_thread_metrics(void);
 size_t frankenphp_get_thread_memory_usage(uintptr_t thread_index);
 
 void register_extensions(zend_module_entry **m, int len);
+
+void frankenphp_init_force_kill(int num_threads);
+void frankenphp_save_php_timer(uintptr_t thread_index);
+void frankenphp_force_kill_thread(uintptr_t thread_index);
+void frankenphp_destroy_force_kill(void);
 
 #endif

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -16,6 +16,19 @@ const FRANKENPHP_LOG_LEVEL_ERROR = 8;
 
 function frankenphp_handle_request(callable $callback): bool {}
 
+/**
+ * @param array<null|scalar|\UnitEnum|array<mixed>> $vars Nested arrays must recursively follow the same type constraints
+ */
+function frankenphp_worker_set_vars(array $vars): void {}
+
+/**
+ * @return array<null|scalar|array<mixed>|\UnitEnum> Nested arrays recursively follow the same type constraints
+ */
+function frankenphp_worker_get_vars(string|array $name, float $timeout = 30.0): array {}
+
+/** @return resource */
+function frankenphp_worker_get_signaling_stream() {}
+
 function headers_send(int $status = 200): int {}
 
 function frankenphp_finish_request(): bool {}
@@ -50,7 +63,7 @@ function apache_response_headers(): array|bool {}
 function mercure_publish(string|array $topics, string $data = '', bool $private = false, ?string $id = null, ?string $type = null, ?int $retry = null): string {}
 
 /**
- * @param int $level The importance or severity of a log event. The higher the level, the more important or severe the event. For more details, see: https://pkg.go.dev/log/slog#Level
- * array<string, any> $context Values of the array will be converted to the corresponding Go type (if supported by FrankenPHP) and added to the context of the structured logs using https://pkg.go.dev/log/slog#Attr
+ * @param int                  $level   The importance or severity of a log event. The higher the level, the more important or severe the event. For more details, see: https://pkg.go.dev/log/slog#Level
+ * @param array<string, mixed> $context Values of the array will be converted to the corresponding Go type (if supported by FrankenPHP) and added to the context of the structured logs using https://pkg.go.dev/log/slog#Attr
  */
 function frankenphp_log(string $message, int $level = 0, array $context = []): void {}

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -29,6 +29,50 @@ function frankenphp_worker_get_vars(string|array $name, float $timeout = 30.0): 
 /** @return resource */
 function frankenphp_worker_get_signaling_stream() {}
 
+/**
+ * Sends a task to a background worker and returns a readable stream for receiving updates.
+ * The background worker is started if not already running (at-most-once).
+ * Close the stream with fclose() to cancel the task.
+ *
+ * @param array<array-key, null|scalar|\UnitEnum|array<mixed>> $payload
+ * @return resource A readable stream - use stream_select() to wait for updates, task_read() to dequeue
+ * @throws \ValueError If name is empty or payload contains unsupported types
+ * @throws \RuntimeException If the background worker cannot be started
+ */
+function frankenphp_worker_task_send(string $name, array $payload, float $timeout = 30.0) {}
+
+/**
+ * Reads the next update from a task stream. Returns null on EOF (task completed).
+ *
+ * @param resource $stream The stream returned by task_send()
+ * @return array|null The update data, or null when the background worker closed the stream cleanly
+ * @throws \RuntimeException If the background worker exited without completing the task
+ * @throws \ValueError If the argument is not a task stream from task_send()
+ */
+function frankenphp_worker_task_read(mixed $stream): ?array {}
+
+/**
+ * Dequeues the next pending task. Call after reading "task\n" from the signaling stream.
+ * Returns [$taskStream, $payload] or false if no task is available (spurious signal,
+ * cancelled task, or fan-out contention with num > 1).
+ * Can only be called from a background worker.
+ *
+ * @return array{resource, array}|null [$stream, $payload] or null
+ * @throws \RuntimeException If not called from a background worker
+ */
+function frankenphp_worker_task_receive(): ?array {}
+
+/**
+ * Sends an update to the task sender. Blocks if the FIFO is full (backpressure).
+ * Can only be called from a background worker with a task stream from task_receive().
+ *
+ * @param resource $stream The stream from task_receive()
+ * @param array<array-key, null|scalar|\UnitEnum|array<mixed>> $data
+ * @throws \ValueError If the argument is not a task stream from task_receive()
+ * @throws \RuntimeException If not called from a background worker, stream is closed, or cancelled by sender
+ */
+function frankenphp_worker_task_update(mixed $stream, array $data): void {}
+
 function headers_send(int $status = 200): int {}
 
 function frankenphp_finish_request(): bool {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -5,6 +5,18 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1,
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_worker_set_vars, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, vars, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_worker_get_vars, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, name, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "30.0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_frankenphp_worker_get_signaling_stream, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_headers_send, 0, 0, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, status, IS_LONG, 0, "200")
 ZEND_END_ARG_INFO()
@@ -43,6 +55,9 @@ ZEND_END_ARG_INFO()
 
 
 ZEND_FUNCTION(frankenphp_handle_request);
+ZEND_FUNCTION(frankenphp_worker_set_vars);
+ZEND_FUNCTION(frankenphp_worker_get_vars);
+ZEND_FUNCTION(frankenphp_worker_get_signaling_stream);
 ZEND_FUNCTION(headers_send);
 ZEND_FUNCTION(frankenphp_finish_request);
 ZEND_FUNCTION(frankenphp_request_headers);
@@ -53,6 +68,9 @@ ZEND_FUNCTION(frankenphp_log);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(frankenphp_handle_request, arginfo_frankenphp_handle_request)
+	ZEND_FE(frankenphp_worker_set_vars, arginfo_frankenphp_worker_set_vars)
+	ZEND_FE(frankenphp_worker_get_vars, arginfo_frankenphp_worker_get_vars)
+	ZEND_FE(frankenphp_worker_get_signaling_stream, arginfo_frankenphp_worker_get_signaling_stream)
 	ZEND_FE(headers_send, arginfo_headers_send)
 	ZEND_FE(frankenphp_finish_request, arginfo_frankenphp_finish_request)
 	ZEND_FALIAS(fastcgi_finish_request, frankenphp_finish_request, arginfo_fastcgi_finish_request)

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -17,6 +17,24 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_frankenphp_worker_get_signaling_stream, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_frankenphp_worker_task_send, 0, 0, 2)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, payload, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "30.0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_frankenphp_worker_task_read, 0, 1, MAY_BE_ARRAY|MAY_BE_NULL)
+	ZEND_ARG_TYPE_INFO(0, stream, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_frankenphp_worker_task_receive, 0, 0, MAY_BE_ARRAY|MAY_BE_NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_worker_task_update, 0, 2, IS_VOID, 0)
+	ZEND_ARG_INFO(0, stream)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_headers_send, 0, 0, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, status, IS_LONG, 0, "200")
 ZEND_END_ARG_INFO()
@@ -58,6 +76,10 @@ ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(frankenphp_worker_set_vars);
 ZEND_FUNCTION(frankenphp_worker_get_vars);
 ZEND_FUNCTION(frankenphp_worker_get_signaling_stream);
+ZEND_FUNCTION(frankenphp_worker_task_send);
+ZEND_FUNCTION(frankenphp_worker_task_read);
+ZEND_FUNCTION(frankenphp_worker_task_receive);
+ZEND_FUNCTION(frankenphp_worker_task_update);
 ZEND_FUNCTION(headers_send);
 ZEND_FUNCTION(frankenphp_finish_request);
 ZEND_FUNCTION(frankenphp_request_headers);
@@ -71,6 +93,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(frankenphp_worker_set_vars, arginfo_frankenphp_worker_set_vars)
 	ZEND_FE(frankenphp_worker_get_vars, arginfo_frankenphp_worker_get_vars)
 	ZEND_FE(frankenphp_worker_get_signaling_stream, arginfo_frankenphp_worker_get_signaling_stream)
+	ZEND_FE(frankenphp_worker_task_send, arginfo_frankenphp_worker_task_send)
+	ZEND_FE(frankenphp_worker_task_read, arginfo_frankenphp_worker_task_read)
+	ZEND_FE(frankenphp_worker_task_receive, arginfo_frankenphp_worker_task_receive)
+	ZEND_FE(frankenphp_worker_task_update, arginfo_frankenphp_worker_task_update)
 	ZEND_FE(headers_send, arginfo_headers_send)
 	ZEND_FE(frankenphp_finish_request, arginfo_frankenphp_finish_request)
 	ZEND_FALIAS(fastcgi_finish_request, frankenphp_finish_request, arginfo_fastcgi_finish_request)

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -7,6 +7,8 @@ package frankenphp_test
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -23,8 +25,8 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"runtime"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,6 +48,7 @@ type testOptions struct {
 	realServer         bool
 	logger             *slog.Logger
 	initOpts           []frankenphp.Option
+	workerOpts         []frankenphp.WorkerOption
 	requestOpts        []frankenphp.RequestOption
 	phpIni             map[string]string
 }
@@ -67,6 +70,7 @@ func runTest(t *testing.T, test func(func(http.ResponseWriter, *http.Request), *
 			frankenphp.WithWorkerEnv(opts.env),
 			frankenphp.WithWorkerWatchMode(opts.watch),
 		}
+		workerOpts = append(workerOpts, opts.workerOpts...)
 		initOpts = append(initOpts, frankenphp.WithWorkers("workerName", testDataDir+opts.workerScript, opts.nbWorkers, workerOpts...))
 	}
 	initOpts = append(initOpts, opts.initOpts...)
@@ -801,6 +805,319 @@ func testFileUpload(t *testing.T, opts *testOptions) {
 
 		assert.Contains(t, string(body), "Upload OK")
 	}, opts)
+}
+
+func TestBackgroundWorkerGetVars(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-with-argv.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		// get_vars blocks until the background worker calls set_vars - no polling needed
+		body, _ := testGet("http://example.com/background-worker-start.php", handler, t)
+		assert.Equal(t, "test-worker", body)
+	}, &testOptions{
+		workerScript:       "background-worker-start.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerGetVarsIdentity(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-with-argv.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-identity.php", handler, t)
+		assert.Equal(t, "IDENTICAL", body)
+	}, &testOptions{
+		workerScript:       "background-worker-identity.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerAtMostOnce(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-dedup.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-start-twice.php", handler, t)
+		assert.Equal(t, "dedup-worker", body)
+	}, &testOptions{
+		workerScript:       "background-worker-start-twice.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerNoEntrypoint(t *testing.T) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-no-entrypoint.php", handler, t)
+		assert.Equal(t, "no background worker configured in this php_server", body)
+	}, &testOptions{
+		workerScript:       "background-worker-no-entrypoint.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+	})
+}
+
+func TestBackgroundWorkerSetVarsValidation(t *testing.T) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-set-server-var-validation.php", handler, t)
+		assert.Contains(t, body, "NON_BACKGROUND:blocked")
+		assert.Contains(t, body, "STREAM_NON_BACKGROUND:blocked")
+	}, &testOptions{
+		workerScript:       "background-worker-set-server-var-validation.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+	})
+}
+
+func TestBackgroundWorkerTypeValidation(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-type-validation-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-type-validation.php", handler, t)
+		assert.Contains(t, body, "INT_VAL:allowed")
+		assert.Contains(t, body, "INT_KEY:allowed")
+		assert.Contains(t, body, "NESTED:allowed")
+		assert.Contains(t, body, "OBJECT:blocked")
+		assert.Contains(t, body, "REFERENCE:blocked")
+		assert.Contains(t, body, "ENUM:allowed")
+		assert.Contains(t, body, "ENUM_RESTORED:match")
+	}, &testOptions{
+		workerScript:       "background-worker-type-validation.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerBinarySafe(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-binary-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-binary-safe.php", handler, t)
+		assert.Contains(t, body, "BINARY_LEN:11")
+		assert.Contains(t, body, "BINARY_CONTENT:"+hex.EncodeToString([]byte("hello\x00world")))
+		assert.Contains(t, body, "UTF8:héllo wörld 🚀")
+		assert.Contains(t, body, "EMPTY_EXISTS:yes")
+		assert.Contains(t, body, "EMPTY_LEN:0")
+	}, &testOptions{
+		workerScript:       "background-worker-binary-safe.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerGetVarsMultiple(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-multi-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-multi.php", handler, t)
+		assert.Equal(t, "worker-a:NAME_WORKER_A=worker-a,worker-b:NAME_WORKER_B=worker-b", body)
+	}, &testOptions{
+		workerScript:       "background-worker-multi.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerEnumMissing(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-enum-missing-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-enum-missing.php", handler, t)
+		assert.Contains(t, body, "LogicException:")
+		assert.Contains(t, body, "SidekickOnlyEnum")
+	}, &testOptions{
+		workerScript:       "background-worker-enum-missing.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerCrashRestart(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-crash.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		// get_vars blocks - background worker crashes, restarts, then publishes
+		body, _ := testGet("http://example.com/background-worker-crash-starter.php", handler, t)
+		assert.Equal(t, "restarted", body)
+	}, &testOptions{
+		workerScript:       "background-worker-crash-starter.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerSignalingStream(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-stop-fd-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-stop-fd.php", handler, t)
+		assert.Equal(t, "stream", body)
+	}, &testOptions{
+		workerScript:       "background-worker-stop-fd.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerStopsOnWorkerRestart(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-restart-entrypoint.php"
+	name := fmt.Sprintf("restart-background-worker-%d", time.Now().UnixNano())
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(name)))
+	runningMarker := filepath.Join(os.TempDir(), "background-worker-restart-running-"+hash)
+	t.Cleanup(func() {
+		_ = os.Remove(runningMarker)
+	})
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-restart.php?name="+name, handler, t)
+		assert.Equal(t, "1", body)
+		require.FileExists(t, runningMarker)
+
+		frankenphp.RestartWorkers()
+
+		require.Eventually(t, func() bool {
+			_, err := os.Stat(runningMarker)
+			return errors.Is(err, os.ErrNotExist)
+		}, 5*time.Second, 50*time.Millisecond)
+
+		body, _ = testGet("http://example.com/background-worker-restart.php?name="+name, handler, t)
+		assert.Equal(t, "2", body)
+		require.FileExists(t, runningMarker)
+
+		frankenphp.RestartWorkers()
+
+		require.Eventually(t, func() bool {
+			_, err := os.Stat(runningMarker)
+			return errors.Is(err, os.ErrNotExist)
+		}, 5*time.Second, 50*time.Millisecond)
+	}, &testOptions{
+		workerScript:       "background-worker-restart.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerSignalingStreamNonBackgroundWorker(t *testing.T) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-stop-fd-non-background-worker.php", handler, t)
+		assert.Equal(t, "thrown", body)
+	}, &testOptions{
+		workerScript:       "background-worker-stop-fd-non-background-worker.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+	})
+}
+
+func TestBackgroundWorkerMultipleEntrypoints(t *testing.T) {
+	cwd, _ := os.Getwd()
+
+	t.Run("entrypoint-a", func(t *testing.T) {
+		entrypoint := cwd + "/testdata/background-worker-multi-entrypoint-a.php"
+
+		runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+			body, _ := testGet("http://example.com/background-worker-multi-file.php", handler, t)
+			assert.Equal(t, "entrypoint-a:worker-from-a,entrypoint-a:worker-from-b", body)
+		}, &testOptions{
+			workerScript:       "background-worker-multi-file.php",
+			nbWorkers:          1,
+			nbParallelRequests: 1,
+			initOpts: []frankenphp.Option{
+				frankenphp.WithMaxThreads(50),
+				frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+			},
+		})
+	})
+
+	t.Run("entrypoint-b", func(t *testing.T) {
+		entrypoint := cwd + "/testdata/background-worker-multi-entrypoint-b.php"
+
+		runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+			body, _ := testGet("http://example.com/background-worker-multi-file.php", handler, t)
+			assert.Equal(t, "entrypoint-b:worker-from-a,entrypoint-b:worker-from-b", body)
+		}, &testOptions{
+			workerScript:       "background-worker-multi-file.php",
+			nbWorkers:          1,
+			nbParallelRequests: 1,
+			initOpts: []frankenphp.Option{
+				frankenphp.WithMaxThreads(50),
+				frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+			},
+		})
+	})
+}
+
+func TestBackgroundWorkerNamedAutoStart(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-named-autostart.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-named-autostart-reader.php", handler, t)
+		assert.Equal(t, "my-named-worker|true", body)
+	}, &testOptions{
+		workerScript:       "background-worker-named-autostart-reader.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			// Simulate Caddy's m# prefix for module workers with auto-start
+			frankenphp.WithWorkers("m#my-named-worker", entrypoint, 1,
+				frankenphp.WithWorkerBackground(),
+			),
+			// Catch-all with 0 threads registers the lookup without starting threads
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
 }
 
 func ExampleServeHTTP() {

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -1110,11 +1110,176 @@ func TestBackgroundWorkerNamedAutoStart(t *testing.T) {
 		nbParallelRequests: 1,
 		initOpts: []frankenphp.Option{
 			frankenphp.WithMaxThreads(50),
-			// Simulate Caddy's m# prefix for module workers with auto-start
 			frankenphp.WithWorkers("m#my-named-worker", entrypoint, 1,
 				frankenphp.WithWorkerBackground(),
 			),
-			// Catch-all with 0 threads registers the lookup without starting threads
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskBasic(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-sender.php", handler, t)
+		assert.Equal(t, "processed:hello", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskProgress(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-progress-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-progress-sender.php", handler, t)
+		assert.Equal(t, "progress:25,progress:75,completed:done", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-progress-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskNonWorker(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-non-worker.php", handler, t)
+		assert.Equal(t, "processed:from-non-worker", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskCrash(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-crash-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-crash-sender.php", handler, t)
+		// Background worker crashes - sender gets RuntimeException
+		assert.Equal(t, "ERROR:background worker exited without completing the task", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-crash-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskCrashMidTask(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-crash-mid-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-crash-mid-sender.php", handler, t)
+		// Background worker received the task then crashed - sender gets RuntimeException
+		assert.Equal(t, "CRASH:background worker exited without completing the task", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-crash-mid-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskCancel(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-cancel-sender.php", handler, t)
+		assert.Equal(t, "cancelled", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-cancel-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskCancelThenSend(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-cancel-then-send.php", handler, t)
+		assert.Equal(t, "processed:should-work", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-cancel-then-send.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskCancelThenCrash(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-cancel-crash-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-cancel-crash-sender.php", handler, t)
+		assert.Equal(t, "cancelled", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-cancel-crash-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
+		},
+	})
+}
+
+func TestBackgroundWorkerTaskPooling(t *testing.T) {
+	cwd, _ := os.Getwd()
+	entrypoint := cwd + "/testdata/background-worker-task-pool-entrypoint.php"
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		body, _ := testGet("http://example.com/background-worker-task-pool-sender.php", handler, t)
+		assert.Equal(t, "processed:first,processed:second", body)
+	}, &testOptions{
+		workerScript:       "background-worker-task-pool-sender.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		initOpts: []frankenphp.Option{
+			frankenphp.WithMaxThreads(50),
+			frankenphp.WithWorkers("pool-worker", entrypoint, 2,
+				frankenphp.WithWorkerBackground(),
+			),
 			frankenphp.WithWorkers("", entrypoint, 0, frankenphp.WithWorkerBackground()),
 		},
 	})

--- a/options.go
+++ b/options.go
@@ -49,6 +49,8 @@ type workerOpt struct {
 	onThreadShutdown       func(int)
 	onServerStartup        func()
 	onServerShutdown       func()
+	isBackgroundWorker     bool
+	backgroundScope        string // scope ID for background worker isolation
 }
 
 // WithContext sets the main context to use.
@@ -80,6 +82,28 @@ func WithMaxThreads(maxThreads int) Option {
 func WithMetrics(m Metrics) Option {
 	return func(o *opt) error {
 		o.metrics = m
+
+		return nil
+	}
+}
+
+// WithWorkerBackground marks this worker as a background (non-HTTP) worker.
+// The worker's fileName is used as the entrypoint, and maxThreads as the
+// safety cap for lazy-started instances (catch-all only).
+func WithWorkerBackground() WorkerOption {
+	return func(w *workerOpt) error {
+		w.isBackgroundWorker = true
+
+		return nil
+	}
+}
+
+// WithWorkerBackgroundScope sets the scope ID for background worker isolation.
+// Workers in the same scope share a background worker lookup. Each php_server
+// block gets its own scope. The global frankenphp block uses scope "".
+func WithWorkerBackgroundScope(scope string) WorkerOption {
+	return func(w *workerOpt) error {
+		w.backgroundScope = scope
 
 		return nil
 	}

--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -56,6 +56,9 @@ func initPHPThreads(numThreads int, numMaxThreads int, phpIni map[string]string)
 
 	C.frankenphp_init_thread_metrics(C.int(mainThread.maxThreads))
 
+	// initialize force-kill support for stuck background workers
+	C.frankenphp_init_force_kill(C.int(mainThread.maxThreads))
+
 	// initialize all other threads
 	phpThreads = make([]*phpThread, mainThread.maxThreads)
 	phpThreads[0] = initialThread
@@ -97,6 +100,7 @@ func drainPHPThreads() {
 	}
 
 	doneWG.Wait()
+	C.frankenphp_destroy_force_kill()
 	mainThread.state.Set(state.Done)
 	mainThread.state.WaitFor(state.Reserved)
 	C.frankenphp_destroy_thread_metrics()

--- a/phpthread.go
+++ b/phpthread.go
@@ -34,6 +34,7 @@ type threadHandler interface {
 	afterScriptExecution(exitStatus int)
 	context() context.Context
 	frankenPHPContext() *frankenPHPContext
+	drain()
 }
 
 func newPHPThread(threadIndex int) *phpThread {
@@ -74,6 +75,7 @@ func (thread *phpThread) shutdown() {
 		return
 	}
 
+	thread.handler.drain()
 	close(thread.drainChan)
 	thread.state.WaitFor(state.Done)
 	thread.drainChan = make(chan struct{})

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -164,3 +164,13 @@ func WithWorkerName(name string) RequestOption {
 		return nil
 	}
 }
+
+// WithRequestBackgroundScope sets the background worker scope for this request.
+// Requests in the same scope can access the same background workers.
+func WithRequestBackgroundScope(scope string) RequestOption {
+	return func(o *frankenPHPContext) error {
+		o.backgroundScope = scope
+
+		return nil
+	}
+}

--- a/scaling.go
+++ b/scaling.go
@@ -78,7 +78,11 @@ func addWorkerThread(worker *worker) (*phpThread, error) {
 	if thread == nil {
 		return nil, ErrMaxThreadsReached
 	}
-	convertToWorkerThread(thread, worker)
+	if worker.isBackgroundWorker {
+		convertToBackgroundWorkerThread(thread, worker)
+	} else {
+		convertToWorkerThread(thread, worker)
+	}
 	thread.state.WaitFor(state.Ready, state.ShuttingDown, state.Reserved)
 	return thread, nil
 }

--- a/testdata/background-worker-binary-entrypoint.php
+++ b/testdata/background-worker-binary-entrypoint.php
@@ -1,0 +1,12 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+frankenphp_worker_set_vars([
+    'BINARY_TEST' => "hello\x00world",
+    'UTF8_TEST' => "héllo wörld 🚀",
+    'EMPTY_VAL' => "",
+]);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-binary-safe.php
+++ b/testdata/background-worker-binary-safe.php
@@ -1,0 +1,23 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('binary-worker', 5.0);
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+        return;
+    }
+
+    $results = [];
+
+    $bin = $vars['BINARY_TEST'] ?? 'NOT_SET';
+    $results[] = 'BINARY_LEN:' . strlen($bin);
+    $results[] = 'BINARY_CONTENT:' . bin2hex($bin);
+
+    $results[] = 'UTF8:' . ($vars['UTF8_TEST'] ?? 'NOT_SET');
+
+    $results[] = 'EMPTY_EXISTS:' . (array_key_exists('EMPTY_VAL', $vars) ? 'yes' : 'no');
+    $results[] = 'EMPTY_LEN:' . strlen($vars['EMPTY_VAL'] ?? 'NOT_SET');
+
+    echo implode("\n", $results);
+});

--- a/testdata/background-worker-caddy-entrypoint.php
+++ b/testdata/background-worker-caddy-entrypoint.php
@@ -1,0 +1,12 @@
+<?php
+
+// Background worker for Caddy integration test
+frankenphp_worker_set_vars(['CADDY_TEST' => 'hello from background worker']);
+
+$stream = frankenphp_worker_get_signaling_stream();
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (false === @stream_select($r, $w, $e, 30)) { break; }
+    if ($r && "stop\n" === fgets($stream)) { break; }
+}

--- a/testdata/background-worker-caddy-reader.php
+++ b/testdata/background-worker-caddy-reader.php
@@ -1,0 +1,4 @@
+<?php
+
+$vars = frankenphp_worker_get_vars('caddy-bg-worker', 5.0);
+echo $vars['CADDY_TEST'] ?? 'NOT_SET';

--- a/testdata/background-worker-crash-starter.php
+++ b/testdata/background-worker-crash-starter.php
@@ -1,0 +1,10 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('crash-worker', 5.0);
+        echo $vars['WORKER_STATUS'] ?? 'MISSING_KEY';
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-crash.php
+++ b/testdata/background-worker-crash.php
@@ -1,0 +1,18 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$marker = sys_get_temp_dir() . '/background-worker-crash-' . getmypid();
+$restarted = file_exists($marker);
+
+if (!$restarted) {
+    file_put_contents($marker, '1');
+    exit(1);
+}
+
+frankenphp_worker_set_vars(['WORKER_STATUS' => 'restarted']);
+
+while (!background_worker_should_stop(30)) {
+}
+
+@unlink($marker);

--- a/testdata/background-worker-dedup.php
+++ b/testdata/background-worker-dedup.php
@@ -1,0 +1,10 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$name = $_SERVER['FRANKENPHP_WORKER_NAME'] ?? $_SERVER['argv'][1] ?? 'unknown';
+
+frankenphp_worker_set_vars(['WORKER_NAME' => $name]);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-enum-missing-entrypoint.php
+++ b/testdata/background-worker-enum-missing-entrypoint.php
@@ -1,0 +1,13 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+// This enum only exists in the background worker, not in the HTTP worker
+enum SidekickOnlyEnum {
+    case Foo;
+}
+
+frankenphp_worker_set_vars(['val' => SidekickOnlyEnum::Foo]);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-enum-missing.php
+++ b/testdata/background-worker-enum-missing.php
@@ -1,0 +1,14 @@
+<?php
+
+// SidekickOnlyEnum is NOT defined here - get_vars should throw LogicException
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('enum-missing');
+        echo 'no_error';
+    } catch (\LogicException $e) {
+        echo 'LogicException:' . $e->getMessage();
+    } catch (\Throwable $e) {
+        echo 'other:' . get_class($e);
+    }
+});

--- a/testdata/background-worker-helper.php
+++ b/testdata/background-worker-helper.php
@@ -1,0 +1,14 @@
+<?php
+
+function background_worker_should_stop(float $timeout = 0): bool
+{
+    static $signalingStream;
+    $signalingStream ??= frankenphp_worker_get_signaling_stream();
+    $s = (int) $timeout;
+
+    return match (@stream_select(...[[$signalingStream], [], [], $s, (int) (($timeout - $s) * 1e6)])) {
+        0 => false, // timeout
+        false => true, // error (pipe closed) = stop
+        default => "stop\n" === fgets($signalingStream),
+    };
+}

--- a/testdata/background-worker-identity.php
+++ b/testdata/background-worker-identity.php
@@ -1,0 +1,11 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $a = frankenphp_worker_get_vars('test-worker', 5.0);
+        $b = frankenphp_worker_get_vars('test-worker', 5.0);
+        echo ($a === $b) ? 'IDENTICAL' : 'DIFFERENT';
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-multi-entrypoint-a.php
+++ b/testdata/background-worker-multi-entrypoint-a.php
@@ -1,0 +1,8 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+frankenphp_worker_set_vars(['SOURCE' => 'entrypoint-a', 'NAME' => $_SERVER['FRANKENPHP_WORKER_NAME'] ?? 'unknown']);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-multi-entrypoint-b.php
+++ b/testdata/background-worker-multi-entrypoint-b.php
@@ -1,0 +1,8 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+frankenphp_worker_set_vars(['SOURCE' => 'entrypoint-b', 'NAME' => $_SERVER['FRANKENPHP_WORKER_NAME'] ?? 'unknown']);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-multi-entrypoint.php
+++ b/testdata/background-worker-multi-entrypoint.php
@@ -1,0 +1,10 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$name = $_SERVER['FRANKENPHP_WORKER_NAME'] ?? $_SERVER['argv'][1] ?? 'unknown';
+
+frankenphp_worker_set_vars(['NAME_' . strtoupper(str_replace('-', '_', $name)) => $name]);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-multi-file.php
+++ b/testdata/background-worker-multi-file.php
@@ -1,0 +1,8 @@
+<?php
+
+frankenphp_handle_request(function () {
+    $a = frankenphp_worker_get_vars('worker-from-a');
+    $b = frankenphp_worker_get_vars('worker-from-b');
+
+    echo $a['SOURCE'] . ':' . $a['NAME'] . ',' . $b['SOURCE'] . ':' . $b['NAME'];
+});

--- a/testdata/background-worker-multi.php
+++ b/testdata/background-worker-multi.php
@@ -1,0 +1,17 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $all = frankenphp_worker_get_vars(['worker-a', 'worker-b'], 5.0);
+        ksort($all);
+        $parts = [];
+        foreach ($all as $name => $vars) {
+            foreach ($vars as $k => $v) {
+                $parts[] = "$name:$k=$v";
+            }
+        }
+        echo implode(',', $parts);
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-named-autostart-reader.php
+++ b/testdata/background-worker-named-autostart-reader.php
@@ -1,0 +1,6 @@
+<?php
+
+frankenphp_handle_request(function () {
+    $vars = frankenphp_worker_get_vars('my-named-worker', 5.0);
+    echo ($vars['WORKER_NAME'] ?? 'missing') . '|' . ($vars['AUTOSTART'] ? 'true' : 'false');
+});

--- a/testdata/background-worker-named-autostart.php
+++ b/testdata/background-worker-named-autostart.php
@@ -1,0 +1,19 @@
+<?php
+
+// Auto-started named background worker
+// Publishes its name so HTTP workers can verify it started
+
+require __DIR__ . '/background-worker-helper.php';
+
+frankenphp_worker_set_vars([
+    'WORKER_NAME' => $_SERVER['FRANKENPHP_WORKER_NAME'] ?? 'unknown',
+    'AUTOSTART' => true,
+]);
+
+// Wait for stop signal
+$stream = frankenphp_worker_get_signaling_stream();
+while (true) {
+    $r = [$stream]; $w = $e = [];
+    if (false === @stream_select($r, $w, $e, 30)) { break; }
+    if ($r && "stop\n" === fgets($stream)) { break; }
+}

--- a/testdata/background-worker-no-entrypoint.php
+++ b/testdata/background-worker-no-entrypoint.php
@@ -1,0 +1,10 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('should-fail', 1.0);
+        echo 'no error';
+    } catch (\RuntimeException $e) {
+        echo $e->getMessage();
+    }
+});

--- a/testdata/background-worker-restart-entrypoint.php
+++ b/testdata/background-worker-restart-entrypoint.php
@@ -1,0 +1,19 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$name = $_SERVER['FRANKENPHP_WORKER_NAME'] ?? $_SERVER['argv'][1] ?? 'unknown';
+$marker = sys_get_temp_dir() . '/background-worker-restart-' . md5($name);
+$runningMarker = sys_get_temp_dir() . '/background-worker-restart-running-' . md5($name);
+$generation = file_exists($marker) ? ((int) file_get_contents($marker)) + 1 : 1;
+
+file_put_contents($marker, (string) $generation);
+file_put_contents($runningMarker, (string) getmypid());
+frankenphp_worker_set_vars(['GENERATION' => (string) $generation]);
+
+try {
+    while (!background_worker_should_stop(30)) {
+    }
+} finally {
+    @unlink($runningMarker);
+}

--- a/testdata/background-worker-restart.php
+++ b/testdata/background-worker-restart.php
@@ -1,0 +1,7 @@
+<?php
+
+frankenphp_handle_request(function () {
+    $name = $_GET['name'] ?? 'restart-worker';
+    $vars = frankenphp_worker_get_vars($name, 5.0);
+    echo $vars['GENERATION'] ?? 'NOT_SET';
+});

--- a/testdata/background-worker-set-server-var-validation.php
+++ b/testdata/background-worker-set-server-var-validation.php
@@ -1,0 +1,23 @@
+<?php
+
+frankenphp_handle_request(function () {
+    $results = [];
+
+    // set_vars from non-background-worker context should throw RuntimeException
+    try {
+        frankenphp_worker_set_vars(['KEY' => 'val']);
+        $results[] = 'NON_BACKGROUND:no_error';
+    } catch (\RuntimeException $e) {
+        $results[] = 'NON_BACKGROUND:blocked';
+    }
+
+    // get_signaling_stream from non-background-worker context should throw
+    try {
+        frankenphp_worker_get_signaling_stream();
+        $results[] = 'STREAM_NON_BACKGROUND:no_error';
+    } catch (\RuntimeException $e) {
+        $results[] = 'STREAM_NON_BACKGROUND:blocked';
+    }
+
+    echo implode("\n", $results);
+});

--- a/testdata/background-worker-start-twice.php
+++ b/testdata/background-worker-start-twice.php
@@ -1,0 +1,10 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('dedup-worker', 5.0);
+        echo $vars['WORKER_NAME'] ?? 'MISSING_KEY';
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-start.php
+++ b/testdata/background-worker-start.php
@@ -1,0 +1,10 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $vars = frankenphp_worker_get_vars('test-worker', 5.0);
+        echo $vars['WORKER_NAME'] ?? 'MISSING_KEY';
+    } catch (\Throwable $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-stop-fd-entrypoint.php
+++ b/testdata/background-worker-stop-fd-entrypoint.php
@@ -1,0 +1,18 @@
+<?php
+
+$stream = frankenphp_worker_get_signaling_stream();
+
+frankenphp_worker_set_vars([
+    'STREAM_TYPE' => get_resource_type($stream),
+]);
+
+$r = [$stream];
+$w = $e = [];
+stream_select($r, $w, $e, 30);
+
+$signal = fgets($stream);
+
+frankenphp_worker_set_vars([
+    'STREAM_TYPE' => get_resource_type($stream),
+    'SIGNAL' => $signal,
+]);

--- a/testdata/background-worker-stop-fd-non-background-worker.php
+++ b/testdata/background-worker-stop-fd-non-background-worker.php
@@ -1,0 +1,10 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        frankenphp_worker_get_signaling_stream();
+        echo 'no_error';
+    } catch (\RuntimeException $e) {
+        echo 'thrown';
+    }
+});

--- a/testdata/background-worker-stop-fd.php
+++ b/testdata/background-worker-stop-fd.php
@@ -1,0 +1,6 @@
+<?php
+
+frankenphp_handle_request(function () {
+    $vars = frankenphp_worker_get_vars('stop-fd-test');
+    echo $vars['STREAM_TYPE'] ?? 'NOT_SET';
+});

--- a/testdata/background-worker-task-cancel-crash-entrypoint.php
+++ b/testdata/background-worker-task-cancel-crash-entrypoint.php
@@ -1,0 +1,27 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$stream = frankenphp_worker_get_signaling_stream();
+frankenphp_worker_set_vars(['READY' => '1']);
+
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    $signal = fgets($stream);
+    if ("stop\n" === $signal) {
+        break;
+    }
+
+    if ("task\n" === $signal) {
+        if ($task = frankenphp_worker_task_receive()) {
+            // Simulate slow processing - crash before fclose($task)
+            usleep(200_000);
+            exit(1);
+        }
+    }
+}

--- a/testdata/background-worker-task-cancel-crash-sender.php
+++ b/testdata/background-worker-task-cancel-crash-sender.php
@@ -1,0 +1,12 @@
+<?php
+
+frankenphp_handle_request(function () {
+    frankenphp_worker_get_vars('cancel-crash-worker');
+
+    $task = frankenphp_worker_task_send('cancel-crash-worker', ['input' => 'test']);
+    // Wait a bit for background worker to receive the task, then cancel
+    usleep(50_000);
+    fclose($task);
+
+    echo 'cancelled';
+});

--- a/testdata/background-worker-task-cancel-sender.php
+++ b/testdata/background-worker-task-cancel-sender.php
@@ -1,0 +1,12 @@
+<?php
+
+frankenphp_handle_request(function () {
+    // Ensure background worker is running
+    frankenphp_worker_get_vars('task-worker');
+
+    // Send a task then immediately cancel it
+    $task = frankenphp_worker_task_send('task-worker', ['input' => 'cancelled']);
+    fclose($task);
+
+    echo 'cancelled';
+});

--- a/testdata/background-worker-task-cancel-then-send.php
+++ b/testdata/background-worker-task-cancel-then-send.php
@@ -1,0 +1,19 @@
+<?php
+
+frankenphp_handle_request(function () {
+    // Ensure background worker is running
+    frankenphp_worker_get_vars('task-worker');
+
+    // Send a task and immediately cancel it
+    $task1 = frankenphp_worker_task_send('task-worker', ['input' => 'will-be-cancelled']);
+    fclose($task1);
+
+    // Small delay to let the background worker dequeue the cancelled task
+    usleep(50_000);
+
+    // Send a second task - the background worker must still be responsive
+    $task2 = frankenphp_worker_task_send('task-worker', ['input' => 'should-work']);
+    $update = frankenphp_worker_task_read($task2);
+
+    echo null === $update ? 'EOF' : ($update['result'] ?? 'NO_RESULT');
+});

--- a/testdata/background-worker-task-crash-entrypoint.php
+++ b/testdata/background-worker-task-crash-entrypoint.php
@@ -1,0 +1,4 @@
+<?php
+
+// Background worker that crashes immediately without processing tasks
+exit(1);

--- a/testdata/background-worker-task-crash-mid-entrypoint.php
+++ b/testdata/background-worker-task-crash-mid-entrypoint.php
@@ -1,0 +1,27 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$stream = frankenphp_worker_get_signaling_stream();
+frankenphp_worker_set_vars(['READY' => '1']);
+
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    $signal = fgets($stream);
+    if ("stop\n" === $signal) {
+        break;
+    }
+
+    if ("task\n" === $signal) {
+        if ($task = frankenphp_worker_task_receive()) {
+            [$handle, $payload] = $task;
+            // Crash mid-task without closing the stream
+            exit(1);
+        }
+    }
+}

--- a/testdata/background-worker-task-crash-mid-sender.php
+++ b/testdata/background-worker-task-crash-mid-sender.php
@@ -1,0 +1,17 @@
+<?php
+
+frankenphp_handle_request(function () {
+    frankenphp_worker_get_vars('crash-mid-worker');
+
+    $task = frankenphp_worker_task_send('crash-mid-worker', ['input' => 'hello']);
+
+    // Background worker received the task but crashed before fclose
+    // task_read should throw RuntimeException
+    try {
+        $update = frankenphp_worker_task_read($task);
+        echo null === $update ? 'EOF' : ('GOT:' . json_encode($update));
+    } catch (\RuntimeException $e) {
+        echo 'CRASH:' . $e->getMessage();
+    }
+    fclose($task);
+});

--- a/testdata/background-worker-task-crash-sender.php
+++ b/testdata/background-worker-task-crash-sender.php
@@ -1,0 +1,11 @@
+<?php
+
+frankenphp_handle_request(function () {
+    try {
+        $task = frankenphp_worker_task_send('crash-task-worker', ['input' => 'test']);
+        $update = frankenphp_worker_task_read($task);
+        echo null === $update ? 'EOF' : 'GOT_DATA';
+    } catch (\RuntimeException $e) {
+        echo 'ERROR:' . $e->getMessage();
+    }
+});

--- a/testdata/background-worker-task-entrypoint.php
+++ b/testdata/background-worker-task-entrypoint.php
@@ -1,0 +1,29 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$stream = frankenphp_worker_get_signaling_stream();
+
+frankenphp_worker_set_vars(['READY' => '1']);
+
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    $signal = fgets($stream);
+
+    if ("stop\n" === $signal) {
+        break;
+    }
+
+    if ("task\n" === $signal) {
+        if ($task = frankenphp_worker_task_receive()) {
+            [$handle, $payload] = $task;
+            frankenphp_worker_task_update($handle, ['result' => 'processed:' . ($payload['input'] ?? 'none')]);
+            fclose($handle);
+        }
+    }
+}

--- a/testdata/background-worker-task-non-worker.php
+++ b/testdata/background-worker-task-non-worker.php
@@ -1,0 +1,10 @@
+<?php
+
+// Non-worker mode: no frankenphp_handle_request loop
+frankenphp_worker_get_vars('task-worker');
+
+$task = frankenphp_worker_task_send('task-worker', ['input' => 'from-non-worker']);
+
+$update = frankenphp_worker_task_read($task);
+
+echo null === $update ? 'EOF' : ($update['result'] ?? 'NO_RESULT');

--- a/testdata/background-worker-task-pool-entrypoint.php
+++ b/testdata/background-worker-task-pool-entrypoint.php
@@ -1,0 +1,31 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$stream = frankenphp_worker_get_signaling_stream();
+
+frankenphp_worker_set_vars(['READY' => '1']);
+
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    $signal = fgets($stream);
+
+    if ("stop\n" === $signal) {
+        break;
+    }
+
+    if ("task\n" === $signal) {
+        if ($task = frankenphp_worker_task_receive()) {
+            [$handle, $payload] = $task;
+            // Simulate work - sleep briefly so both threads can be busy
+            usleep(100000); // 100ms
+            frankenphp_worker_task_update($handle, ['result' => 'processed:' . ($payload['input'] ?? 'none')]);
+            fclose($handle);
+        }
+    }
+}

--- a/testdata/background-worker-task-pool-sender.php
+++ b/testdata/background-worker-task-pool-sender.php
@@ -1,0 +1,21 @@
+<?php
+
+frankenphp_handle_request(function () {
+    // First ensure the background worker is running
+    frankenphp_worker_get_vars('pool-worker');
+
+    // Send two tasks - with num=2, both should be processed
+    $task1 = frankenphp_worker_task_send('pool-worker', ['input' => 'first']);
+    $task2 = frankenphp_worker_task_send('pool-worker', ['input' => 'second']);
+
+    // Read results from both tasks
+    $r1 = frankenphp_worker_task_read($task1);
+    $r2 = frankenphp_worker_task_read($task2);
+
+    $results = [];
+    if (null !== $r1) $results[] = $r1['result'];
+    if (null !== $r2) $results[] = $r2['result'];
+
+    sort($results);
+    echo implode(',', $results);
+});

--- a/testdata/background-worker-task-progress-entrypoint.php
+++ b/testdata/background-worker-task-progress-entrypoint.php
@@ -1,0 +1,31 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$stream = frankenphp_worker_get_signaling_stream();
+
+frankenphp_worker_set_vars(['READY' => '1']);
+
+while (true) {
+    $r = [$stream];
+    $w = $e = [];
+    if (!stream_select($r, $w, $e, 30)) {
+        continue;
+    }
+
+    $signal = fgets($stream);
+
+    if ("stop\n" === $signal) {
+        break;
+    }
+
+    if ("task\n" === $signal) {
+        if ($task = frankenphp_worker_task_receive()) {
+            [$handle, $payload] = $task;
+            frankenphp_worker_task_update($handle, ['status' => 'progress', 'percent' => 25]);
+            frankenphp_worker_task_update($handle, ['status' => 'progress', 'percent' => 75]);
+            frankenphp_worker_task_update($handle, ['status' => 'completed', 'result' => 'done']);
+            fclose($handle);
+        }
+    }
+}

--- a/testdata/background-worker-task-progress-sender.php
+++ b/testdata/background-worker-task-progress-sender.php
@@ -1,0 +1,15 @@
+<?php
+
+frankenphp_handle_request(function () {
+    frankenphp_worker_get_vars('progress-worker');
+
+    $task = frankenphp_worker_task_send('progress-worker', ['job' => 'resize']);
+
+    // Read all updates until EOF
+    $updates = [];
+    while (null !== $update = frankenphp_worker_task_read($task)) {
+        $updates[] = $update['status'] . ':' . ($update['percent'] ?? $update['result'] ?? '');
+    }
+
+    echo implode(',', $updates);
+});

--- a/testdata/background-worker-task-sender.php
+++ b/testdata/background-worker-task-sender.php
@@ -1,0 +1,18 @@
+<?php
+
+frankenphp_handle_request(function () {
+    // First ensure the background worker is running
+    frankenphp_worker_get_vars('task-worker');
+
+    // Send a task
+    $task = frankenphp_worker_task_send('task-worker', ['input' => 'hello']);
+
+    // Read the result
+    $update = frankenphp_worker_task_read($task);
+
+    if (null === $update) {
+        echo 'EOF';
+    } else {
+        echo $update['result'] ?? 'NO_RESULT';
+    }
+});

--- a/testdata/background-worker-type-validation-entrypoint.php
+++ b/testdata/background-worker-type-validation-entrypoint.php
@@ -1,0 +1,63 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+enum TestStatus {
+    case Active;
+    case Inactive;
+}
+
+$results = [];
+
+// int values allowed
+try {
+    frankenphp_worker_set_vars(['KEY' => 123]);
+    $results[] = 'INT_VAL:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'INT_VAL:blocked';
+}
+
+// int keys allowed
+try {
+    frankenphp_worker_set_vars([0 => 'val']);
+    $results[] = 'INT_KEY:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'INT_KEY:blocked';
+}
+
+// nested arrays allowed
+try {
+    frankenphp_worker_set_vars(['nested' => ['a' => 1, 'b' => [true, null]]]);
+    $results[] = 'NESTED:allowed';
+} catch (\Throwable $e) {
+    $results[] = 'NESTED:blocked';
+}
+
+// objects rejected
+try {
+    frankenphp_worker_set_vars(['KEY' => new \stdClass()]);
+    $results[] = 'OBJECT:allowed';
+} catch (\ValueError $e) {
+    $results[] = 'OBJECT:blocked';
+}
+
+// references rejected
+try {
+    $ref = 'hello';
+    frankenphp_worker_set_vars(['KEY' => &$ref]);
+    $results[] = 'REFERENCE:allowed';
+} catch (\ValueError $e) {
+    $results[] = 'REFERENCE:blocked';
+}
+
+// enums allowed - final set_vars with all results
+try {
+    $results[] = 'ENUM:allowed'; // if we get here, the call below will confirm it
+    frankenphp_worker_set_vars(['status' => TestStatus::Active, 'RESULTS' => implode(',', $results)]);
+} catch (\Throwable $e) {
+    $results[array_key_last($results)] = 'ENUM:blocked';
+    frankenphp_worker_set_vars(['RESULTS' => implode(',', $results)]);
+}
+
+while (!background_worker_should_stop(30)) {
+}

--- a/testdata/background-worker-type-validation.php
+++ b/testdata/background-worker-type-validation.php
@@ -1,0 +1,23 @@
+<?php
+
+enum TestStatus {
+    case Active;
+    case Inactive;
+}
+
+frankenphp_handle_request(function () {
+    // Retry until we see the final snapshot with RESULTS
+    for ($i = 0; $i < 100; $i++) {
+        $vars = frankenphp_worker_get_vars('type-validation');
+        if (isset($vars['RESULTS'])) break;
+        usleep(10_000);
+    }
+
+    $results = $vars['RESULTS'] ?? 'NOT_SET';
+
+    if (isset($vars['status'])) {
+        $results .= $vars['status'] === TestStatus::Active ? ',ENUM_RESTORED:match' : ',ENUM_RESTORED:mismatch(' . get_debug_type($vars['status']) . ')';
+    }
+
+    echo $results;
+});

--- a/testdata/background-worker-with-argv.php
+++ b/testdata/background-worker-with-argv.php
@@ -1,0 +1,12 @@
+<?php
+
+require __DIR__ . '/background-worker-helper.php';
+
+$argv = $_SERVER['argv'] ?? [];
+array_shift($argv);
+$name = $argv[0] ?? 'unknown';
+
+frankenphp_worker_set_vars(['WORKER_NAME' => $name]);
+
+while (!background_worker_should_stop(30)) {
+}

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -24,6 +24,10 @@ type backgroundWorkerState struct {
 	varsVersion atomic.Uint64 // incremented on each set_vars call
 	ready       chan struct{}
 	readyOnce   sync.Once
+	tasks       chan *taskRequest // buffered(1): sender blocks until receiver picks up
+	dead        chan struct{}     // closed when worker exits, unblocks waiting senders
+	deadOnce    sync.Once
+	fds         *backgroundFdList // signaling fds for task notifications
 }
 
 // backgroundWorkerThread handles background worker scripts.
@@ -36,6 +40,8 @@ type backgroundWorkerThread struct {
 	dummyContext          context.Context
 	isBootingScript       bool
 	failureCount          int
+	stopFd                int32
+	currentTask           *taskRequest
 }
 
 func convertToBackgroundWorkerThread(thread *phpThread, worker *worker) {
@@ -64,9 +70,9 @@ func (handler *backgroundWorkerThread) context() context.Context {
 }
 
 func (handler *backgroundWorkerThread) drain() {
-	if fd := handler.worker.backgroundStopFdWrite.Load(); fd >= 0 {
+	handler.worker.backgroundFds.writeAll(func(fd int32) {
 		C.frankenphp_worker_write_stop_fd(C.int(fd))
-	}
+	})
 }
 
 func (handler *backgroundWorkerThread) beforeScriptExecution() string {
@@ -112,6 +118,7 @@ func (handler *backgroundWorkerThread) setupScript() {
 			bgw, _, err := handler.worker.backgroundRegistry.reserve(strings.TrimPrefix(handler.worker.name, "m#"))
 			if err == nil {
 				handler.worker.backgroundWorker = bgw
+				bgw.fds = &handler.worker.backgroundFds
 			}
 		}
 	})
@@ -120,7 +127,16 @@ func (handler *backgroundWorkerThread) setupScript() {
 
 	opts := append([]RequestOption(nil), handler.worker.requestOptions...)
 	C.frankenphp_set_worker_name(handler.thread.pinCString(strings.TrimPrefix(handler.worker.name, "m#")), C._Bool(true))
-	handler.worker.backgroundStopFdWrite.Store(int32(C.frankenphp_worker_get_stop_fd_write()))
+	fd := int32(C.frankenphp_worker_get_stop_fd_write())
+	handler.stopFd = fd
+	handler.worker.backgroundFds.addFd(fd)
+
+	// Flush signals for tasks queued before the stop fd existed
+	if handler.worker.backgroundWorker != nil {
+		for range len(handler.worker.backgroundWorker.tasks) {
+			C.frankenphp_worker_write_task_signal(C.int(fd))
+		}
+	}
 
 	fc, err := newDummyContext(
 		filepath.Base(handler.worker.fileName),
@@ -146,7 +162,17 @@ func (handler *backgroundWorkerThread) setupScript() {
 }
 
 func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
-	handler.worker.backgroundStopFdWrite.Store(-1)
+	// Task cleanup: remove fd, close in-flight task, drain pending
+	handler.worker.backgroundFds.removeFd(handler.stopFd)
+	handler.stopFd = 0
+	if handler.currentTask != nil {
+		handler.currentTask.abortBackgroundWorker()
+		handler.currentTask = nil
+	}
+	if handler.worker.backgroundWorker != nil {
+		handler.worker.backgroundWorker.drainPendingTasks()
+	}
+
 	worker := handler.worker
 	handler.dummyFrankenPHPContext = nil
 	handler.dummyContext = nil

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -1,0 +1,215 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/dunglas/frankenphp/internal/state"
+)
+
+// backgroundWorkerState holds the shared state for a single background worker.
+// Accessed by the background worker thread (writes) and HTTP worker threads (reads).
+type backgroundWorkerState struct {
+	varsPtr     unsafe.Pointer // *C.HashTable, persistent, managed by C
+	mu          sync.RWMutex
+	varsVersion atomic.Uint64 // incremented on each set_vars call
+	ready       chan struct{}
+	readyOnce   sync.Once
+}
+
+// backgroundWorkerThread handles background worker scripts.
+// Decoupled from workerThread; owns its own lifecycle state.
+type backgroundWorkerThread struct {
+	state                 *state.ThreadState
+	thread                *phpThread
+	worker                *worker
+	dummyFrankenPHPContext *frankenPHPContext
+	dummyContext          context.Context
+	isBootingScript       bool
+	failureCount          int
+}
+
+func convertToBackgroundWorkerThread(thread *phpThread, worker *worker) {
+	handler := &backgroundWorkerThread{
+		state:  thread.state,
+		thread: thread,
+		worker: worker,
+	}
+	thread.setHandler(handler)
+	worker.attachThread(thread)
+}
+
+func (handler *backgroundWorkerThread) name() string {
+	return "Background Worker PHP Thread - " + handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) frankenPHPContext() *frankenPHPContext {
+	return handler.dummyFrankenPHPContext
+}
+
+func (handler *backgroundWorkerThread) context() context.Context {
+	if handler.dummyContext != nil {
+		return handler.dummyContext
+	}
+	return globalCtx
+}
+
+func (handler *backgroundWorkerThread) drain() {
+	if fd := handler.worker.backgroundStopFdWrite.Load(); fd >= 0 {
+		C.frankenphp_worker_write_stop_fd(C.int(fd))
+	}
+}
+
+func (handler *backgroundWorkerThread) beforeScriptExecution() string {
+	switch handler.state.Get() {
+	case state.TransitionRequested:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return handler.thread.transitionToNewHandler()
+	case state.Restarting:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.state.Set(state.Yielding)
+		handler.state.WaitFor(state.Ready, state.ShuttingDown)
+		return handler.beforeScriptExecution()
+	case state.Ready, state.TransitionComplete:
+		handler.thread.updateContext(true)
+		if handler.worker.onThreadReady != nil {
+			handler.worker.onThreadReady(handler.thread.threadIndex)
+		}
+
+		handler.setupScript()
+
+		return handler.worker.fileName
+	case state.ShuttingDown:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return ""
+	}
+
+	panic("unexpected state: " + handler.state.Name())
+}
+
+func (handler *backgroundWorkerThread) setupScript() {
+	// Ensure backgroundWorker state is reserved (for auto-started workers).
+	// Uses sync.Once to handle pool workers (num > 1) safely.
+	handler.worker.backgroundReserveOnce.Do(func() {
+		if handler.worker.backgroundWorker == nil && handler.worker.backgroundRegistry != nil {
+			bgw, _, err := handler.worker.backgroundRegistry.reserve(strings.TrimPrefix(handler.worker.name, "m#"))
+			if err == nil {
+				handler.worker.backgroundWorker = bgw
+			}
+		}
+	})
+
+	metrics.StartWorker(handler.worker.name)
+
+	opts := append([]RequestOption(nil), handler.worker.requestOptions...)
+	C.frankenphp_set_worker_name(handler.thread.pinCString(strings.TrimPrefix(handler.worker.name, "m#")), C._Bool(true))
+	handler.worker.backgroundStopFdWrite.Store(int32(C.frankenphp_worker_get_stop_fd_write()))
+
+	fc, err := newDummyContext(
+		filepath.Base(handler.worker.fileName),
+		opts...,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.WithValue(globalCtx, contextKey, fc)
+
+	fc.worker = handler.worker
+	handler.dummyFrankenPHPContext = fc
+	handler.dummyContext = ctx
+	handler.isBootingScript = true
+
+	if globalLogger.Enabled(ctx, slog.LevelDebug) {
+		globalLogger.LogAttrs(ctx, slog.LevelDebug, "starting", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex))
+	}
+
+	handler.thread.state.Set(state.Ready)
+	fc.scriptFilename = handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
+	handler.worker.backgroundStopFdWrite.Store(-1)
+	worker := handler.worker
+	handler.dummyFrankenPHPContext = nil
+	handler.dummyContext = nil
+
+	// on exit status 0 we just run the worker script again
+	if exitStatus == 0 && !handler.isBootingScript {
+		metrics.StopWorker(worker.name, StopReasonRestart)
+
+		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
+		}
+
+		return
+	}
+
+	// worker has thrown a fatal error or has not reached set_vars
+	if handler.isBootingScript {
+		metrics.StopWorker(worker.name, StopReasonBootFailure)
+	} else {
+		metrics.StopWorker(worker.name, StopReasonCrash)
+	}
+
+	if !handler.isBootingScript {
+		// Background worker crashed after it was running - operationally significant
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "background worker exited, restarting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
+		}
+
+		return
+	}
+
+	if worker.maxConsecutiveFailures >= 0 && startupFailChan != nil && !watcherIsEnabled && handler.failureCount >= worker.maxConsecutiveFailures {
+		startupFailChan <- fmt.Errorf("too many consecutive failures: worker %s has not reached frankenphp_handle_request()", worker.fileName)
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	if watcherIsEnabled {
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "(watcher enabled) worker script has not reached frankenphp_handle_request()", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
+		}
+	} else {
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "worker script has failed on restart", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount))
+		}
+	}
+
+	backoffDuration := time.Duration(handler.failureCount*handler.failureCount*100) * time.Millisecond
+	if backoffDuration > time.Second {
+		backoffDuration = time.Second
+	}
+	handler.failureCount++
+	time.Sleep(backoffDuration)
+}
+
+// markBackgroundReady resets failure state when the background worker
+// successfully calls set_vars for the first time.
+func (handler *backgroundWorkerThread) markBackgroundReady() {
+	if !handler.isBootingScript {
+		return
+	}
+
+	handler.failureCount = 0
+	handler.isBootingScript = false
+	metrics.ReadyWorker(handler.worker.name)
+}

--- a/threadinactive.go
+++ b/threadinactive.go
@@ -58,3 +58,6 @@ func (handler *inactiveThread) context() context.Context {
 func (handler *inactiveThread) name() string {
 	return "Inactive PHP Thread"
 }
+
+func (handler *inactiveThread) drain() {
+}

--- a/threadregular.go
+++ b/threadregular.go
@@ -76,6 +76,9 @@ func (handler *regularThread) name() string {
 	return "Regular PHP Thread"
 }
 
+func (handler *regularThread) drain() {
+}
+
 func (handler *regularThread) waitForRequest() string {
 	handler.state.MarkAsWaiting(true)
 

--- a/threadtasks_test.go
+++ b/threadtasks_test.go
@@ -79,6 +79,9 @@ func (handler *taskThread) name() string {
 	return "Task PHP Thread"
 }
 
+func (handler *taskThread) drain() {
+}
+
 func (handler *taskThread) waitForTasks() {
 	for {
 		select {

--- a/threadworker.go
+++ b/threadworker.go
@@ -26,6 +26,8 @@ type workerThread struct {
 	workerContext           context.Context
 	isBootingScript         bool // true if the worker has not reached frankenphp_handle_request yet
 	failureCount            int  // number of consecutive startup failures
+	currentTask             *taskRequest
+	stopFd                  int32 // this thread's own stop pipe fd (for cleanup in teardown)
 }
 
 func convertToWorkerThread(thread *phpThread, worker *worker) {

--- a/threadworker.go
+++ b/threadworker.go
@@ -98,13 +98,18 @@ func (handler *workerThread) name() string {
 	return "Worker PHP Thread - " + handler.worker.fileName
 }
 
+func (handler *workerThread) drain() {
+}
+
 func setupWorkerScript(handler *workerThread, worker *worker) {
 	metrics.StartWorker(worker.name)
 
-	// Create a dummy request to set up the worker
+	opts := append([]RequestOption(nil), worker.requestOptions...)
+	C.frankenphp_set_worker_name(nil, C._Bool(false))
+
 	fc, err := newDummyContext(
 		filepath.Base(worker.fileName),
-		worker.requestOptions...,
+		opts...,
 	)
 	if err != nil {
 		panic(err)
@@ -120,7 +125,9 @@ func setupWorkerScript(handler *workerThread, worker *worker) {
 	if globalLogger.Enabled(ctx, slog.LevelDebug) {
 		globalLogger.LogAttrs(ctx, slog.LevelDebug, "starting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
 	}
+
 }
+
 
 func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 	worker := handler.worker

--- a/worker.go
+++ b/worker.go
@@ -20,6 +20,37 @@ import (
 // gracefully after receiving the stop signal before being force-killed.
 const backgroundWorkerGracePeriod = 5 * time.Second
 
+// backgroundFdList is a thread-safe list of file descriptors for background worker stop pipes.
+type backgroundFdList struct {
+	mu  sync.RWMutex
+	fds []int32
+}
+
+func (l *backgroundFdList) addFd(fd int32) {
+	l.mu.Lock()
+	l.fds = append(l.fds, fd)
+	l.mu.Unlock()
+}
+
+func (l *backgroundFdList) removeFd(fd int32) {
+	l.mu.Lock()
+	for i, f := range l.fds {
+		if f == fd {
+			l.fds = append(l.fds[:i], l.fds[i+1:]...)
+			break
+		}
+	}
+	l.mu.Unlock()
+}
+
+func (l *backgroundFdList) writeAll(fn func(fd int32)) {
+	l.mu.RLock()
+	for _, fd := range l.fds {
+		fn(fd)
+	}
+	l.mu.RUnlock()
+}
+
 // represents a worker script and can have many threads assigned to it
 type worker struct {
 	mercureContext
@@ -43,7 +74,7 @@ type worker struct {
 	backgroundRegistry     *backgroundWorkerRegistry
 	backgroundWorker       *backgroundWorkerState
 	backgroundReserveOnce  sync.Once
-	backgroundStopFdWrite  atomic.Int32 // write end of the stop pipe, -1 if not set
+	backgroundFds          backgroundFdList
 }
 
 var (
@@ -176,8 +207,6 @@ func newWorker(o workerOpt) (*worker, error) {
 		isBackgroundWorker:     o.isBackgroundWorker,
 		backgroundScope:        o.backgroundScope,
 	}
-
-	w.backgroundStopFdWrite.Store(-1)
 
 	w.configureMercure(&o)
 

--- a/worker.go
+++ b/worker.go
@@ -16,6 +16,10 @@ import (
 	"github.com/dunglas/frankenphp/internal/state"
 )
 
+// backgroundWorkerGracePeriod is the time background workers have to stop
+// gracefully after receiving the stop signal before being force-killed.
+const backgroundWorkerGracePeriod = 5 * time.Second
+
 // represents a worker script and can have many threads assigned to it
 type worker struct {
 	mercureContext
@@ -33,6 +37,13 @@ type worker struct {
 	onThreadReady          func(int)
 	onThreadShutdown       func(int)
 	queuedRequests         atomic.Int32
+	isBackgroundWorker     bool
+	backgroundScope        string
+	backgroundLookup       *backgroundWorkerLookup
+	backgroundRegistry     *backgroundWorkerRegistry
+	backgroundWorker       *backgroundWorkerState
+	backgroundReserveOnce  sync.Once
+	backgroundStopFdWrite  atomic.Int32 // write end of the stop pipe, -1 if not set
 }
 
 var (
@@ -71,12 +82,26 @@ func initWorkers(opt []workerOpt) error {
 		}
 	}
 
+	// Build per-scope background worker lookups
+	backgroundLookups = buildBackgroundWorkerLookups(workers, opt)
+	if backgroundLookups != nil {
+		for _, w := range workers {
+			if lookup := backgroundLookups[w.backgroundScope]; lookup != nil {
+				w.backgroundLookup = lookup
+			}
+		}
+	}
+
 	startupFailChan = make(chan error, totalThreadsToStart)
 
 	for _, w := range workers {
 		for i := 0; i < w.num; i++ {
 			thread := getInactivePHPThread()
-			convertToWorkerThread(thread, w)
+			if w.isBackgroundWorker {
+				convertToBackgroundWorkerThread(thread, w)
+			} else {
+				convertToWorkerThread(thread, w)
+			}
 
 			workersReady.Go(func() {
 				thread.state.WaitFor(state.Ready, state.ShuttingDown, state.Done)
@@ -122,7 +147,7 @@ func newWorker(o workerOpt) (*worker, error) {
 
 	// workers that have a name starting with "m#" are module workers
 	// they can only be matched by their name, not by their path
-	allowPathMatching := !strings.HasPrefix(o.name, "m#")
+	allowPathMatching := !strings.HasPrefix(o.name, "m#") && !o.isBackgroundWorker
 
 	if w := workersByPath[absFileName]; w != nil && allowPathMatching {
 		return w, fmt.Errorf("two workers cannot have the same filename: %q", absFileName)
@@ -148,7 +173,11 @@ func newWorker(o workerOpt) (*worker, error) {
 		maxConsecutiveFailures: o.maxConsecutiveFailures,
 		onThreadReady:          o.onThreadReady,
 		onThreadShutdown:       o.onThreadShutdown,
+		isBackgroundWorker:     o.isBackgroundWorker,
+		backgroundScope:        o.backgroundScope,
 	}
+
+	w.backgroundStopFdWrite.Store(-1)
 
 	w.configureMercure(&o)
 
@@ -162,11 +191,23 @@ func newWorker(o workerOpt) (*worker, error) {
 		o.extensionWorkers.internalWorker = w
 	}
 
+	// Reserve background worker state in the registry during init
+	if w.isBackgroundWorker && w.backgroundRegistry != nil {
+		bgw, _, err := w.backgroundRegistry.reserve(w.name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reserve background worker %q: %w", w.name, err)
+		}
+		w.backgroundWorker = bgw
+	}
+
 	return w, nil
 }
 
 // EXPERIMENTAL: DrainWorkers finishes all worker scripts before a graceful shutdown
 func DrainWorkers() {
+	scalingMu.Lock()
+	defer scalingMu.Unlock()
+
 	_ = drainWorkerThreads()
 }
 
@@ -174,21 +215,34 @@ func drainWorkerThreads() []*phpThread {
 	var (
 		ready          sync.WaitGroup
 		drainedThreads []*phpThread
+		bgThreads      []*phpThread
+		bgWorkers      []*worker
 	)
 
 	for _, worker := range workers {
 		worker.threadMutex.RLock()
-		ready.Add(len(worker.threads))
+		threads := append([]*phpThread(nil), worker.threads...)
+		worker.threadMutex.RUnlock()
 
-		for _, thread := range worker.threads {
-			if !thread.state.RequestSafeStateChange(state.Restarting) {
-				ready.Done()
-
-				// no state change allowed == thread is shutting down
-				// we'll proceed to restart all other threads anyway
+		for _, thread := range threads {
+			if worker.isBackgroundWorker {
+				// Signal background workers to stop via the signaling stream
+				if !thread.state.RequestSafeStateChange(state.ShuttingDown) {
+					continue
+				}
+				thread.handler.drain()
+				close(thread.drainChan)
+				bgThreads = append(bgThreads, thread)
+				bgWorkers = append(bgWorkers, worker)
 				continue
 			}
 
+			if !thread.state.RequestSafeStateChange(state.Restarting) {
+				continue
+			}
+
+			ready.Add(1)
+			thread.handler.drain()
 			close(thread.drainChan)
 			drainedThreads = append(drainedThreads, thread)
 
@@ -197,11 +251,64 @@ func drainWorkerThreads() []*phpThread {
 				ready.Done()
 			}(thread)
 		}
-
-		worker.threadMutex.RUnlock()
 	}
 
 	ready.Wait()
+
+	// Wait for background workers with a grace period.
+	// Well-written workers check the signaling stream and stop promptly.
+	// Stuck workers (e.g., blocking C calls) are abandoned after the timeout;
+	// new threads are created on restart, and the old thread exits when the
+	// blocking call eventually returns.
+	if len(bgThreads) > 0 {
+		bgDone := make(chan struct{})
+		go func() {
+			for _, thread := range bgThreads {
+				thread.state.WaitFor(state.Done)
+			}
+			close(bgDone)
+		}()
+
+		select {
+		case <-bgDone:
+			// all stopped gracefully
+		case <-time.After(backgroundWorkerGracePeriod):
+			// Best-effort force-kill: arm PHP's max_execution_time timer on
+			// stuck threads. Linux ZTS: arms PHP's timer. Windows: interrupts
+			// I/O and alertable waits. Other platforms: no-op.
+			// Safe because after 5s, stuck threads are guaranteed to be in C code.
+			for _, thread := range bgThreads {
+				if !thread.state.Is(state.Done) {
+					C.frankenphp_force_kill_thread(C.uintptr_t(thread.threadIndex))
+				}
+			}
+			globalLogger.Warn("background workers did not stop within grace period, force-killing stuck threads")
+		}
+
+		// Clean up registry entries for stopped workers
+		stopped := make(map[*worker]struct{}, len(bgWorkers))
+		for _, w := range bgWorkers {
+			if w.backgroundRegistry != nil && w.backgroundWorker != nil {
+				w.backgroundRegistry.remove(w.name, w.backgroundWorker)
+			}
+			stopped[w] = struct{}{}
+		}
+		filtered := workers[:0]
+		for _, w := range workers {
+			if _, ok := stopped[w]; !ok {
+				filtered = append(filtered, w)
+			}
+		}
+		workers = filtered
+
+		// Reset drained background threads for restart
+		for _, thread := range bgThreads {
+			thread.drainChan = make(chan struct{})
+			if mainThread.state.Is(state.Ready) {
+				thread.state.Set(state.Reserved)
+			}
+		}
+	}
 
 	return drainedThreads
 }


### PR DESCRIPTION
This PR builds on top of #2287 (background workers), which is the first commit.

The following description is only about what's currently the second commit.

An overview of both features combined together can be reviewed by reading the doc attached to this PR.

## Summary

Adds a task API for bidirectional communication between HTTP workers and background workers. While `set_vars`/`get_vars` pushes config from background workers to HTTP workers, tasks enable the reverse: HTTP workers dispatch work to background workers and stream results back.

### PHP API

Sender-side:
- **`frankenphp_worker_task_send(string $name, array $payload, float $timeout = 30.0): resource`** - sends a task to a named background worker, returns a readable stream for results
- **`frankenphp_worker_task_read(resource $stream): ?array`** - reads the next update, returns `null` on clean completion

Receiver-side:
- **`frankenphp_worker_task_receive(): ?array`** - dequeues a pending task to process, returns `[$stream, $payload]` or `null`
- **`frankenphp_worker_task_update(resource $stream, array $data): void`** - sends a progress update or result back to the sender

All payloads and updates follow the same type constraints as `set_vars`: `null`, `bool`, `int`, `float`, `string`, `array` (nested), and enums. Objects and resources are rejected.


<img width="1095" height="1148" alt="Capture d&#39;écran 2026-03-27 085826" src="https://github.com/user-attachments/assets/b07c2577-3a67-4d88-b269-7d2a75a0e57e" />

### How it works

1. HTTP worker calls `task_send('worker-name', $payload)` - blocks until a background worker picks up the task
2. Background worker receives `"task\n"` on the signaling stream, calls `task_receive()` to get `[$stream, $payload]`
3. Background worker processes the payload, sends results via `task_update($stream, $data)`
4. HTTP worker reads results via `task_read($stream)` - wakes up on each update
5. Background worker calls `fclose($stream)` when done - sender gets `null` from `task_read()`
6. Sender calls `fclose($stream)` to acknowledge completion

### Blocking behavior

- `task_send` blocks until the background worker picks up the task (with timeout). Uses a buffered channel (size 1) so the sender can enqueue before the `"task\n"` signal reaches the receiver.
- `task_read` blocks until the next update arrives or the stream is closed. The task stream from `task_send` is `stream_select`-compatible, so callers can check readability before calling `task_read`.
- Sender can cancel a task by calling `fclose()` before the background worker completes. Cancelled tasks are detected at `task_receive()` time and skipped.

### Crash detection

- If the background worker exits without calling `fclose($stream)` (crash, `exit()`, fatal error), `task_read()` throws `RuntimeException`
- Clean completion (`fclose` by the background worker) returns `null` from `task_read()`
- Detection uses `EG(flags) & EG_FLAGS_IN_SHUTDOWN` to distinguish explicit `fclose()` from resource cleanup during script exit

### Pooling

Named background workers support `num > 1` to run multiple threads. All threads share the same task channel - tasks are distributed automatically across the pool. The signaling stream fans out `"task\n"` to all threads.

<img width="1386" height="800" alt="Capture d&#39;écran 2026-03-27 085922" src="https://github.com/user-attachments/assets/b3182cc8-e63b-492b-bc10-671b0d56c0d2" />

### Example

```php
// Background worker: process tasks
$signaling = frankenphp_worker_get_signaling_stream();

while (true) {
    $r = [$signaling];
    $w = $e = [];
    if (!stream_select($r, $w, $e, 30)) { continue; }

    $signal = fgets($signaling);
    if ("stop\n" === $signal) { break; }

    if ("task\n" === $signal && [$stream, $payload] = frankenphp_worker_task_receive()) {
        frankenphp_worker_task_update($stream, ['result' => process($payload)]);
        fclose($stream);
    }
}
```

```php
// HTTP worker: send a task and read the result
$stream = frankenphp_worker_task_send('image-resizer', ['file' => 'photo.jpg']);
$result = frankenphp_worker_task_read($stream);
fclose($stream);
```

### Architecture

- `taskRequest` struct coordinates sender and receiver via `closedSides` atomic counter - task slot is freed when both sides close
- `taskFIFO` provides bounded backpressure for updates (max 16 items, blocks on push when full)
- Pipe-based signaling: each task gets a pipe pair. Background worker writes nudge bytes via `task_update`, sender detects them via `stream_select`
- Custom PHP stream ops for both sender (read-only, wraps pipe read fd) and receiver (write-only, wraps task id)
- Task signal fan-out uses `backgroundFdList` stored on `backgroundWorkerState` for O(1) lookup (no worker search)

### Test coverage

10 tests covering: basic task send/receive, progress streaming, non-worker sender, crash before receive, crash mid-task, cancellation, cancel-then-send recovery, cancel-then-crash, pooling (num=2).

### Documentation

Task API section added to `docs/background-workers.md`.
