### PR TITLE
fix(pgo): skip re-symbolization when merging pprof profiles

### DIFF
--- a/profiles/build-pgo.sh
+++ b/profiles/build-pgo.sh
@@ -30,6 +30,10 @@ collect "$HERE/app/Caddyfile.worker" "$HERE/worker.pgo"
 export CGO_CFLAGS="${CGO_CFLAGS:-} -fno-sanitize=undefined"
 PPROF="$(go env GOPATH)/bin/pprof"
 [ -x "$PPROF" ] || go install github.com/google/pprof@latest
-"$PPROF" -proto "$HERE/regular.pgo" "$HERE/worker.pgo" >"$ROOT/caddy/frankenphp/default.pgo"
+# Input profiles from net/http/pprof already carry Function.start_line.
+# pprof's addr2line symbolizer doesn't set it, so re-symbolizing here
+# overwrites the existing records with start_line=0 and Go PGO's
+# preprofile then rejects the merged profile.
+"$PPROF" -symbolize=none -proto "$HERE/regular.pgo" "$HERE/worker.pgo" >"$ROOT/caddy/frankenphp/default.pgo"
 
 (cd "$ROOT/caddy/frankenphp" && go build -o frankenphp-pgo)


### PR DESCRIPTION
## Summary

The PGO refresh workflow at https://github.com/php/frankenphp/actions/runs/25779871543/job/75719971682 (and the two prior runs - the job has never succeeded) failed when building `frankenphp-pgo` with:

```
preprofile: error parsing profile: profile missing Function.start_line data (Go version of profiled application too old? Go 1.20+ automatically adds this to profiles)
```

The two input profiles produced by `net/http/pprof` already carry `Function.start_line` (Go 1.20+ guarantees this). The problem is the merge step itself:

```
pprof -proto regular.pgo worker.pgo > default.pgo
```

`pprof -proto` runs local symbolization by default. On the CI runner that falls back to `addr2line`, whose adapter in https://github.com/google/pprof/blob/main/internal/binutils/addr2liner.go constructs `plugin.Frame` with only `Func`, `File`, and `Line`. `StartLine` is never set, so the new `Function` records that replace the original symbolized ones come out with `start_line = 0`, which Go PGO's `preprofile` rejects.

`pprof -symbolize=none` skips that step so the already-symbolized records from `net/http/pprof` survive the merge intact. (The PGO Tools wiki notes that pprof "should produce a PGO-compatible output" only when its symbolization preserves metadata - that's true with llvm-symbolizer's JSON path added in https://github.com/google/pprof/pull/891, but not with the addr2line fallback used in CI.)