### PR TITLE
test: stop autoscale tests from hanging on request failure

### DIFF
--- a/caddy/admin_test.go
+++ b/caddy/admin_test.go
@@ -162,14 +162,15 @@ func TestAutoScaleWorkerThreads(t *testing.T) {
 		wg.Add(requestsPerTry)
 		for range requestsPerTry {
 			go func() {
+				// deferred so a t.Fatalf from a failed request doesn't leak the WaitGroup
+				defer wg.Done()
 				tester.AssertGetResponse(endpoint, http.StatusOK, "slept for 2 ms and worked for 1000 iterations")
-				wg.Done()
 			}()
 		}
 		wg.Wait()
 
 		amountOfThreads = getNumThreads(t, tester)
-		if amountOfThreads > 2 {
+		if amountOfThreads > 2 || t.Failed() {
 			break
 		}
 	}
@@ -214,14 +215,15 @@ func TestAutoScaleRegularThreadsOnAutomaticThreadLimit(t *testing.T) {
 		wg.Add(requestsPerTry)
 		for range requestsPerTry {
 			go func() {
+				// deferred so a t.Fatalf from a failed request doesn't leak the WaitGroup
+				defer wg.Done()
 				tester.AssertGetResponse(endpoint, http.StatusOK, "slept for 2 ms and worked for 1000 iterations")
-				wg.Done()
 			}()
 		}
 		wg.Wait()
 
 		amountOfThreads = getNumThreads(t, tester)
-		if amountOfThreads > 1 {
+		if amountOfThreads > 1 || t.Failed() {
 			break
 		}
 	}


### PR DESCRIPTION
`TestAutoScaleRegularThreadsOnAutomaticThreadLimit` (and its sibling `TestAutoScaleWorkerThreads`) in `caddy/admin_test.go` would burn the package-wide 10 minute Go test timeout whenever the PHP server returned a connection error during the load loop. This was observed on the PHP 8.5 / Linux CI matrix on https://github.com/php/frankenphp/pull/2412 (and on https://github.com/php/frankenphp/pull/2381 for the related `TestAddModuleWorkerViaAdminApi`).

Root cause: `caddytest.AssertGetResponse` calls `t.Fatalf` on connection errors. From a non-test goroutine that triggers `runtime.Goexit`, which skips the plain `wg.Done()` after it, so `wg.Wait()` blocks forever and the retry loop never gets to check `amountOfThreads` or break out.

Two surgical changes:
- `defer wg.Done()` so a `Fatalf`'d goroutine still decrements the WaitGroup.
- Break out of the retry loop once `t.Failed()` is true so we don't keep hammering an already-broken server for another 9 rounds.

Net diff: +6 / -2 lines per test, no new imports.