### PR TITLE
ci: factor plumbing calls into a composite actions

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - uses: actions/setup-go@v6
-      with: # zizmor: ignore[cache-poisoning]
+      with:
         go-version-file: ${{ inputs.working-directory }}/go.mod
         cache-dependency-path: |
           ${{ inputs.working-directory }}/go.sum

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,22 +1,18 @@
 name: setup-go
-description: Setup Go with FrankenPHP's pinned version and standard cache configuration
+description: Setup Go using the version from go.mod, with standard cache configuration
 inputs:
   working-directory:
-    description: Path prefix for go.sum files (used when the repo is checked out into a subdirectory)
+    description: Path prefix for go.mod / go.sum files (used when the repo is checked out into a subdirectory)
     required: false
     default: "."
-  cache:
-    description: Whether to enable the Go modules cache
-    required: false
-    default: "true"
 runs:
   using: composite
   steps:
     - uses: actions/setup-go@v6
       with: # zizmor: ignore[cache-poisoning]
-        go-version: "1.26"
+        go-version-file: ${{ inputs.working-directory }}/go.mod
         cache-dependency-path: |
           ${{ inputs.working-directory }}/go.sum
           ${{ inputs.working-directory }}/caddy/go.sum
-        cache: ${{ inputs.cache }}
+        cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
         check-latest: true

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,22 @@
+name: setup-go
+description: Setup Go with FrankenPHP's pinned version and standard cache configuration
+inputs:
+  working-directory:
+    description: Path prefix for go.sum files (used when the repo is checked out into a subdirectory)
+    required: false
+    default: "."
+  cache:
+    description: Whether to enable the Go modules cache
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v6
+      with: # zizmor: ignore[cache-poisoning]
+        go-version: "1.26"
+        cache-dependency-path: |
+          ${{ inputs.working-directory }}/go.sum
+          ${{ inputs.working-directory }}/caddy/go.sum
+        cache: ${{ inputs.cache }}
+        check-latest: true

--- a/.github/actions/setup-php/action.yaml
+++ b/.github/actions/setup-php/action.yaml
@@ -1,0 +1,18 @@
+name: setup-php
+description: Setup PHP in ZTS + debug mode with FrankenPHP's standard configuration
+inputs:
+  php-version:
+    description: PHP version (e.g. "8.5")
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        ini-file: development
+        coverage: none
+        tools: none
+      env:
+        phpts: ts
+        debug: true

--- a/.github/actions/setup-php/action.yaml
+++ b/.github/actions/setup-php/action.yaml
@@ -3,7 +3,8 @@ description: Setup PHP in ZTS + debug mode with FrankenPHP's standard configurat
 inputs:
   php-version:
     description: PHP version (e.g. "8.5")
-    required: true
+    required: false
+    default: "8.5"
 runs:
   using: composite
   steps:

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -1,17 +1,22 @@
 name: version
-description: Resolve FRANKENPHP_VERSION from the current ref (stripped tag name, with commit SHA fallback)
+description: Resolve the FrankenPHP version from the current ref (stripped tag name, with commit SHA fallback)
 inputs:
   ref:
     description: Optional ref override (e.g. tag name resolved by a prepare job for schedule/dispatch flows)
     required: false
     default: ""
+outputs:
+  version:
+    description: Resolved version string
+    value: ${{ steps.resolve.outputs.version }}
 runs:
   using: composite
   steps:
-    - shell: bash
+    - id: resolve
+      shell: bash
       env:
         REF: ${{ inputs.ref }}
-      run: | # zizmor: ignore[github-env]
+      run: |
         if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
           version="${GITHUB_REF_NAME#v}"
         elif [ -n "${REF}" ]; then
@@ -20,7 +25,7 @@ runs:
           version="${GITHUB_SHA}"
         fi
         if [[ ! "${version}" =~ ^[A-Za-z0-9._-]+$ ]]; then
-          echo "::error::invalid FRANKENPHP_VERSION value: ${version}" >&2
+          echo "::error::invalid version value: ${version}" >&2
           exit 1
         fi
-        echo "FRANKENPHP_VERSION=${version}" >> "${GITHUB_ENV}"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/version/action.yaml
+++ b/.github/actions/version/action.yaml
@@ -1,0 +1,26 @@
+name: version
+description: Resolve FRANKENPHP_VERSION from the current ref (stripped tag name, with commit SHA fallback)
+inputs:
+  ref:
+    description: Optional ref override (e.g. tag name resolved by a prepare job for schedule/dispatch flows)
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        REF: ${{ inputs.ref }}
+      run: | # zizmor: ignore[github-env]
+        if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+          version="${GITHUB_REF_NAME#v}"
+        elif [ -n "${REF}" ]; then
+          version="${REF#v}"
+        else
+          version="${GITHUB_SHA}"
+        fi
+        if [[ ! "${version}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::invalid FRANKENPHP_VERSION value: ${version}" >&2
+          exit 1
+        fi
+        echo "FRANKENPHP_VERSION=${version}" >> "${GITHUB_ENV}"

--- a/.github/workflows/pgo-profile.yaml
+++ b/.github/workflows/pgo-profile.yaml
@@ -37,8 +37,6 @@ jobs:
           # workflow needs to push a branch via git push (mirrors translate.yaml).
       - uses: ./.github/actions/setup-go
       - uses: ./.github/actions/setup-php
-        with:
-          php-version: "8.5"
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
       - name: Set CGO flags

--- a/.github/workflows/pgo-profile.yaml
+++ b/.github/workflows/pgo-profile.yaml
@@ -35,12 +35,7 @@ jobs:
           # zizmor: ignore[artipacked]
           # persist-credentials is intentionally left enabled because this
           # workflow needs to push a branch via git push (mirrors translate.yaml).
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.5"

--- a/.github/workflows/pgo-profile.yaml
+++ b/.github/workflows/pgo-profile.yaml
@@ -36,15 +36,9 @@ jobs:
           # persist-credentials is intentionally left enabled because this
           # workflow needs to push a branch via git push (mirrors translate.yaml).
       - uses: ./.github/actions/setup-go
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-php
         with:
           php-version: "8.5"
-          ini-file: development
-          coverage: none
-          tools: none
-        env:
-          phpts: ts
-          debug: true
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
       - name: Set CGO flags

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -44,12 +44,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum 
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
       - name: Determine PHP version
         id: determine-php-version
         run: |

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -453,8 +453,6 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-        with:
-          cache: ${{ github.event_name != 'release' }}
       - name: Set FRANKENPHP_VERSION
         run: |
           if [ "${GITHUB_REF_TYPE}" == "tag" ]; then

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -453,9 +453,14 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - uses: ./.github/actions/version
+      - id: version
+        uses: ./.github/actions/version
         with:
           ref: ${{ needs.prepare.outputs.ref }}
+      - name: Set FRANKENPHP_VERSION
+        run: echo "FRANKENPHP_VERSION=${VERSION}" >> "${GITHUB_ENV}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
       - name: Build FrankenPHP
         run: ./build-static.sh
         env:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -452,12 +452,8 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
-      - uses: actions/setup-go@v6
-        with: # zizmor: ignore[cache-poisoning]
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
+        with:
           cache: ${{ github.event_name != 'release' }}
       - name: Set FRANKENPHP_VERSION
         run: |

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -453,19 +453,9 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - name: Set FRANKENPHP_VERSION
-        run: |
-          if [ "${GITHUB_REF_TYPE}" == "tag" ]; then
-            export FRANKENPHP_VERSION=${GITHUB_REF_NAME:1}
-          elif [ "${GITHUB_EVENT_NAME}" == "schedule" ]; then
-            export FRANKENPHP_VERSION="${REF}"
-          else
-            export FRANKENPHP_VERSION=${GITHUB_SHA}
-          fi
-
-          echo "FRANKENPHP_VERSION=${FRANKENPHP_VERSION}" >> "${GITHUB_ENV}"
-        env:
-          REF: ${{ needs.prepare.outputs.ref }}
+      - uses: ./.github/actions/version
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
       - name: Build FrankenPHP
         run: ./build-static.sh
         env:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -457,14 +457,11 @@ jobs:
         uses: ./.github/actions/version
         with:
           ref: ${{ needs.prepare.outputs.ref }}
-      - name: Set FRANKENPHP_VERSION
-        run: echo "FRANKENPHP_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
       - name: Build FrankenPHP
         run: ./build-static.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FRANKENPHP_VERSION: ${{ steps.version.outputs.version }}
           RELEASE: ${{ (needs.prepare.outputs.ref || github.ref_type == 'tag') && '1' || '' }}
           NO_COMPRESS: ${{ github.event_name == 'pull_request' && '1' || '' }}
       - name: Upload logs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,15 +42,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          ini-file: development
-          coverage: none
-          tools: none
-        env:
-          phpts: ts
-          debug: true
       - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
       - name: Reinstall libbrotli-dev
@@ -113,15 +107,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          ini-file: development
-          coverage: none
-          tools: none
-        env:
-          phpts: ts
-          debug: true
       - name: Install PHP development libraries
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev libsodium-dev libargon2-dev
       - name: Install xcaddy
@@ -152,15 +140,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
-      - uses: shivammathur/setup-php@v2
+      - uses: ./.github/actions/setup-php
         with:
-          php-version: 8.5
-          ini-file: development
-          coverage: none
-          tools: none
-        env:
-          phpts: ts
-          debug: true
+          php-version: "8.5"
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Set CGO flags

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum 
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -117,12 +112,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -161,12 +151,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache-dependency-path: |
-            go.sum
-            caddy/go.sum
+      - uses: ./.github/actions/setup-go
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -141,8 +141,6 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-go
       - uses: ./.github/actions/setup-php
-        with:
-          php-version: "8.5"
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Set CGO flags

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -73,11 +73,6 @@ jobs:
         uses: ./frankenphp/.github/actions/version
         with:
           ref: ${{ env.REF }}
-      - name: Set FRANKENPHP_VERSION
-        shell: bash
-        run: echo "FRANKENPHP_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Setup Go
         uses: ./frankenphp/.github/actions/setup-go
@@ -141,6 +136,8 @@ jobs:
 
           "CGO_CFLAGS=-DFRANKENPHP_VERSION=$env:FRANKENPHP_VERSION -I$vcpkgRoot\include -I$watcherRoot -I$phpDevel\include -I$phpDevel\include\main -I$phpDevel\include\TSRM -I$phpDevel\include\Zend -I$phpDevel\include\ext" >> $env:GITHUB_ENV
           "CGO_LDFLAGS=-L$vcpkgRoot\lib -lbrotlienc -L$watcherRoot -llibwatcher-c -L$phpBin -L$phpDevel\lib -lphp8ts -lphp8embed" >> $env:GITHUB_ENV
+        env:
+          FRANKENPHP_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Embed Windows icon and metadata
         working-directory: frankenphp\caddy\frankenphp
@@ -177,12 +174,16 @@ jobs:
           $json | Set-Content "versioninfo.json"
 
           goversioninfo -64 -icon ..\..\frankenphp.ico versioninfo.json -o resource.syso
+        env:
+          FRANKENPHP_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Build FrankenPHP
         run: |
           $customVersion = "FrankenPHP $env:FRANKENPHP_VERSION PHP $env:PHP_VERSION Caddy"
           go build -ldflags="-extldflags=-fuse-ld=lld -X 'github.com/caddyserver/caddy/v2.CustomVersion=$customVersion' -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp' -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy'"
         working-directory: frankenphp\caddy\frankenphp
+        env:
+          FRANKENPHP_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Create Directory
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -69,9 +69,15 @@ jobs:
           path: frankenphp
           persist-credentials: false
 
-      - uses: ./frankenphp/.github/actions/version
+      - id: version
+        uses: ./frankenphp/.github/actions/version
         with:
           ref: ${{ env.REF }}
+      - name: Set FRANKENPHP_VERSION
+        shell: bash
+        run: echo "FRANKENPHP_VERSION=${VERSION}" >> "${GITHUB_ENV}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Setup Go
         uses: ./frankenphp/.github/actions/setup-go

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -69,23 +69,9 @@ jobs:
           path: frankenphp
           persist-credentials: false
 
-      - name: Set FRANKENPHP_VERSION
-        run: |
-          $ref = $env:REF
-
-          if ($env:GITHUB_REF_TYPE -eq "tag") {
-            $frankenphpVersion = $env:GITHUB_REF_NAME.Substring(1)
-          } elseif ($ref) {
-            if ($ref.StartsWith("v")) {
-              $frankenphpVersion = $ref.Substring(1)
-            } else {
-              $frankenphpVersion = $ref
-            }
-          } else {
-            $frankenphpVersion = $env:GITHUB_SHA
-          }
-
-          "FRANKENPHP_VERSION=$frankenphpVersion" >> $env:GITHUB_ENV
+      - uses: ./frankenphp/.github/actions/version
+        with:
+          ref: ${{ env.REF }}
 
       - name: Setup Go
         uses: ./frankenphp/.github/actions/setup-go

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -91,7 +91,6 @@ jobs:
         uses: ./frankenphp/.github/actions/setup-go
         with:
           working-directory: frankenphp
-          cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install Vcpkg Libraries
         working-directory: frankenphp

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -88,14 +88,10 @@ jobs:
           "FRANKENPHP_VERSION=$frankenphpVersion" >> $env:GITHUB_ENV
 
       - name: Setup Go
-        uses: actions/setup-go@v6
-        with: # zizmor: ignore[cache-poisoning]
-          go-version: "1.26"
-          cache-dependency-path: |
-            frankenphp/go.sum
-            frankenphp/caddy/go.sum
+        uses: ./frankenphp/.github/actions/setup-go
+        with:
+          working-directory: frankenphp
           cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          check-latest: true
 
       - name: Install Vcpkg Libraries
         working-directory: frankenphp


### PR DESCRIPTION
Factor repeated CI plumbing into three composite actions under `.github/actions/`:

- **`setup-go/`** — reads `go-version-file: go.mod` with `check-latest: true` so future Go upgrades only require bumping `go.mod`. Disables the Go module cache on tag-triggered runs (`!startsWith(github.ref, 'refs/tags/')`) to prevent cache poisoning into release binaries. Replaces 7 `actions/setup-go@v6` call sites.
- **`setup-php/`** — wraps `shivammathur/setup-php@v2` with the ZTS + debug + `development` ini-file flavor used by tests and PGO. Defaults `php-version` to `"8.5"`. Replaces 4 nearly-identical call sites in `tests.yaml` and `pgo-profile.yaml`. (`translate.yaml` left alone — it uses plain non-debug PHP.)
- **`version/`** — resolves the FrankenPHP version from the current ref (stripped tag name, fallback to commit SHA), exposed as a step output. Unifies the bash logic in `static.yaml` with the duplicated PowerShell logic in `windows.yaml`. Output is consumed via per-step `env: FRANKENPHP_VERSION:` injection in consuming steps, so the action does no `$GITHUB_ENV` write.

Side benefits:
- `static.yaml`'s `cache: ${{ github.event_name != 'release' }}` was effectively always-true (the workflow never fires on `release` events). The new rule actually disables cache on tag pushes as intended.
- Dependabot's `github-actions` ecosystem already tracks `.github/actions/`, so pins inside the composite actions get auto-bumped.
- Zero zizmor ignore pragmas added by this PR (`cache-poisoning` and `github-env` were both eliminated by structural changes rather than silencing).

Net: +96 / -107 lines.