### PR TITLE
ci: reinstall libbrotli-dev on Linux test runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,10 +59,7 @@ jobs:
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
       - name: Reinstall libbrotli-dev
-        # The runner image (ubuntu-latest, noble) lists libbrotli-dev as installed
-        # in dpkg, but the headers and pkg-config files are missing on disk, so
-        # the cbrotli cgo build cannot find brotli/decode.h. --reinstall forces
-        # apt to re-extract the package even though dpkg thinks it's current.
+        # TODO: remove this workaround when fixed upstream
         run: sudo apt-get install --reinstall -y libbrotli-dev
       - name: Set CGO flags
         run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,20 +58,12 @@ jobs:
           debug: true
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
-      - name: Diagnose brotli state on runner
-        run: |
-          echo "=== dpkg -l brotli ==="
-          dpkg -l | grep -iE '(^ii|^un).*brotli' || echo "(no brotli rows)"
-          echo "=== /usr/include/brotli/ ==="
-          ls -la /usr/include/brotli/ 2>&1 || true
-          echo "=== brotli .pc files ==="
-          find /usr -name 'libbrotli*.pc' 2>/dev/null || true
-          echo "=== pkg-config --cflags ==="
-          pkg-config --cflags libbrotlicommon libbrotlidec libbrotlienc 2>&1 || true
-          echo "=== pkg-config --libs ==="
-          pkg-config --libs libbrotlicommon libbrotlidec libbrotlienc 2>&1 || true
-          echo "=== gcc default include search ==="
-          echo | gcc -E -v - 2>&1 | sed -n '/search starts here/,/End of search list/p' || true
+      - name: Reinstall libbrotli-dev
+        # The runner image (ubuntu-latest, noble) lists libbrotli-dev as installed
+        # in dpkg, but the headers and pkg-config files are missing on disk, so
+        # the cbrotli cgo build cannot find brotli/decode.h. --reinstall forces
+        # apt to re-extract the package even though dpkg thinks it's current.
+        run: sudo apt-get install --reinstall -y libbrotli-dev
       - name: Set CGO flags
         run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"
       - name: Build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,6 +58,8 @@ jobs:
           debug: true
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
+      - name: Install libbrotli-dev
+        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
       - name: Set CGO flags
         run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"
       - name: Build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,8 +58,20 @@ jobs:
           debug: true
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
-      - name: Install libbrotli-dev
-        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
+      - name: Diagnose brotli state on runner
+        run: |
+          echo "=== dpkg -l brotli ==="
+          dpkg -l | grep -iE '(^ii|^un).*brotli' || echo "(no brotli rows)"
+          echo "=== /usr/include/brotli/ ==="
+          ls -la /usr/include/brotli/ 2>&1 || true
+          echo "=== brotli .pc files ==="
+          find /usr -name 'libbrotli*.pc' 2>/dev/null || true
+          echo "=== pkg-config --cflags ==="
+          pkg-config --cflags libbrotlicommon libbrotlidec libbrotlienc 2>&1 || true
+          echo "=== pkg-config --libs ==="
+          pkg-config --libs libbrotlicommon libbrotlidec libbrotlienc 2>&1 || true
+          echo "=== gcc default include search ==="
+          echo | gcc -E -v - 2>&1 | sed -n '/search starts here/,/End of search list/p' || true
       - name: Set CGO flags
         run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"
       - name: Build


### PR DESCRIPTION
The Linux Caddy module tests fail at compile time:

```
../../../../go/pkg/mod/github.com/google/brotli/go/cbrotli@v1.1.0/reader.go:13:10: fatal error: brotli/decode.h: No such file or directory
```

`caddy/` pulls in [`github.com/dunglas/caddy-cbrotli`](https://github.com/dunglas/caddy-cbrotli), which depends on [`github.com/google/brotli/go/cbrotli`](https://github.com/google/brotli/tree/master/go/cbrotli) and uses ``// #cgo pkg-config: libbrotlicommon libbrotlidec libbrotlienc``.

## Root cause

The `ubuntu-latest` runner (noble, image `ubuntu24/2026..*`) lists `libbrotli-dev 1.1.0-2build2` as installed in dpkg, but the package's files are missing on disk. Diagnostics from a CI run on this branch:

```
$ dpkg -l | grep brotli
ii  brotli                  1.1.0-2build2  amd64  ...
ii  libbrotli-dev:amd64     1.1.0-2build2  amd64  ...
ii  libbrotli1:amd64        1.1.0-2build2  amd64  ...

$ ls /usr/include/brotli/
ls: cannot access '/usr/include/brotli/': No such file or directory

$ find /usr -name 'libbrotli*.pc'
/usr/share/miniconda/lib/pkgconfig/libbrotli{common,dec,enc}.pc
# system /usr/lib/x86_64-linux-gnu/pkgconfig/libbrotli*.pc absent

$ pkg-config --cflags libbrotlicommon libbrotlidec libbrotlienc
Package libbrotlicommon was not found in the pkg-config search path.
Package 'libbrotlicommon', required by 'virtual:world', not found
```

A plain `apt-get install -y libbrotli-dev` is a no-op because dpkg believes the package is current. `--reinstall` forces apt to re-extract the files so cgo's pkg-config invocation succeeds and gcc can resolve `<brotli/decode.h>`.

Reproduces on PR-2365 https://github.com/php/frankenphp/actions/runs/25315574252/job/74212221237 and on every recent main run, e.g. https://github.com/php/frankenphp/actions/runs/25286789334.