### PR TITLE
fix: Fix upstream BC break on INI_INT() macro

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -570,7 +570,11 @@ PHP_FUNCTION(frankenphp_handle_request) {
    * Reset default timeout
    */
   if (PG(max_input_time) != -1) {
+#if PHP_VERSION_ID < 80600
     zend_set_timeout(INI_INT("max_execution_time"), 0);
+#else
+    zend_set_timeout(zend_ini_long_literal("max_execution_time"), 0);
+#endif
   }
 #endif
 


### PR DESCRIPTION
The latest PHP development branch has removed the `INI_INT()` macro in favor of `zend_ini_long_literal()` (see php/php-src#21146).

This breaks FrankenPHP builds against PHP master. This PR introduces a preprocessor macro to support both the old and new APIs.