### PR TITLE
fix(docs): add migration guide to the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Go to `https://localhost`, and enjoy!
 
 - [Classic mode](https://frankenphp.dev/docs/classic/)
 - [Worker mode](https://frankenphp.dev/docs/worker/)
+- [Migrating from Nginx/PHP-FPM](https://frankenphp.dev/docs/migrate/)
 - [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
 - [Real-time](https://frankenphp.dev/docs/mercure/)
 - [Logging](https://frankenphp.dev/docs/logging/)

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,4 +1,4 @@
-# Migrating from PHP-FPM
+# Migrating from Nginx/PHP-FPM
 
 FrankenPHP replaces both your web server (Nginx, Apache) and PHP-FPM with a single binary.
 This guide covers a basic migration for a typical PHP application.


### PR DESCRIPTION
Oops, I forgot to add it in #2275 and it is not findable on the website right now