### PR TITLE
fix(extgen): better error handling

### DIFF
--- a/internal/extgen/cfile_namespace_test.go
+++ b/internal/extgen/cfile_namespace_test.go
@@ -66,8 +66,7 @@ func (m *MySuperClass) Test() string {
 	tmpfile, err := os.CreateTemp("", "test_cfile_namespace_*.go")
 	require.NoError(t, err, "Failed to create temp file")
 	defer func() {
-		err := os.Remove(tmpfile.Name())
-		assert.NoError(t, err, "Failed to remove temp file: %v", err)
+		require.NoError(t, os.Remove(tmpfile.Name()), "Failed to remove temp file")
 	}()
 
 	_, err = tmpfile.Write([]byte(content))

--- a/internal/extgen/classparser.go
+++ b/internal/extgen/classparser.go
@@ -2,6 +2,7 @@ package extgen
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -211,10 +212,7 @@ func (cp *classParser) parseMethods(filename string) (methods []phpClassMethod, 
 	}
 
 	defer func() {
-		e := file.Close()
-		if err != nil {
-			err = e
-		}
+		err = errors.Join(err, file.Close())
 	}()
 
 	scanner := bufio.NewScanner(file)

--- a/internal/extgen/constparser.go
+++ b/internal/extgen/constparser.go
@@ -2,6 +2,7 @@ package extgen
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -20,11 +21,9 @@ func (cp *ConstantParser) parse(filename string) (constants []phpConstant, err e
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() {
-		e := file.Close()
-		if err == nil {
-			err = e
-		}
+		err = errors.Join(err, file.Close())
 	}()
 
 	scanner := bufio.NewScanner(file)

--- a/internal/extgen/funcparser.go
+++ b/internal/extgen/funcparser.go
@@ -2,6 +2,7 @@ package extgen
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -19,11 +20,9 @@ func (fp *FuncParser) parse(filename string) (functions []phpFunction, err error
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() {
-		e := file.Close()
-		if err == nil {
-			err = e
-		}
+		err = errors.Join(err, file.Close())
 	}()
 
 	scanner := bufio.NewScanner(file)

--- a/internal/extgen/namespace_test.go
+++ b/internal/extgen/namespace_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,8 +57,7 @@ func main() {}`,
 			tmpfile, err := os.CreateTemp("", "test_namespace_*.go")
 			require.NoError(t, err, "Failed to create temp file")
 			defer func() {
-				err := os.Remove(tmpfile.Name())
-				assert.NoError(t, err, "Failed to remove temp file: %v", err)
+				require.NoError(t, os.Remove(tmpfile.Name()), "Failed to remove temp file")
 			}()
 
 			_, err = tmpfile.Write([]byte(tt.content))
@@ -98,9 +96,7 @@ const TEST_CONSTANT = "test_value"
 	tmpfile, err := os.CreateTemp("", "test_generator_namespace_*.go")
 	require.NoError(t, err, "Failed to create temp file")
 	defer func() {
-		if err := os.Remove(tmpfile.Name()); err != nil {
-			t.Logf("Failed to remove temp file: %v", err)
-		}
+		require.NoError(t, os.Remove(tmpfile.Name()), "Failed to remove temp file")
 	}()
 
 	_, err = tmpfile.Write([]byte(content))

--- a/internal/extgen/nsparser.go
+++ b/internal/extgen/nsparser.go
@@ -13,7 +13,7 @@ type NamespaceParser struct{}
 
 var namespaceRegex = regexp.MustCompile(`//\s*export_php:namespace\s+(.+)`)
 
-func (np *NamespaceParser) parse(filename string) (string, error) {
+func (np *NamespaceParser) parse(filename string) (foundNamespace string, err error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return "", err
@@ -23,9 +23,7 @@ func (np *NamespaceParser) parse(filename string) (string, error) {
 		err = errors.Join(err, file.Close())
 	}()
 
-	var foundNamespace string
-	var lineNumber int
-	var foundLineNumber int
+	var lineNumber, foundLineNumber int
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -36,6 +34,7 @@ func (np *NamespaceParser) parse(filename string) (string, error) {
 			if foundNamespace != "" {
 				return "", fmt.Errorf("multiple namespace declarations found: first at line %d, second at line %d", foundLineNumber, lineNumber)
 			}
+
 			foundNamespace = namespace
 			foundLineNumber = lineNumber
 		}

--- a/internal/extgen/nsparser.go
+++ b/internal/extgen/nsparser.go
@@ -2,6 +2,7 @@ package extgen
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -17,10 +18,9 @@ func (np *NamespaceParser) parse(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	defer func() {
-		if err := file.Close(); err != nil {
-			fmt.Printf("Error closing file %s: %v\n", filename, err)
-		}
+		err = errors.Join(err, file.Close())
 	}()
 
 	var foundNamespace string


### PR DESCRIPTION
Superseeds #2351.

Use `errors.Join()` to preserve all errors in extgen.