### PR TITLE
fix(release): stage PGO blob through --rawfile to avoid ARG_MAX

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,16 +139,17 @@ jobs:
           else
             # Stage the base64 in a temp file and feed it to jq via
             # --rawfile: passing big blobs (the PGO profile is ~2 MB encoded)
-            # through --arg exceeds ARG_MAX on the runner.
-            make_blob() {
+            # through --arg exceeds ARG_MAX on the runner. Subshell body +
+            # EXIT trap clean up the tmpfile even if base64/jq/gh aborts.
+            make_blob() (
               local tmp
               tmp=$(mktemp)
+              trap 'rm -f "$tmp"' EXIT
               base64 -w0 <"$1" >"$tmp"
               jq -nc --rawfile content "$tmp" \
                 '{content: $content, encoding: "base64"}' \
                 | gh api "repos/${REPO}/git/blobs" --input - -q .sha
-              rm -f "$tmp"
-            }
+            )
 
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)
             base_tree=$(gh api "repos/${REPO}/git/commits/${parent_sha}" -q .tree.sha)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,10 +137,17 @@ jobs:
             commit_sha="${RELEASE_COMMIT}"
             echo "Reusing existing release commit ${commit_sha}"
           else
+            # Stage the base64 in a temp file and feed it to jq via
+            # --rawfile: passing big blobs (the PGO profile is ~2 MB encoded)
+            # through --arg exceeds ARG_MAX on the runner.
             make_blob() {
-              jq -nc --arg content "$(base64 -w0 <"$1")" \
+              local tmp
+              tmp=$(mktemp)
+              base64 -w0 <"$1" >"$tmp"
+              jq -nc --rawfile content "$tmp" \
                 '{content: $content, encoding: "base64"}' \
                 | gh api "repos/${REPO}/git/blobs" --input - -q .sha
+              rm -f "$tmp"
             }
 
             parent_sha=$(gh api "repos/${REPO}/git/refs/heads/main" -q .object.sha)


### PR DESCRIPTION
## Summary

The `Commit and tag via GitHub API` step in `release.yaml` blew up on its first real dispatch (https://github.com/php/frankenphp/actions/runs/25914409401):

```
/usr/bin/jq: Argument list too long
gh: Validation Failed (HTTP 422)
```

`jq --arg content "$(base64 -w0 <default.pgo)" ...` was passing the ~2 MB base64-encoded PGO blob as a CLI argument, which exceeds the runner's `ARG_MAX`.

Fix: stage the base64 in a tmpfile and feed it via `--rawfile` so jq reads it from disk, not the argv. `go.mod` and `go.sum` keep going through `--rawfile` for consistency.

This needs to land before the next release dispatch can succeed.