### PR TITLE
Add --no-upx and --no-compress flags

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -14,6 +14,13 @@ arch="$(uname -m)"
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 [ "$os" = "darwin" ] && os="mac"
 
+# Parse command line arguments
+for arg in "$@"; do
+    if [ "$arg" = "--no-upx" ] || [ "$arg" = "--no-compress" ]; then
+        NO_COMPRESS=1
+    fi
+don
+
 # Supported variables:
 # - PHP_VERSION: PHP version to build (default: "8.4")
 # - PHP_EXTENSIONS: PHP extensions to build (default: ${defaultExtensions} set below)

--- a/build-static.sh
+++ b/build-static.sh
@@ -19,7 +19,7 @@ for arg in "$@"; do
     if [ "$arg" = "--no-upx" ] || [ "$arg" = "--no-compress" ]; then
         NO_COMPRESS=1
     fi
-don
+done
 
 # Supported variables:
 # - PHP_VERSION: PHP version to build (default: "8.4")


### PR DESCRIPTION
**Description**
Currently, developers can skip the UPX compression stage by setting the `NO_COMPRESS=1` environment variable. However, this is not immediately obvious, and many users intuitively try to pass flags like `--no-upx` to the script. Since `build-static.sh` doesn't parse this argument, the flag is ignored, resulting in a 40-60 minute build time on ARM64/Apple Silicon.

This PR adds basic command-line argument parsing to `build-static.sh`. Passing `--no-upx` (or `--no-compress`) will automatically set `NO_COMPRESS=1`, making the developer experience much smoother and more intuitive.

**Related Issue**
Closes #2408