### PR TITLE
ci: run golangci-lint on the Caddy module

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,6 +91,12 @@ jobs:
         if: matrix.php-versions == '8.5'
         with:
           version: latest
+      - name: Lint Caddy module Go code
+        uses: golangci/golangci-lint-action@v9
+        if: matrix.php-versions == '8.5'
+        with:
+          version: latest
+          working-directory: caddy
       - name: Ensure go.mod is tidy
         if: matrix.php-versions == '8.5'
         run: go mod tidy -diff

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.php-versions == '8.5'
         with:
           version: latest
-          working-directory: caddy
+          working-directory: caddy/
       - name: Ensure go.mod is tidy
         if: matrix.php-versions == '8.5'
         run: go mod tidy -diff

--- a/caddy/admin.go
+++ b/caddy/admin.go
@@ -41,9 +41,8 @@ func (admin *FrankenPHPAdmin) restartWorkers(w http.ResponseWriter, r *http.Requ
 
 	frankenphp.RestartWorkers()
 	caddy.Log().Info("workers restarted from admin api")
-	admin.success(w, "workers restarted successfully\n")
 
-	return nil
+	return admin.success(w, "workers restarted successfully\n")
 }
 
 func (admin *FrankenPHPAdmin) threads(w http.ResponseWriter, _ *http.Request) error {

--- a/caddy/admin_test.go
+++ b/caddy/admin_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRestartWorkerViaAdminApi(t *testing.T) {
@@ -245,7 +246,7 @@ func getAdminResponseBody(t *testing.T, tester *caddytest.Tester, method string,
 	r, err := http.NewRequest(method, adminUrl+path, nil)
 	assert.NoError(t, err)
 	resp := tester.AssertResponseCode(r, http.StatusOK)
-	defer resp.Body.Close()
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 	bytes, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 
@@ -319,7 +320,7 @@ func TestAddModuleWorkerViaAdminApi(t *testing.T) {
 	assert.NoError(t, err)
 	r.Header.Set("Content-Type", "text/caddyfile")
 	resp := tester.AssertResponseCode(r, http.StatusOK)
-	defer resp.Body.Close()
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	// Get the updated debug state to check if the worker was added
 	updatedDebugState := getDebugState(t, tester)

--- a/caddy/app.go
+++ b/caddy/app.go
@@ -66,7 +66,7 @@ type FrankenPHPApp struct {
 	logger  *slog.Logger
 }
 
-var iniError = errors.New(`"php_ini" must be in the format: php_ini "<key>" "<value>"`)
+var errIni = errors.New(`"php_ini" must be in the format: php_ini "<key>" "<value>"`)
 
 // CaddyModule returns the Caddy module information.
 func (f FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
@@ -274,14 +274,14 @@ func (f *FrankenPHPApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				parseIniLine := func(d *caddyfile.Dispenser) error {
 					key := d.Val()
 					if !d.NextArg() {
-						return d.WrapErr(iniError)
+						return d.WrapErr(errIni)
 					}
 					if f.PhpIni == nil {
 						f.PhpIni = make(map[string]string)
 					}
 					f.PhpIni[key] = d.Val()
 					if d.NextArg() {
-						return d.WrapErr(iniError)
+						return d.WrapErr(errIni)
 					}
 
 					return nil
@@ -298,7 +298,7 @@ func (f *FrankenPHPApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 				if !isBlock {
 					if !d.NextArg() {
-						return d.WrapErr(iniError)
+						return d.WrapErr(errIni)
 					}
 					err := parseIniLine(d)
 					if err != nil {

--- a/caddy/mercure.go
+++ b/caddy/mercure.go
@@ -40,12 +40,12 @@ func (f *FrankenPHPModule) assignMercureHub(ctx caddy.Context) {
 func createMercureRoute() (caddyhttp.Route, error) {
 	mercurePublisherJwtKey := os.Getenv("MERCURE_PUBLISHER_JWT_KEY")
 	if mercurePublisherJwtKey == "" {
-		return caddyhttp.Route{}, errors.New(`The "MERCURE_PUBLISHER_JWT_KEY" environment variable must be set to use the Mercure.rocks hub`)
+		return caddyhttp.Route{}, errors.New(`the "MERCURE_PUBLISHER_JWT_KEY" environment variable must be set to use the Mercure.rocks hub`)
 	}
 
 	mercureSubscriberJwtKey := os.Getenv("MERCURE_SUBSCRIBER_JWT_KEY")
 	if mercureSubscriberJwtKey == "" {
-		return caddyhttp.Route{}, errors.New(`The "MERCURE_SUBSCRIBER_JWT_KEY" environment variable must be set to use the Mercure.rocks hub`)
+		return caddyhttp.Route{}, errors.New(`the "MERCURE_SUBSCRIBER_JWT_KEY" environment variable must be set to use the Mercure.rocks hub`)
 	}
 
 	mercureRoute := caddyhttp.Route{


### PR DESCRIPTION
## Summary

The Caddy module under `caddy/` has its own `go.mod` and was never linted by CI. Enabling lint surfaced a handful of real issues; this PR fixes them and wires the linter in.

### Workflow

Adds a second `golangci/golangci-lint-action@v9` step with `working-directory: caddy`, gated on `matrix.php-versions == '8.5'` (same as the existing root lint).

### Fixes

- `caddy/admin.go`: `restartWorkers` discarded the error from `admin.success`. Now returned.
- `caddy/admin_test.go`: `defer resp.Body.Close()` (errcheck). Switched to `defer func() { require.NoError(t, resp.Body.Close()) }()` so a real failure surfaces.
- `caddy/app.go`: `var iniError` renamed to `errIni` (ST1012).
- `caddy/mercure.go`: lowercase leading article in two error strings (ST1005).

Lint passes on both modules with the CI build tags `nobadger,nomysql,nopgx`.