### PR TITLE
feat: declared background workers + frankenphp_get_worker_handle()

### DIFF
--- a/bgworker.go
+++ b/bgworker.go
@@ -1,0 +1,116 @@
+package frankenphp
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Scope isolates background workers between php_server blocks; the
+// zero value is the global/embed scope. Obtain values via NextScope.
+type Scope uint64
+
+var scopeCounter atomic.Uint64
+
+// NextScope returns a fresh scope value. Each php_server block should
+// call this once during provisioning.
+func NextScope() Scope {
+	return Scope(scopeCounter.Add(1))
+}
+
+// scopeLabels maps Scope -> human-readable label registered by the
+// embedder (e.g. the Caddy module).
+var scopeLabels sync.Map
+
+// SetScopeLabel attaches a human-readable label to a scope; the bg-worker
+// metric emitter renders it as e.g. server="api.example.com" instead of
+// an opaque numeric id. Empty labels are ignored.
+func SetScopeLabel(s Scope, label string) {
+	if label == "" {
+		return
+	}
+	scopeLabels.Store(s, label)
+}
+
+// lookupScopeLabel reports whether a label has been registered for s,
+// returning ("", false) when none has. Distinguishes "unset" from
+// "explicitly empty" without the numeric fallback.
+func lookupScopeLabel(s Scope) (string, bool) {
+	v, ok := scopeLabels.Load(s)
+	if !ok {
+		return "", false
+	}
+	return v.(string), true
+}
+
+// bgWorkerMetricName formats the metric label for a background worker:
+// "m#<scopeLabel>:<runtimeName>". scopeLabel is empty when the scope
+// has no registered label (embed/global, or before the embedder calls
+// SetScopeLabel). The "m#" prefix mirrors the m# convention used for
+// module workers; the colon keeps the format uniform so a single regex
+// (m#([^:]*):(.+)) parses both labelled and unlabelled forms.
+func bgWorkerMetricName(scope Scope, runtimeName string) string {
+	label, _ := lookupScopeLabel(scope)
+	return "m#" + label + ":" + runtimeName
+}
+
+// backgroundLookups maps scope -> name -> *worker. Scope 0 is the
+// global/embed scope. nil when no background worker is declared.
+var backgroundLookups map[Scope]map[string]*worker
+
+// buildBackgroundWorkerLookups maps each declared bg worker into its scope's
+// lookup. Per-scope name collisions are caught here because bg workers
+// intentionally skip the global workersByName map (so two scopes can share
+// a user-facing name). Names are not allowed to be empty in this minimal
+// build; catch-all bg workers are deferred to a follow-up PR.
+func buildBackgroundWorkerLookups(workers []*worker, opts []workerOpt) (map[Scope]map[string]*worker, error) {
+	lookups := make(map[Scope]map[string]*worker)
+
+	for i, o := range opts {
+		if !o.isBackgroundWorker {
+			continue
+		}
+		w := workers[i]
+		w.scope = o.scope
+
+		phpName := strings.TrimPrefix(w.name, "m#")
+		if phpName == "" || phpName == w.fileName {
+			return nil, fmt.Errorf("background worker must have an explicit name (got %q)", w.name)
+		}
+
+		byName := lookups[o.scope]
+		if byName == nil {
+			byName = make(map[string]*worker)
+			lookups[o.scope] = byName
+		}
+		if _, exists := byName[phpName]; exists {
+			return nil, fmt.Errorf("duplicate background worker name %q in the same scope", phpName)
+		}
+		byName[phpName] = w
+	}
+
+	if len(lookups) == 0 {
+		return nil, nil
+	}
+	return lookups, nil
+}
+
+// reserveBackgroundWorkerThreads returns the thread budget to add to the
+// pool for declared bg workers, and pre-registers totalWorkers so a bg-only
+// deployment has the metric initialised. num must be >= 1 for bg workers
+// in this build.
+func reserveBackgroundWorkerThreads(opt *opt) (int, error) {
+	reserved := 0
+	for _, w := range opt.workers {
+		if !w.isBackgroundWorker {
+			continue
+		}
+		if w.num < 1 {
+			return 0, fmt.Errorf("background worker %q must declare num >= 1 (lazy/ensure() machinery is not in this build)", w.name)
+		}
+		reserved += w.num
+		metrics.TotalWorkers(bgWorkerMetricName(w.scope, w.name), w.num)
+	}
+	return reserved, nil
+}

--- a/bgworker_test.go
+++ b/bgworker_test.go
@@ -1,0 +1,86 @@
+package frankenphp_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackgroundWorkerLifecycle boots a background worker that touches a
+// sentinel file then parks on the stop pipe. It proves the bg worker runs
+// (sentinel appears) and that Shutdown returns within a reasonable time.
+func TestBackgroundWorkerLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-lifecycle.sentinel")
+
+	require.NoError(t, frankenphp.Init(
+		frankenphp.WithWorkers("bg-lifecycle", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	))
+	// Note: this test asserts on Shutdown timing, so it manages Shutdown
+	// itself instead of using setupFrankenPHP's t.Cleanup hook.
+
+	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+
+	done := make(chan struct{})
+	go func() {
+		frankenphp.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Shutdown did not return within 10s")
+	}
+}
+
+// TestBackgroundWorkerCrashRestarts boots a worker that exit(1)s on its
+// first run and touches a "restarted" sentinel on its second run. The
+// sentinel proves the crash-restart loop fired.
+func TestBackgroundWorkerCrashRestarts(t *testing.T) {
+	tmp := t.TempDir()
+	crashMarker := filepath.Join(tmp, "bg-crash.marker")
+	restarted := filepath.Join(tmp, "bg-crash.restarted")
+
+	setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-crash", "testdata/bgworker/crash.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{
+				"BG_CRASH_MARKER":       crashMarker,
+				"BG_RESTARTED_SENTINEL": restarted,
+			}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, restarted, "background worker did not restart after crash")
+}
+
+// TestBackgroundWorkerWithoutHTTP confirms that a request to a script
+// unrelated to the bg worker still works: the bg worker doesn't intercept
+// HTTP traffic.
+func TestBackgroundWorkerWithoutHTTP(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-nohttp.sentinel")
+
+	testDataDir := setupFrankenPHP(t,
+		frankenphp.WithWorkers("bg-nohttp", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+
+	body := serveBody(t, testDataDir, "index.php")
+	assert.NotEmpty(t, body, "expected non-empty body from index.php")
+}

--- a/bgworkerhelpers_test.go
+++ b/bgworkerhelpers_test.go
@@ -1,0 +1,57 @@
+package frankenphp_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/require"
+)
+
+// requireFileEventually asserts that `path` appears on disk before the
+// deadline. Wraps require.Eventually so call sites stay short.
+func requireFileEventually(t testing.TB, path string, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, msgAndArgs...)
+}
+
+// setupFrankenPHP boots FrankenPHP with the given options, registers
+// Shutdown as a t.Cleanup, and returns the absolute path to the testdata
+// directory. Saves the boilerplate every bg-worker test repeats.
+func setupFrankenPHP(t *testing.T, opts ...frankenphp.Option) (testDataDir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataDir = cwd + "/testdata/"
+	require.NoError(t, frankenphp.Init(opts...))
+	t.Cleanup(frankenphp.Shutdown)
+	return
+}
+
+// serveBody runs `script` (relative to testDataDir, may include a query
+// string) through FrankenPHP and returns the response body. ErrRejected is
+// treated as a non-fatal outcome so worker-mode quirks don't fail tests
+// that only care about the script's stdout.
+func serveBody(t *testing.T, testDataDir, scriptAndQuery string, opts ...frankenphp.RequestOption) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "http://example.com/"+scriptAndQuery, nil)
+	reqOpts := append([]frankenphp.RequestOption{
+		frankenphp.WithRequestDocumentRoot(testDataDir, false),
+	}, opts...)
+	fr, err := frankenphp.NewRequestWithContext(req, reqOpts...)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	if err := frankenphp.ServeHTTP(w, fr); err != nil {
+		require.ErrorAs(t, err, &frankenphp.ErrRejected{})
+	}
+	body, err := io.ReadAll(w.Result().Body)
+	require.NoError(t, err)
+	return string(body)
+}

--- a/bgworkerscope_test.go
+++ b/bgworkerscope_test.go
@@ -1,0 +1,89 @@
+package frankenphp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBgWorker boots FrankenPHP with the given options (internal-package
+// variant), registers Shutdown as a t.Cleanup, and returns the absolute
+// path to the testdata directory.
+func setupBgWorker(t *testing.T, opts ...Option) (testDataDir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataDir = cwd + "/testdata/"
+	require.NoError(t, Init(opts...))
+	t.Cleanup(Shutdown)
+	return
+}
+
+// requireSentinelEventually asserts that `path` appears on disk before the
+// deadline. Wraps require.Eventually so call sites stay short.
+func requireSentinelEventually(t testing.TB, path string, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, msgAndArgs...)
+}
+
+// TestNextScopeIsDistinct verifies the scope counter
+// hands out unique values on consecutive calls.
+func TestNextScopeIsDistinct(t *testing.T) {
+	a := NextScope()
+	b := NextScope()
+	assert.NotEqual(t, a, b, "consecutive scopes must differ")
+	assert.NotZero(t, a, "scopes must be non-zero (zero is the global scope)")
+	assert.NotZero(t, b, "scopes must be non-zero (zero is the global scope)")
+}
+
+// TestBackgroundWorkerSameNameDifferentScope declares two named bg
+// workers with the same user-facing name in distinct scopes. Both must
+// Init successfully (the global workersByName collision check must
+// recognize bg workers as scope-isolated), each must produce its own
+// sentinel under its scope-specific directory.
+func TestBackgroundWorkerSameNameDifferentScope(t *testing.T) {
+	scopeA := NextScope()
+	scopeB := NextScope()
+
+	tmp := t.TempDir()
+	dirA := filepath.Join(tmp, "a")
+	dirB := filepath.Join(tmp, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0o755))
+	require.NoError(t, os.MkdirAll(dirB, 0o755))
+
+	setupBgWorker(t,
+		WithWorkers("shared", "testdata/bgworker/named.php", 1,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeA),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirA}),
+		),
+		WithWorkers("shared", "testdata/bgworker/named.php", 1,
+			WithWorkerBackground(),
+			WithWorkerScope(scopeB),
+			WithWorkerEnv(map[string]string{"BG_SENTINEL_DIR": dirB}),
+		),
+		WithNumThreads(4),
+	)
+
+	// Both lookups must exist and resolve "shared" to a *worker.
+	require.NotNil(t, backgroundLookups[scopeA], "scope A lookup missing")
+	require.NotNil(t, backgroundLookups[scopeB], "scope B lookup missing")
+	assert.NotNil(t, backgroundLookups[scopeA]["shared"], "scope A must resolve 'shared'")
+	assert.NotNil(t, backgroundLookups[scopeB]["shared"], "scope B must resolve 'shared'")
+	// And they must be distinct *worker instances (not the same pointer).
+	assert.NotSame(t,
+		backgroundLookups[scopeA]["shared"],
+		backgroundLookups[scopeB]["shared"],
+		"each scope must own a distinct *worker for the same name")
+
+	// Each scope's worker writes its sentinel under its own dir.
+	requireSentinelEventually(t, filepath.Join(dirA, "shared"), "scope A worker did not touch sentinel")
+	requireSentinelEventually(t, filepath.Join(dirB, "shared"), "scope B worker did not touch sentinel")
+}

--- a/caddy/app.go
+++ b/caddy/app.go
@@ -1,7 +1,6 @@
 package caddy
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -62,17 +61,24 @@ type FrankenPHPApp struct {
 
 	opts    []frankenphp.Option
 	metrics frankenphp.Metrics
-	ctx     context.Context
+	ctx     caddy.Context
 	logger  *slog.Logger
+
+	// scopeOwners is the per-php_server module registry used by Start
+	// to resolve a human-readable scope label (via the cascade in
+	// scopelabel.go) before frankenphp.Init starts any bg worker, so
+	// the very first metric call already carries the right prefix.
+	scopeOwnersMu sync.Mutex
+	scopeOwners   map[frankenphp.Scope]*FrankenPHPModule
 }
 
 var errIni = errors.New(`"php_ini" must be in the format: php_ini "<key>" "<value>"`)
 
 // CaddyModule returns the Caddy module information.
-func (f FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
+func (*FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "frankenphp",
-		New: func() caddy.Module { return &f },
+		New: func() caddy.Module { return new(FrankenPHPApp) },
 	}
 }
 
@@ -139,12 +145,49 @@ func (f *FrankenPHPApp) addModuleWorkers(workers ...workerConfig) ([]workerConfi
 	return workers, nil
 }
 
+// registerScopeOwner records the FrankenPHPModule that allocated the
+// given scope so Start() can resolve its label before frankenphp.Init.
+func (f *FrankenPHPApp) registerScopeOwner(scope frankenphp.Scope, mod *FrankenPHPModule) {
+	f.scopeOwnersMu.Lock()
+	defer f.scopeOwnersMu.Unlock()
+	if f.scopeOwners == nil {
+		f.scopeOwners = make(map[frankenphp.Scope]*FrankenPHPModule)
+	}
+	f.scopeOwners[scope] = mod
+}
+
+// resolveScopeLabels walks the http app's servers once per registered
+// module, picks the one whose route tree contains the module, runs the
+// scopelabel.go cascade, and stores the result via SetScopeLabel. Runs
+// before frankenphp.Init so the first metric emit on every bg worker
+// already carries the right "m#<label>:<name>" prefix.
+func (f *FrankenPHPApp) resolveScopeLabels() {
+	if len(f.scopeOwners) == 0 {
+		return
+	}
+	httpApp, err := f.ctx.AppIfConfigured("http")
+	if err != nil || httpApp == nil {
+		return
+	}
+	servers := httpApp.(*caddyhttp.App).Servers
+	for scope, mod := range f.scopeOwners {
+		for _, srv := range servers {
+			if label := mod.resolveScopeLabel(srv); label != "" {
+				frankenphp.SetScopeLabel(scope, label)
+				break
+			}
+		}
+	}
+}
+
 func (f *FrankenPHPApp) Start() error {
 	repl := caddy.NewReplacer()
 
 	optionsMU.RLock()
 	f.opts = append(f.opts, options...)
 	optionsMU.RUnlock()
+
+	f.resolveScopeLabels()
 
 	f.opts = append(f.opts,
 		frankenphp.WithContext(f.ctx),
@@ -166,6 +209,10 @@ func (f *FrankenPHPApp) Start() error {
 			frankenphp.WithWorkerMaxThreads(w.MaxThreads),
 			frankenphp.WithWorkerRequestOptions(w.requestOptions...),
 		)
+
+		if w.Background {
+			w.options = append(w.options, frankenphp.WithWorkerBackground())
+		}
 
 		f.opts = append(f.opts, frankenphp.WithWorkers(w.Name, repl.ReplaceKnown(w.FileName, ""), w.Num, w.options...))
 	}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -16,7 +16,7 @@ const (
 )
 
 func init() {
-	caddy.RegisterModule(FrankenPHPApp{})
+	caddy.RegisterModule(new(FrankenPHPApp))
 	caddy.RegisterModule(FrankenPHPModule{})
 	caddy.RegisterModule(FrankenPHPAdmin{})
 

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -51,6 +51,7 @@ type FrankenPHPModule struct {
 	preparedEnvNeedsReplacement bool
 	logger                      *slog.Logger
 	requestOptions              []frankenphp.RequestOption
+	scope                       frankenphp.Scope
 }
 
 // CaddyModule returns the Caddy module information.
@@ -78,6 +79,14 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 
 	f.assignMercureHub(ctx)
 
+	// Each php_server block gets its own scope so workers declared with
+	// the same name in different blocks don't collide. Provision can be
+	// called more than once for the same module; only assign once.
+	if f.scope == 0 {
+		f.scope = frankenphp.NextScope()
+	}
+	fapp.registerScopeOwner(f.scope, f)
+
 	loggerOpt := frankenphp.WithRequestLogger(f.logger)
 	for i, wc := range f.Workers {
 		// make the file path absolute from the public directory
@@ -92,6 +101,7 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 		}
 
 		wc.requestOptions = append(wc.requestOptions, loggerOpt)
+		wc.options = append(wc.options, frankenphp.WithWorkerScope(f.scope))
 		f.Workers[i] = wc
 	}
 

--- a/caddy/scopelabel.go
+++ b/caddy/scopelabel.go
@@ -1,0 +1,59 @@
+package caddy
+
+import (
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+// resolveScopeLabel picks a stable, human-friendly identifier for this
+// module's background-worker scope so metric/log emitters can render it
+// (e.g. server="api.example.com") instead of the opaque numeric id.
+// Cascade:
+//  1. First host of the route's host matcher.
+//  2. First listener address of the server.
+func (f *FrankenPHPModule) resolveScopeLabel(srv *caddyhttp.Server) string {
+	if h := findHostInRoutes(srv.Routes, f); h != "" {
+		return h
+	}
+	if len(srv.Listen) > 0 {
+		return srv.Listen[0]
+	}
+	return ""
+}
+
+// findHostInRoutes walks routes (recursing into Subroute handlers) to
+// locate the route that contains target, then returns the first host of
+// that route's host matcher. Returns "" if no enclosing route or no host
+// matcher is found.
+func findHostInRoutes(routes caddyhttp.RouteList, target caddyhttp.MiddlewareHandler) string {
+	for _, route := range routes {
+		if !routeContainsHandler(route, target) {
+			continue
+		}
+		for _, mset := range route.MatcherSets {
+			for _, m := range mset {
+				hp, ok := m.(*caddyhttp.MatchHost)
+				if !ok || hp == nil || len(*hp) == 0 {
+					continue
+				}
+				return (*hp)[0]
+			}
+		}
+	}
+	return ""
+}
+
+func routeContainsHandler(route caddyhttp.Route, target caddyhttp.MiddlewareHandler) bool {
+	for _, h := range route.Handlers {
+		if h == target {
+			return true
+		}
+		if sub, ok := h.(*caddyhttp.Subroute); ok {
+			for _, r := range sub.Routes {
+				if routeContainsHandler(r, target) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/caddy/workerconfig.go
+++ b/caddy/workerconfig.go
@@ -41,6 +41,8 @@ type workerConfig struct {
 	MatchPath []string `json:"match_path,omitempty"`
 	// MaxConsecutiveFailures sets the maximum number of consecutive failures before panicking (defaults to 6, set to -1 to never panick)
 	MaxConsecutiveFailures int `json:"max_consecutive_failures,omitempty"`
+	// Background marks this worker as a background (non-HTTP) worker.
+	Background bool `json:"background,omitempty"`
 
 	options        []frankenphp.WorkerOption
 	requestOptions []frankenphp.RequestOption
@@ -145,13 +147,19 @@ func unmarshalWorker(d *caddyfile.Dispenser) (workerConfig, error) {
 			}
 
 			wc.MaxConsecutiveFailures = v
+		case "background":
+			wc.Background = true
 		default:
-			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads", v)
+			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads, background", v)
 		}
 	}
 
 	if wc.FileName == "" {
 		return wc, d.Err(`the "file" argument must be specified`)
+	}
+
+	if wc.Background && len(wc.MatchPath) != 0 {
+		return wc, d.Err(`"match" is not supported for background workers`)
 	}
 
 	if frankenphp.EmbeddedAppPath != "" && filepath.IsLocal(wc.FileName) {

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -16,6 +16,7 @@
 #else
 #include <php_config.h>
 #endif
+#include <main/php_streams.h>
 #include <php_ini.h>
 #include <php_main.h>
 #include <php_output.h>
@@ -100,6 +101,9 @@ HashTable *main_thread_env = NULL;
 
 __thread uintptr_t thread_index;
 __thread bool is_worker_thread = false;
+__thread bool is_background_worker = false;
+__thread int worker_stop_fds[2] = {-1, -1};
+__thread php_stream *worker_signaling_stream = NULL;
 __thread HashTable *sandboxed_env = NULL;
 
 /* Published via SG(server_context) so ext-parallel children, which inherit
@@ -285,11 +289,96 @@ void frankenphp_release_thread_for_kill(force_kill_slot slot) {
 #endif
 }
 
+static void frankenphp_worker_close_stop_fds(void);
+
 void frankenphp_update_local_thread_context(bool is_worker) {
+  /* A thread that previously ran as a bg worker can be recycled into an
+   * HTTP worker or a regular request thread; reset the bg-worker TLS so
+   * frankenphp_handle_request() and friends don't reject the caller. The
+   * cached worker_signaling_stream is already dangling here (its
+   * zend_resource was freed by php_request_shutdown's EG(regular_list)
+   * teardown), so just NULL it without dereferencing. */
+  bool was_background_worker = is_background_worker;
+
   is_worker_thread = is_worker;
+  is_background_worker = false;
+
+  if (was_background_worker) {
+    frankenphp_worker_close_stop_fds();
+    worker_signaling_stream = NULL;
+  }
 
   /* workers should keep running if the user aborts the connection */
   PG(ignore_user_abort) = is_worker ? 1 : original_user_abort_setting;
+}
+
+/* Background worker stop-pipe: anonymous pipe whose read end is exposed to
+ * the PHP script via frankenphp_get_worker_handle. When the Go side closes
+ * the write end (on drain), the read end reaches EOF so the script can
+ * return from stream_select and exit its loop. */
+static int frankenphp_worker_open_stop_pipe(void) {
+#ifdef PHP_WIN32
+  return _pipe(worker_stop_fds, 4096, _O_BINARY);
+#else
+  return pipe(worker_stop_fds);
+#endif
+}
+
+static void frankenphp_worker_close_stop_fds(void) {
+  for (int i = 0; i < 2; i++) {
+    if (worker_stop_fds[i] >= 0) {
+#ifdef PHP_WIN32
+      _close(worker_stop_fds[i]);
+#else
+      close(worker_stop_fds[i]);
+#endif
+      worker_stop_fds[i] = -1;
+    }
+  }
+}
+
+/* Marks the calling thread as a background worker, opens its stop pipe,
+ * transfers the write fd to the caller (clearing the TLS slot so later
+ * recycle won't double-close), and disarms max_execution_time. Returns
+ * -1 if the pipe could not be opened. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void) {
+  is_background_worker = true;
+  /* Drop the dangling stream pointer (see
+   * frankenphp_update_local_thread_context for why). */
+  worker_signaling_stream = NULL;
+  /* Bg workers don't enforce max_execution_time; disarm any lingering timer. */
+  zend_unset_timeout();
+
+  frankenphp_worker_close_stop_fds();
+  if (frankenphp_worker_open_stop_pipe() != 0) {
+    worker_stop_fds[0] = -1;
+    worker_stop_fds[1] = -1;
+    return -1;
+  }
+  int fd = worker_stop_fds[1];
+  worker_stop_fds[1] = -1;
+  return fd;
+}
+
+void frankenphp_worker_close_fd(int fd) {
+  if (fd < 0) {
+    return;
+  }
+  /* Closing the write end of the stop pipe lands as EOF on the read end,
+   * so the PHP side's stream_select returns promptly. */
+#ifdef PHP_WIN32
+  _close(fd);
+#else
+  close(fd);
+#endif
+}
+
+static int frankenphp_worker_dup_fd(int fd) {
+#ifdef PHP_WIN32
+  return _dup(fd);
+#else
+  return dup(fd);
+#endif
 }
 
 static void frankenphp_update_request_context() {
@@ -907,6 +996,56 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+PHP_FUNCTION(frankenphp_get_worker_handle) {
+  ZEND_PARSE_PARAMETERS_NONE();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_get_worker_handle() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  /* Return the cached stream on repeat calls. The first call (below)
+   * crosses the boundary that opens a fresh PHP stream over the read end
+   * of the stop pipe; subsequent calls hand back the same stream. */
+  if (worker_signaling_stream != NULL) {
+    php_stream_to_zval(worker_signaling_stream, return_value);
+    GC_ADDREF(Z_COUNTED_P(return_value));
+    return;
+  }
+
+  if (worker_stop_fds[0] < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create background worker stop pipe", 0);
+    RETURN_THROWS();
+  }
+
+  /* DUP so closing the PHP stream doesn't affect worker_stop_fds[0]; the
+   * original stays owned by the C side for cleanup at worker restart. */
+  int fd = frankenphp_worker_dup_fd(worker_stop_fds[0]);
+  if (fd < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to dup background worker stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  php_stream *stream = php_stream_fopen_from_fd(fd, "rb", NULL);
+  if (!stream) {
+    frankenphp_worker_close_fd(fd);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create stream from stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  worker_signaling_stream = stream;
+  php_stream_to_zval(stream, return_value);
+
+  /* Extra ref so PHP can't destroy the stream while TLS caches the pointer. */
+  GC_ADDREF(Z_COUNTED_P(return_value));
+}
+
 #ifdef FRANKENPHP_TEST
 /* Test-only entry point that exercises zval.h end-to-end:
  * validate -> persist (request -> persistent memory) ->
@@ -1363,6 +1502,12 @@ static void *php_thread(void *arg) {
         frankenphp_log_message("Request startup failed, thread is unhealthy",
                                LOG_ERR);
         zend_bailout();
+      }
+
+      /* php_request_startup re-arms max_execution_time; bg workers
+       * never enforce it, disarm again. */
+      if (is_background_worker) {
+        zend_unset_timeout();
       }
 
       zend_file_handle file_handle;

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -156,11 +156,30 @@ func Config() PHPConfig {
 	}
 }
 
-func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
+func calculateMaxThreads(opt *opt) (numWorkers int, err error) {
 	maxProcs := runtime.GOMAXPROCS(0) * 2
 	maxThreadsFromWorkers := 0
+	// Bg workers reserve their thread budget separately from HTTP
+	// workers so they don't double-count against the HTTP-worker
+	// admission check below; the bump is applied at the end.
+	reservedThreads, reserveErr := reserveBackgroundWorkerThreads(opt)
+	if reserveErr != nil {
+		return 0, reserveErr
+	}
+	defer func() {
+		if err != nil {
+			return
+		}
+		opt.numThreads += reservedThreads
+		opt.maxThreads += reservedThreads
+		numWorkers += reservedThreads
+	}()
 
 	for i, w := range opt.workers {
+		if w.isBackgroundWorker {
+			continue
+		}
+
 		if w.num <= 0 {
 			// https://github.com/php/frankenphp/issues/126
 			opt.workers[i].num = maxProcs
@@ -791,6 +810,7 @@ func resetGlobals() {
 	workers = nil
 	workersByName = nil
 	workersByPath = nil
+	backgroundLookups = nil
 	watcherIsEnabled = false
 	maxIdleTime = defaultMaxIdleTime
 	maxRequestsPerThread = 0

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -226,6 +226,10 @@ size_t frankenphp_get_thread_memory_usage(uintptr_t thread_index);
 void frankenphp_force_kill_thread(force_kill_slot slot);
 void frankenphp_release_thread_for_kill(force_kill_slot slot);
 
+/* Background worker primitives. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void);
+void frankenphp_worker_close_fd(int fd);
+
 void register_extensions(zend_module_entry **m, int len);
 
 #endif

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -54,3 +54,12 @@ function mercure_publish(string|array $topics, string $data = '', bool $private 
  * array<string, any> $context Values of the array will be converted to the corresponding Go type (if supported by FrankenPHP) and added to the context of the structured logs using https://pkg.go.dev/log/slog#Attr
  */
 function frankenphp_log(string $message, int $level = 0, array $context = []): void {}
+
+/**
+ * Returns the stop-signal stream for the current background worker. The
+ * stream closes when FrankenPHP is draining the worker so the script can
+ * exit its loop gracefully. Only callable from inside a background worker.
+ *
+ * @return resource
+ */
+function frankenphp_get_worker_handle(): mixed {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 60f0d27c04f94d7b24c052e91ef294595a2bc421 */
+ * Stub hash: 5b7c1f3abf8e4a9c00bcf88e08a5d3a7ce9d6b21 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
@@ -41,6 +41,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_log, 0, 1, IS_VOID, 0
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, context, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_get_worker_handle, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(headers_send);
@@ -49,6 +52,7 @@ ZEND_FUNCTION(frankenphp_request_headers);
 ZEND_FUNCTION(frankenphp_response_headers);
 ZEND_FUNCTION(mercure_publish);
 ZEND_FUNCTION(frankenphp_log);
+ZEND_FUNCTION(frankenphp_get_worker_handle);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -63,6 +67,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FALIAS(apache_response_headers, frankenphp_response_headers, arginfo_apache_response_headers)
 	ZEND_FE(mercure_publish, arginfo_mercure_publish)
 	ZEND_FE(frankenphp_log, arginfo_frankenphp_log)
+	ZEND_FE(frankenphp_get_worker_handle, arginfo_frankenphp_get_worker_handle)
 	ZEND_FE_END
 };
 

--- a/options.go
+++ b/options.go
@@ -50,6 +50,8 @@ type workerOpt struct {
 	onThreadShutdown       func(int)
 	onServerStartup        func()
 	onServerShutdown       func()
+	isBackgroundWorker     bool
+	scope                  Scope
 }
 
 // WithContext sets the main context to use.
@@ -253,6 +255,32 @@ func WithWorkerOnServerStartup(f func()) WorkerOption {
 func WithWorkerOnServerShutdown(f func()) WorkerOption {
 	return func(w *workerOpt) error {
 		w.onServerShutdown = f
+
+		return nil
+	}
+}
+
+// EXPERIMENTAL: WithWorkerBackground marks this worker as a background
+// (non-HTTP) worker. Background workers run outside the request cycle and
+// share the PHP runtime with HTTP threads but don't serve HTTP requests.
+// They expose a stop pipe via frankenphp_get_worker_handle() so PHP scripts
+// can park on stream_select and exit gracefully when FrankenPHP drains.
+func WithWorkerBackground() WorkerOption {
+	return func(w *workerOpt) error {
+		w.isBackgroundWorker = true
+
+		return nil
+	}
+}
+
+// EXPERIMENTAL: WithWorkerScope assigns this worker to a given scope.
+// Workers in the same scope share a background lookup; each php_server
+// block gets its own scope so workers with the same name in different
+// blocks don't collide. The zero value is the global/embed scope and is
+// the default.
+func WithWorkerScope(scope Scope) WorkerOption {
+	return func(w *workerOpt) error {
+		w.scope = scope
 
 		return nil
 	}

--- a/phpthread.go
+++ b/phpthread.go
@@ -105,6 +105,9 @@ func (thread *phpThread) shutdown() {
 		return
 	}
 
+	// Wake up handlers parked in a blocking C call (background workers'
+	// stream_select on the stop pipe). No-op for regular/worker handlers.
+	thread.handler.drain()
 	close(thread.drainChan)
 
 	// Arm force-kill after the grace period to wake any thread stuck in

--- a/testdata/bgworker/basic.php
+++ b/testdata/bgworker/basic.php
@@ -1,0 +1,20 @@
+<?php
+
+// Long-lived background worker: disable PHP max_execution_time so the
+// 30s default cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Touch the sentinel so the test can confirm the worker actually ran.
+if (!empty($_SERVER['BG_SENTINEL'])) {
+    @touch($_SERVER['BG_SENTINEL']);
+}
+
+// Park on the stop pipe until FrankenPHP drains us (drain closes the
+// write end, which lands as EOF on the read end).
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/crash.php
+++ b/testdata/bgworker/crash.php
@@ -1,0 +1,29 @@
+<?php
+
+// Crash-and-recover fixture. On the first boot (no marker), creates the
+// marker and exit(1) so the bg worker thread observes a non-zero exit
+// status. On the second boot (marker present), touches a "restarted"
+// sentinel and parks on the stop pipe. The test asserts the restarted
+// sentinel appears, proving the crash-restart loop ran.
+set_time_limit(0);
+
+$marker = $_SERVER['BG_CRASH_MARKER'] ?? '';
+$restarted = $_SERVER['BG_RESTARTED_SENTINEL'] ?? '';
+
+if ($marker === '' || $restarted === '') {
+    // Misconfigured: don't loop forever on a missing env.
+    exit(2);
+}
+
+if (!file_exists($marker)) {
+    file_put_contents($marker, '1');
+    exit(1);
+}
+
+@touch($restarted);
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/named.php
+++ b/testdata/bgworker/named.php
@@ -1,0 +1,19 @@
+<?php
+
+// Long-lived bg worker that touches a per-name sentinel under
+// $_SERVER['BG_SENTINEL_DIR'] so tests can confirm the right instance
+// ran. The bg worker's $_SERVER['FRANKENPHP_WORKER'] value is the
+// declared name, so the same fixture serves multiple distinct names
+// across scopes.
+set_time_limit(0);
+
+$name = $_SERVER['FRANKENPHP_WORKER'] ?? 'unknown';
+if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
+    @touch($_SERVER['BG_SENTINEL_DIR'] . DIRECTORY_SEPARATOR . $name);
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -1,0 +1,198 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/dunglas/frankenphp/internal/state"
+)
+
+// backgroundWorkerThread handles background worker scripts. Owns its own
+// lifecycle: boot, loop, optionally crash-restart with exponential backoff.
+// Background workers share the PHP runtime with HTTP threads but don't
+// serve HTTP requests. They expose a stop pipe (via
+// frankenphp_get_worker_handle) so PHP scripts can park on stream_select
+// and exit gracefully when FrankenPHP drains them.
+type backgroundWorkerThread struct {
+	state                  *state.ThreadState
+	thread                 *phpThread
+	worker                 *worker
+	dummyFrankenPHPContext *frankenPHPContext
+	dummyContext           context.Context
+	failureCount           int
+
+	// stopFdWrite is this thread's stop-pipe write end (per-thread so pool
+	// workers drain independently); read end is exposed to PHP via
+	// frankenphp_get_worker_handle().
+	stopFdWrite atomic.Int32
+}
+
+func convertToBackgroundWorkerThread(thread *phpThread, worker *worker) {
+	handler := &backgroundWorkerThread{
+		state:  thread.state,
+		thread: thread,
+		worker: worker,
+	}
+	handler.stopFdWrite.Store(-1)
+	thread.setHandler(handler)
+	worker.attachThread(thread)
+}
+
+func (handler *backgroundWorkerThread) name() string {
+	return "Background Worker PHP Thread - " + handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) frankenPHPContext() *frankenPHPContext {
+	return handler.dummyFrankenPHPContext
+}
+
+func (handler *backgroundWorkerThread) context() context.Context {
+	if handler.dummyContext != nil {
+		return handler.dummyContext
+	}
+	return globalCtx
+}
+
+// drain is called by drainWorkerThreads (and thread.shutdown) right before
+// drainChan is closed. We close the stop-pipe's write end so the PHP worker
+// script, which is typically parked in stream_select on the read end, wakes
+// up and can finish its loop gracefully. Per-thread fd so pool workers
+// drain their threads independently.
+func (handler *backgroundWorkerThread) drain() {
+	if fd := handler.stopFdWrite.Swap(-1); fd >= 0 {
+		C.frankenphp_worker_close_fd(C.int(fd))
+	}
+}
+
+func (handler *backgroundWorkerThread) beforeScriptExecution() string {
+	switch handler.state.Get() {
+	case state.TransitionRequested:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return handler.thread.transitionToNewHandler()
+	case state.Restarting:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.state.Set(state.Yielding)
+		handler.state.WaitFor(state.Ready, state.ShuttingDown)
+		return handler.beforeScriptExecution()
+	case state.Ready, state.TransitionComplete:
+		handler.thread.updateContext(true)
+		if handler.worker.onThreadReady != nil {
+			handler.worker.onThreadReady(handler.thread.threadIndex)
+		}
+
+		handler.setupScript()
+
+		return handler.worker.fileName
+	case state.ShuttingDown:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return ""
+	}
+
+	panic("unexpected state: " + handler.state.Name())
+}
+
+func (handler *backgroundWorkerThread) setupScript() {
+	metrics.StartWorker(bgWorkerMetricName(handler.worker.scope, handler.worker.name))
+
+	opts := append([]RequestOption(nil), handler.worker.requestOptions...)
+	handler.stopFdWrite.Store(int32(C.frankenphp_set_background_worker_and_get_stop_fd_write()))
+
+	fc, err := newDummyContext(
+		filepath.Base(handler.worker.fileName),
+		opts...,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.WithValue(globalCtx, contextKey, fc)
+
+	fc.worker = handler.worker
+	handler.dummyFrankenPHPContext = fc
+	handler.dummyContext = ctx
+
+	if globalLogger.Enabled(ctx, slog.LevelDebug) {
+		globalLogger.LogAttrs(ctx, slog.LevelDebug, "starting background worker", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex))
+	}
+
+	handler.thread.state.Set(state.Ready)
+	fc.scriptFilename = handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
+	// frankenphp_set_background_worker_and_get_stop_fd_write transferred fd
+	// ownership to Go, so we must close on every exit path to avoid a leak.
+	if fd := handler.stopFdWrite.Swap(-1); fd >= 0 {
+		C.frankenphp_worker_close_fd(C.int(fd))
+	}
+	worker := handler.worker
+	handler.dummyFrankenPHPContext = nil
+	handler.dummyContext = nil
+
+	// During Shutdown the drain's force-kill is armed against one slot; a
+	// freshly spawned pthread would re-enter the script and never exit.
+	if mainThread != nil && mainThread.state.Is(state.ShuttingDown) {
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	metricName := bgWorkerMetricName(worker.scope, worker.name)
+
+	// Cooperative exit: re-run, reset backoff.
+	if exitStatus == 0 {
+		metrics.StopWorker(metricName, StopReasonRestart)
+
+		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting background worker", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
+		}
+
+		handler.failureCount = 0
+		return
+	}
+
+	metrics.StopWorker(metricName, StopReasonCrash)
+
+	// max_consecutive_failures only applies during boot: hitting the cap
+	// before the server finished starting up surfaces on startupFailChan
+	// so Init returns the error to the operator. Past startup, a crashing
+	// bg worker keeps restarting with a louder log line — silently
+	// shutting it down would leave the server in a broken half-state with
+	// no clear way to recover.
+	pastCap := worker.maxConsecutiveFailures >= 0 && handler.failureCount >= worker.maxConsecutiveFailures
+	if pastCap && startupFailChan != nil && !watcherIsEnabled {
+		startupFailChan <- fmt.Errorf("too many consecutive failures: background worker %s keeps crashing", worker.fileName)
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	logLevel := slog.LevelWarn
+	logMsg := "background worker crashed, restarting"
+	if pastCap {
+		logLevel = slog.LevelError
+		logMsg = "background worker exceeded max_consecutive_failures, still restarting"
+	}
+	if globalLogger.Enabled(globalCtx, logLevel) {
+		globalLogger.LogAttrs(globalCtx, logLevel, logMsg, slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount), slog.Int("exit_status", exitStatus))
+	}
+
+	backoffDuration := time.Duration(handler.failureCount*handler.failureCount*100) * time.Millisecond
+	if backoffDuration > time.Second {
+		backoffDuration = time.Second
+	}
+	handler.failureCount++
+	time.Sleep(backoffDuration)
+}

--- a/worker.go
+++ b/worker.go
@@ -33,6 +33,9 @@ type worker struct {
 	onThreadReady          func(int)
 	onThreadShutdown       func(int)
 	queuedRequests         atomic.Int32
+	scope                  Scope
+	// isBackgroundWorker marks this as a background (non-HTTP) worker.
+	isBackgroundWorker bool
 }
 
 var (
@@ -57,18 +60,33 @@ func initWorkers(opt []workerOpt) error {
 	workersByName = make(map[string]*worker, len(opt))
 	workersByPath = make(map[string]*worker, len(opt))
 
-	for _, o := range opt {
+	declared := make([]*worker, len(opt))
+	for i, o := range opt {
 		w, err := newWorker(o)
 		if err != nil {
 			return err
 		}
 
 		totalThreadsToStart += w.num
+		declared[i] = w
 		workers = append(workers, w)
-		workersByName[w.name] = w
+		// Background workers are resolved per-scope via backgroundLookups
+		// so the same user-facing name can appear in multiple scopes
+		// without colliding in the global workersByName map.
+		if !w.isBackgroundWorker {
+			workersByName[w.name] = w
+		}
 		if w.allowPathMatching {
 			workersByPath[w.fileName] = w
 		}
+	}
+
+	// Build the per-scope lookups. Each php_server block gets its own
+	// scope; the global/embed scope is 0.
+	var err error
+	backgroundLookups, err = buildBackgroundWorkerLookups(declared, opt)
+	if err != nil {
+		return err
 	}
 
 	startupFailChan = make(chan error, totalThreadsToStart)
@@ -76,7 +94,11 @@ func initWorkers(opt []workerOpt) error {
 	for _, w := range workers {
 		for i := 0; i < w.num; i++ {
 			thread := getInactivePHPThread()
-			convertToWorkerThread(thread, w)
+			if w.isBackgroundWorker {
+				convertToBackgroundWorkerThread(thread, w)
+			} else {
+				convertToWorkerThread(thread, w)
+			}
 
 			workersReady.Go(func() {
 				thread.state.WaitFor(state.Ready, state.ShuttingDown, state.Done)
@@ -121,21 +143,35 @@ func newWorker(o workerOpt) (*worker, error) {
 	}
 
 	// workers that have a name starting with "m#" are module workers
-	// they can only be matched by their name, not by their path
-	allowPathMatching := !strings.HasPrefix(o.name, "m#")
+	// they can only be matched by their name, not by their path.
+	// Background workers are matched only by name, never by path, since
+	// they don't handle HTTP requests.
+	allowPathMatching := !strings.HasPrefix(o.name, "m#") && !o.isBackgroundWorker
 
-	if w := workersByPath[absFileName]; w != nil && allowPathMatching {
-		return w, fmt.Errorf("two workers cannot have the same filename: %q", absFileName)
-	}
-	if w := workersByName[o.name]; w != nil {
-		return w, fmt.Errorf("two workers cannot have the same name: %q", o.name)
+	// Background workers are resolved through per-scope lookups, not the
+	// global workersByName/workersByPath maps; the same user-facing name
+	// can appear in multiple php_server scopes without collision.
+	if !o.isBackgroundWorker {
+		if w := workersByPath[absFileName]; w != nil && allowPathMatching {
+			return w, fmt.Errorf("two workers cannot have the same filename: %q", absFileName)
+		}
+		if w := workersByName[o.name]; w != nil {
+			return w, fmt.Errorf("two workers cannot have the same name: %q", o.name)
+		}
 	}
 
 	if o.env == nil {
 		o.env = make(PreparedEnv, 1)
 	}
 
-	o.env["FRANKENPHP_WORKER\x00"] = "1"
+	// $_SERVER['FRANKENPHP_WORKER'] is "1" for HTTP workers (existing
+	// behavior) or the worker name for background workers, so a bg
+	// script can also surface its identity via the env injection path.
+	if o.isBackgroundWorker {
+		o.env["FRANKENPHP_WORKER\x00"] = strings.TrimPrefix(o.name, "m#")
+	} else {
+		o.env["FRANKENPHP_WORKER\x00"] = "1"
+	}
 	w := &worker{
 		name:                   o.name,
 		fileName:               absFileName,
@@ -148,6 +184,8 @@ func newWorker(o workerOpt) (*worker, error) {
 		maxConsecutiveFailures: o.maxConsecutiveFailures,
 		onThreadReady:          o.onThreadReady,
 		onThreadShutdown:       o.onThreadShutdown,
+		scope:                  o.scope,
+		isBackgroundWorker:     o.isBackgroundWorker,
 	}
 
 	w.configureMercure(&o)


### PR DESCRIPTION
## Summary

Smallest useful slice of the background-worker work. Adds long-lived
non-HTTP PHP scripts declared via `WithWorkerBackground()` / `background`
in the Caddyfile worker block, plus the `frankenphp_get_worker_handle()`
primitive that gives the script a stream it can park on (`stream_select`)
to exit gracefully on shutdown / restart.

This carves the minimal surface out of the larger PR #2393 so it is small
enough to review and merge on its own. The richer features built on top
of these primitives are deferred to follow-ups.

## What's in

- **PHP API**: `frankenphp_get_worker_handle(): resource` — closes when
  FrankenPHP drains the worker (write end of the stop pipe is closed Go-side).
- **Go API**: `WithWorkerBackground()`, `WithWorkerScope()`, `NextScope`,
  `SetScopeLabel`. `num >= 1` is required for bg workers (no lazy-start
  in this build).
- **Lifecycle**: boot the script, restart on crash with quadratic backoff,
  halt respawn at `max_consecutive_failures`. Exit-status 0 = cooperative
  restart, no failure counted.
- **Caddy**: `background` flag inside `php_server { workers ... }`.
  Per-php_server scope isolation so two server blocks can declare the same
  worker name without colliding. Scope label resolved before `Init` via the
  cascade in `caddy/scopelabel.go` (host matcher → first listener address)
  so the very first metric emit on every bg worker carries the right
  `m#<scope-label>:<name>` prefix.

## Deferred (kept out for review surface)

- `frankenphp_ensure_background_worker()` and the lazy-start / readiness
  / boot-failure machinery it pulls in.
- Catch-all (empty-name) workers.
- Shared-state APIs (`frankenphp_set_vars` / `frankenphp_get_vars`).

## Test plan

- [x] `TestBackgroundWorkerLifecycle` — bg worker boots, touches sentinel,
      parks on stop pipe, `Shutdown()` returns within 10s.
- [x] `TestBackgroundWorkerCrashRestarts` — `exit(1)` on first boot,
      respawned thread runs the success branch.
- [x] `TestBackgroundWorkerWithoutHTTP` — bg worker doesn't intercept
      HTTP traffic; a regular request still serves.
- [x] `TestBackgroundWorkerSameNameDifferentScope` (internal) — two
      php_server scopes each declare "shared", both Init successfully and
      run independently.
- [x] `TestNextScopeIsDistinct`.