### PR TITLE
feat: passive worker_stalled_{1,3,5}s metrics (#1122)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -16,5 +16,8 @@ When [Caddy metrics](https://caddyserver.com/docs/metrics) are enabled, FrankenP
 - `frankenphp_worker_crashes{worker="[worker_name]"}`: The number of times a worker has unexpectedly terminated.
 - `frankenphp_worker_restarts{worker="[worker_name]"}`: The number of times a worker has been deliberately restarted.
 - `frankenphp_worker_queue_depth{worker="[worker_name]"}`: The number of queued requests.
+- `frankenphp_worker_stalled_1s{worker="[worker_name]"}`: Fraction of the last 1 second the worker's request queue was non-empty (`0..1`). `0` means no requests waited; `1` means requests waited for the entire window. The metric is sampled passively, off the request hot path.
+- `frankenphp_worker_stalled_3s{worker="[worker_name]"}`: Same as above, over the last 3 seconds.
+- `frankenphp_worker_stalled_5s{worker="[worker_name]"}`: Same as above, over the last 5 seconds.
 
 For worker metrics, the `[worker_name]` placeholder is replaced by the worker name in the Caddyfile, otherwise absolute path of worker file will be used.

--- a/metrics.go
+++ b/metrics.go
@@ -40,6 +40,9 @@ type Metrics interface {
 	DequeuedWorkerRequest(name string)
 	QueuedRequest()
 	DequeuedRequest()
+	// WorkerStalled reports the rolling 1/3/5-second fraction of time
+	// the worker's request queue was non-empty. Each value is in [0,1].
+	WorkerStalled(name string, win1s, win3s, win5s float64)
 }
 
 type nullMetrics struct{}
@@ -81,6 +84,8 @@ func (n nullMetrics) DequeuedWorkerRequest(string) {}
 func (n nullMetrics) QueuedRequest()   {}
 func (n nullMetrics) DequeuedRequest() {}
 
+func (n nullMetrics) WorkerStalled(string, float64, float64, float64) {}
+
 type PrometheusMetrics struct {
 	registry           prometheus.Registerer
 	totalThreads       prometheus.Counter
@@ -93,6 +98,9 @@ type PrometheusMetrics struct {
 	workerRequestTime  *prometheus.CounterVec
 	workerRequestCount *prometheus.CounterVec
 	workerQueueDepth   *prometheus.GaugeVec
+	workerStalled1s    *prometheus.GaugeVec
+	workerStalled3s    *prometheus.GaugeVec
+	workerStalled5s    *prometheus.GaugeVec
 	queueDepth         prometheus.Gauge
 	mu                 sync.Mutex
 }
@@ -243,6 +251,45 @@ func (m *PrometheusMetrics) TotalWorkers(string, int) {
 			panic(err)
 		}
 	}
+
+	if m.workerStalled1s == nil {
+		m.workerStalled1s = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "stalled_1s",
+			Help:      "Fraction of the last 1 second the worker's request queue was non-empty (0..1)",
+		}, basicLabels)
+		if err := m.registry.Register(m.workerStalled1s); err != nil &&
+			!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			panic(err)
+		}
+	}
+
+	if m.workerStalled3s == nil {
+		m.workerStalled3s = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "stalled_3s",
+			Help:      "Fraction of the last 3 seconds the worker's request queue was non-empty (0..1)",
+		}, basicLabels)
+		if err := m.registry.Register(m.workerStalled3s); err != nil &&
+			!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			panic(err)
+		}
+	}
+
+	if m.workerStalled5s == nil {
+		m.workerStalled5s = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "stalled_5s",
+			Help:      "Fraction of the last 5 seconds the worker's request queue was non-empty (0..1)",
+		}, basicLabels)
+		if err := m.registry.Register(m.workerStalled5s); err != nil &&
+			!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			panic(err)
+		}
+	}
 }
 
 func (m *PrometheusMetrics) TotalThreads(num int) {
@@ -286,6 +333,15 @@ func (m *PrometheusMetrics) DequeuedWorkerRequest(name string) {
 		return
 	}
 	m.workerQueueDepth.WithLabelValues(name).Dec()
+}
+
+func (m *PrometheusMetrics) WorkerStalled(name string, win1s, win3s, win5s float64) {
+	if m.workerStalled1s == nil {
+		return
+	}
+	m.workerStalled1s.WithLabelValues(name).Set(win1s)
+	m.workerStalled3s.WithLabelValues(name).Set(win3s)
+	m.workerStalled5s.WithLabelValues(name).Set(win5s)
 }
 
 func (m *PrometheusMetrics) QueuedRequest() {
@@ -339,6 +395,21 @@ func (m *PrometheusMetrics) Shutdown() {
 	if m.workerQueueDepth != nil {
 		m.registry.Unregister(m.workerQueueDepth)
 		m.workerQueueDepth = nil
+	}
+
+	if m.workerStalled1s != nil {
+		m.registry.Unregister(m.workerStalled1s)
+		m.workerStalled1s = nil
+	}
+
+	if m.workerStalled3s != nil {
+		m.registry.Unregister(m.workerStalled3s)
+		m.workerStalled3s = nil
+	}
+
+	if m.workerStalled5s != nil {
+		m.registry.Unregister(m.workerStalled5s)
+		m.workerStalled5s = nil
 	}
 
 	m.totalThreads = prometheus.NewCounter(prometheus.CounterOpts{
@@ -397,6 +468,9 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 		workerCrashes:      nil,
 		readyWorkers:       nil,
 		workerQueueDepth:   nil,
+		workerStalled1s:    nil,
+		workerStalled3s:    nil,
+		workerStalled5s:    nil,
 	}
 
 	if err := m.registry.Register(m.totalThreads); err != nil &&

--- a/stallsampler.go
+++ b/stallsampler.go
@@ -1,0 +1,89 @@
+package frankenphp
+
+import (
+	"sync"
+	"time"
+)
+
+// stallSampleInterval is how often a worker's request queue is sampled
+// to compute the rolling stall metric. 100ms gives 10 samples/s, which
+// is enough resolution for the 1, 3, and 5 second windows while keeping
+// overhead negligible.
+const stallSampleInterval = 100 * time.Millisecond
+
+// Window sizes are expressed in number of samples at stallSampleInterval.
+const (
+	stallWindow1 = int(time.Second / stallSampleInterval)
+	stallWindow3 = int(3 * time.Second / stallSampleInterval)
+	stallWindow5 = int(5 * time.Second / stallSampleInterval)
+)
+
+// stallSampler tracks whether a worker's request queue was non-empty
+// across a fixed-size sliding window. Samples are recorded by the
+// per-worker sampler goroutine and read out as rolling-window means
+// covering 1, 3, and 5 second windows. Each mean is a fraction in
+// [0,1] representing the share of the window during which the queue
+// was non-empty — i.e. requests were stalling waiting for a worker
+// thread.
+//
+// The sampler is intentionally decoupled from the request hot path:
+// it observes worker.queuedRequests passively from a dedicated
+// goroutine and never blocks request handling.
+type stallSampler struct {
+	mu      sync.Mutex
+	samples [stallWindow5]uint8
+	cursor  int // index of next write
+	filled  int // number of valid samples (capped at stallWindow5)
+}
+
+// record appends a single sample to the ring buffer.
+func (s *stallSampler) record(stalled bool) {
+	var v uint8
+	if stalled {
+		v = 1
+	}
+
+	s.mu.Lock()
+	s.samples[s.cursor] = v
+	s.cursor = (s.cursor + 1) % stallWindow5
+	if s.filled < stallWindow5 {
+		s.filled++
+	}
+	s.mu.Unlock()
+}
+
+// snapshot returns rolling-window stall fractions for the 1, 3, and 5
+// second windows. Each value is in [0,1]; 0 means the queue was empty
+// for the whole window, 1 means the queue was non-empty for the whole
+// window. When fewer than `windowSize` samples have been collected,
+// the available samples are averaged (so the metric ramps up over the
+// first 5 seconds rather than reporting a misleading low value).
+func (s *stallSampler) snapshot() (win1s, win3s, win5s float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.windowLocked(stallWindow1),
+		s.windowLocked(stallWindow3),
+		s.windowLocked(stallWindow5)
+}
+
+// windowLocked computes the mean of the most recent `size` samples.
+// The caller must hold s.mu.
+func (s *stallSampler) windowLocked(size int) float64 {
+	if s.filled == 0 {
+		return 0
+	}
+
+	n := size
+	if n > s.filled {
+		n = s.filled
+	}
+
+	sum := 0
+	for i := 1; i <= n; i++ {
+		idx := (s.cursor - i + stallWindow5) % stallWindow5
+		sum += int(s.samples[idx])
+	}
+
+	return float64(sum) / float64(n)
+}

--- a/stallsampler_test.go
+++ b/stallsampler_test.go
@@ -1,0 +1,181 @@
+package frankenphp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStallSampler_EmptyBufferReturnsZero(t *testing.T) {
+	s := &stallSampler{}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 0.0, w1)
+	require.Equal(t, 0.0, w3)
+	require.Equal(t, 0.0, w5)
+}
+
+func TestStallSampler_AlwaysStalled(t *testing.T) {
+	s := &stallSampler{}
+
+	for i := 0; i < stallWindow5; i++ {
+		s.record(true)
+	}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 1.0, w1)
+	require.Equal(t, 1.0, w3)
+	require.Equal(t, 1.0, w5)
+}
+
+func TestStallSampler_NeverStalled(t *testing.T) {
+	s := &stallSampler{}
+
+	for i := 0; i < stallWindow5; i++ {
+		s.record(false)
+	}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 0.0, w1)
+	require.Equal(t, 0.0, w3)
+	require.Equal(t, 0.0, w5)
+}
+
+func TestStallSampler_PartiallyStalled(t *testing.T) {
+	s := &stallSampler{}
+
+	// Half stalled, half not — interleaved across the full 5-second window.
+	for i := 0; i < stallWindow5; i++ {
+		s.record(i%2 == 0)
+	}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.InDelta(t, 0.5, w1, 0.1)
+	require.InDelta(t, 0.5, w3, 0.05)
+	require.InDelta(t, 0.5, w5, 0.0001)
+}
+
+func TestStallSampler_RecentSamplesDominate(t *testing.T) {
+	s := &stallSampler{}
+
+	// 4 seconds of idle, then 1 second of stalled.
+	for i := 0; i < stallWindow5-stallWindow1; i++ {
+		s.record(false)
+	}
+	for i := 0; i < stallWindow1; i++ {
+		s.record(true)
+	}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 1.0, w1, "1s window should be fully stalled")
+	require.InDelta(t, float64(stallWindow1)/float64(stallWindow3), w3, 0.0001, "3s window covers 1s of stall out of 3s")
+	require.InDelta(t, float64(stallWindow1)/float64(stallWindow5), w5, 0.0001, "5s window covers 1s of stall out of 5s")
+}
+
+func TestStallSampler_RingBufferOverwrites(t *testing.T) {
+	s := &stallSampler{}
+
+	// Fill with `false`, then overwrite the entire buffer with `true`.
+	// The earliest `false` samples must have been evicted.
+	for i := 0; i < stallWindow5; i++ {
+		s.record(false)
+	}
+	for i := 0; i < stallWindow5; i++ {
+		s.record(true)
+	}
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 1.0, w1)
+	require.Equal(t, 1.0, w3)
+	require.Equal(t, 1.0, w5)
+}
+
+func TestStallSampler_PartialFillUsesActualSampleCount(t *testing.T) {
+	s := &stallSampler{}
+
+	// Only 2 samples ever recorded, both stalled. snapshot() should
+	// report 1.0 for every window — averaging over the actual sample
+	// count, not zero-padding the missing slots.
+	s.record(true)
+	s.record(true)
+
+	w1, w3, w5 := s.snapshot()
+
+	require.Equal(t, 1.0, w1)
+	require.Equal(t, 1.0, w3)
+	require.Equal(t, 1.0, w5)
+}
+
+func TestPrometheusMetrics_WorkerStalled(t *testing.T) {
+	m := createPrometheusMetrics()
+	m.TotalWorkers("test_worker", 2)
+
+	require.NotNil(t, m.workerStalled1s)
+	require.NotNil(t, m.workerStalled3s)
+	require.NotNil(t, m.workerStalled5s)
+
+	m.WorkerStalled("test_worker", 0.25, 0.5, 0.75)
+
+	cases := []struct {
+		name     string
+		c        prometheus.Collector
+		metadata string
+		expect   string
+	}{
+		{
+			name: "stalled_1s",
+			c:    m.workerStalled1s,
+			metadata: `
+					# HELP frankenphp_worker_stalled_1s Fraction of the last 1 second the worker's request queue was non-empty (0..1)
+					# TYPE frankenphp_worker_stalled_1s gauge
+				`,
+			expect: `
+					frankenphp_worker_stalled_1s{worker="test_worker"} 0.25
+				`,
+		},
+		{
+			name: "stalled_3s",
+			c:    m.workerStalled3s,
+			metadata: `
+					# HELP frankenphp_worker_stalled_3s Fraction of the last 3 seconds the worker's request queue was non-empty (0..1)
+					# TYPE frankenphp_worker_stalled_3s gauge
+				`,
+			expect: `
+					frankenphp_worker_stalled_3s{worker="test_worker"} 0.5
+				`,
+		},
+		{
+			name: "stalled_5s",
+			c:    m.workerStalled5s,
+			metadata: `
+					# HELP frankenphp_worker_stalled_5s Fraction of the last 5 seconds the worker's request queue was non-empty (0..1)
+					# TYPE frankenphp_worker_stalled_5s gauge
+				`,
+			expect: `
+					frankenphp_worker_stalled_5s{worker="test_worker"} 0.75
+				`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.NoError(t, testutil.CollectAndCompare(c.c, strings.NewReader(c.metadata+c.expect)))
+		})
+	}
+}
+
+func TestPrometheusMetrics_WorkerStalledNoOpBeforeRegistration(t *testing.T) {
+	m := createPrometheusMetrics()
+
+	// Must not panic even if TotalWorkers has not been called yet.
+	m.WorkerStalled("test_worker", 0.5, 0.5, 0.5)
+}

--- a/worker.go
+++ b/worker.go
@@ -33,6 +33,7 @@ type worker struct {
 	onThreadReady          func(int)
 	onThreadShutdown       func(int)
 	queuedRequests         atomic.Int32
+	stalls                 *stallSampler
 }
 
 var (
@@ -95,7 +96,32 @@ func initWorkers(opt []workerOpt) error {
 		startupFailChan = nil
 	}
 
+	// start a passive stall sampler per worker. It runs off the request
+	// hot path and updates the worker_stalled_{1s,3s,5s} metrics.
+	for _, w := range workers {
+		go w.runStallSampler(mainThread.done)
+	}
+
 	return nil
+}
+
+// runStallSampler ticks at stallSampleInterval and records whether the
+// worker's request queue is non-empty, then publishes the rolling 1/3/5s
+// fractions to the metrics backend. It exits when done is closed.
+func (worker *worker) runStallSampler(done <-chan struct{}) {
+	ticker := time.NewTicker(stallSampleInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			worker.stalls.record(worker.queuedRequests.Load() > 0)
+			win1s, win3s, win5s := worker.stalls.snapshot()
+			metrics.WorkerStalled(worker.name, win1s, win3s, win5s)
+		}
+	}
 }
 
 func newWorker(o workerOpt) (*worker, error) {
@@ -148,6 +174,7 @@ func newWorker(o workerOpt) (*worker, error) {
 		maxConsecutiveFailures: o.maxConsecutiveFailures,
 		onThreadReady:          o.onThreadReady,
 		onThreadShutdown:       o.onThreadShutdown,
+		stalls:                 &stallSampler{},
 	}
 
 	w.configureMercure(&o)


### PR DESCRIPTION
## Summary

Adds three new per-worker Prometheus gauges that surface the rolling-window stall fraction proposed by @withinboredom in #1122:

- `frankenphp_worker_stalled_1s{worker="…"}`
- `frankenphp_worker_stalled_3s{worker="…"}`
- `frankenphp_worker_stalled_5s{worker="…"}`

Each value is in `[0, 1]` and represents the fraction of the window during which the worker's request queue was non-empty (i.e. requests were waiting for a worker thread). `0` = no requests waited; `1` = requests waited for the entire window. Per @withinboredom's spec:

> `frankenphp_[worker]_stalled_[1,3,5]: 0-1` — Where the number shows a % over the last 1-5 seconds. This number is a representation of how full the worker request buffer is. In low utilization it is always 0.

## Design

Sampling is **passive and off the request hot path**, as requested:

- Per-worker goroutine ticks at 100 ms (10 samples/s).
- Each tick reads `worker.queuedRequests.Load() > 0` (a single atomic load).
- A 50-slot ring buffer (5 s × 10 Hz) keeps the most recent samples.
- Three windowed means are computed from the last 10 / 30 / 50 entries and published via `metrics.WorkerStalled`.

Per tick the cost is one atomic load, one mutex'd ring-buffer write, three small loops summing ≤ 50 bytes, and three `GaugeVec.Set` calls. The request handling code paths are untouched.

The sampler is started in `initWorkers` after the existing `WaitGroup.Wait()` and stops when `mainThread.done` closes — same lifetime as the autoscaling and downscaling goroutines.

## Files

- `stallsampler.go` (new): ring-buffer sampler with `record(bool)` / `snapshot() (w1, w3, w5 float64)`.
- `stallsampler_test.go` (new): 9 unit tests covering empty / always-stalled / never-stalled / partially stalled / recent-dominates / ring-rotation / partial-fill cases plus Prometheus collector integration.
- `metrics.go`: adds `WorkerStalled` to the `Metrics` interface (with `nullMetrics` no-op) and the three `GaugeVec` fields on `PrometheusMetrics`, registered in `TotalWorkers` and unregistered in `Shutdown` alongside the existing per-worker collectors.
- `worker.go`: per-worker `runStallSampler` goroutine; `stalls *stallSampler` field on `worker`.
- `docs/metrics.md`: documents the three new gauges.

## Test plan

- [x] `go test -race -tags nowatcher,nobadger,nomysql,nopgx,nobrotli ./...` — passes locally inside `php:8.5-zts-bookworm`.
- [x] `TestStallSampler_*` (7 tests) and `TestPrometheusMetrics_WorkerStalled*` (2 tests) all pass under `-race`.
- [x] Existing `TestPrometheusMetrics_*` and `TestWorker*` suites unchanged.
- [ ] CI on this PR (left as draft until green).

## Notes

- Translations (`docs/{cn,fr,ja,pt-br,ru,es}/metrics.md`) intentionally not touched — happy to follow up once English wording is settled, or defer to the translation PR pipeline.
- I'm a first-time contributor; pointers on style or scope welcomed.

Resolves #1122.