### PR TITLE
ci: attest release artifacts with actions/attest

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -209,6 +209,11 @@ jobs:
       - prepare
       - build
     if: fromJson(needs.prepare.outputs.push)
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -241,10 +246,22 @@ jobs:
           TARGET: ${{ matrix.target }}
           VARIANT: ${{ matrix.variant }}
       - name: Inspect image
+        id: inspect
         run: |
           # shellcheck disable=SC2046,SC2086
-          docker buildx imagetools inspect $(jq -cr ".target.\"${TARGET}-${VARIANT}\".tags | first" <<< ${METADATA})
+          tag=$(jq -cr ".target.\"${TARGET}-${VARIANT}\".tags | first" <<< ${METADATA})
+          docker buildx imagetools inspect "${tag}"
+          digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${tag}")
+          {
+            echo "name=${tag%%:*}"
+            echo "digest=${digest}"
+          } >> "${GITHUB_OUTPUT}"
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}
           TARGET: ${{ matrix.target }}
           VARIANT: ${{ matrix.variant }}
+      - uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.inspect.outputs.name }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -88,6 +88,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -202,7 +203,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF: ${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref }}
       - if: fromJson(needs.prepare.outputs.push) && (needs.prepare.outputs.ref || github.ref_type == 'tag')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ github.workspace }}/frankenphp-linux-*
       - name: Run sanity checks
@@ -223,6 +224,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -360,7 +362,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF: ${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref }}
       - if: fromJson(needs.prepare.outputs.push) && (needs.prepare.outputs.ref || github.ref_type == 'tag')
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ github.workspace }}/gh-output/frankenphp-linux-*-gnu
       - name: Run sanity checks
@@ -438,6 +440,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:
@@ -471,7 +474,7 @@ jobs:
           path: dist/static-php-cli/log
           name: static-php-cli-log-${{ matrix.platform }}-${{ github.sha }}
       - if: needs.prepare.outputs.ref || github.ref_type == 'tag'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ github.workspace }}/dist/frankenphp-mac-*
       - name: Upload artifact

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -43,6 +43,9 @@ jobs:
   build:
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     runs-on: windows-latest
     steps:
       - name: Determine ref
@@ -211,6 +214,11 @@ jobs:
         run: gh release upload "$env:REF" "$env:DIR_NAME.zip" --repo php/frankenphp --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ env.REF }}
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ github.workspace }}\${{ env.DIR_NAME }}.zip
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
## Summary

Generate SLSA build-provenance attestations for every released artifact via [`actions/attest@v4`](https://github.com/actions/attest) (the recommended action that auto-fills the SLSA v1 predicate when no custom predicate is supplied).

- `static.yaml`: switch the three existing `actions/attest-build-provenance@v4` calls to `actions/attest@v4` and add the new `artifact-metadata: write` permission required by v4.
- `windows.yaml`: attest the released `frankenphp-windows-x86_64.zip`.
- `docker.yaml`: attest each pushed manifest list (builder + runner per variant) by digest, pushing the attestation to the registry alongside the image so consumers can run `gh attestation verify oci://docker.io/dunglas/frankenphp@sha256:... --owner php`.

## Verifying after merge

```
gh attestation verify ./frankenphp-linux-x86_64-gnu --owner php
gh attestation verify ./frankenphp-windows-x86_64.zip --owner php
gh attestation verify oci://docker.io/dunglas/frankenphp@sha256:<digest> --owner php
```