### PR TITLE
fix(release): detect resume by tag, not by HEAD commit message

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,12 @@ jobs:
             if [[ "${type}" == "tag" ]]; then
               sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" -q .object.sha)
             fi
+            # Refuse to resume against a tag that isn't reachable from main:
+            # protects against an orphan tag created on a side branch.
+            if ! git merge-base --is-ancestor "${sha}" HEAD; then
+              echo "::error::Tag v${VERSION} (${sha}) is not reachable from main; refusing to resume."
+              exit 1
+            fi
             echo "Resuming: v${VERSION} exists at ${sha}"
             {
               echo "resume=true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,28 +63,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
-        # Detect whether main already carries the release commit (we're
-        # resuming after a mid-flight failure) or whether this is a fresh
-        # release attempt. The downstream steps gate themselves on `resume`.
+        # Tag existence is the source of truth for "release in progress":
+        # main HEAD may have moved past the release commit (a follow-up fix
+        # merged on top), so the commit-message check on HEAD is too narrow.
+        # If v<version> exists, resume from the commit it points at;
+        # otherwise it's a fresh attempt and tags must not exist.
         run: |
           set -euo pipefail
-          main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/main" -q .object.sha)
-          first_line=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${main_sha}" -q .message | head -n1)
-          expected="chore: prepare release ${VERSION} [skip ci]"
-          if [[ "${first_line}" == "${expected}" ]]; then
-            echo "Resuming: release commit already at ${main_sha}"
+          if ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" 2>/dev/null); then
+            sha=$(jq -r .object.sha <<<"${ref}")
+            type=$(jq -r .object.type <<<"${ref}")
+            if [[ "${type}" == "tag" ]]; then
+              sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${sha}" -q .object.sha)
+            fi
+            echo "Resuming: v${VERSION} exists at ${sha}"
             {
               echo "resume=true"
-              echo "release_commit=${main_sha}"
+              echo "release_commit=${sha}"
             } >> "${GITHUB_OUTPUT}"
           else
             echo "resume=false" >> "${GITHUB_OUTPUT}"
-            for tag in "v${VERSION}" "caddy/v${VERSION}"; do
-              if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" --silent 2>/dev/null; then
-                echo "::error::Tag ${tag} exists but main HEAD is not the release commit; refusing to release."
-                exit 1
-              fi
-            done
+            if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/caddy/v${VERSION}" --silent 2>/dev/null; then
+              echo "::error::caddy/v${VERSION} exists but v${VERSION} does not; refusing to release into a split state."
+              exit 1
+            fi
           fi
       - if: steps.state.outputs.resume != 'true'
         uses: ./.github/actions/setup-go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,12 @@ jobs:
         # otherwise it's a fresh attempt and tags must not exist.
         run: |
           set -euo pipefail
-          if ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" 2>/dev/null); then
+          err=$(mktemp)
+          trap 'rm -f "${err}"' EXIT
+          # Capture stderr so we can distinguish a real 404 (tag absent → fresh
+          # attempt) from any other failure (rate limit, 5xx, auth) which must
+          # not be silently treated as "tag missing".
+          if ref=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${VERSION}" 2>"${err}"); then
             sha=$(jq -r .object.sha <<<"${ref}")
             type=$(jq -r .object.type <<<"${ref}")
             if [[ "${type}" == "tag" ]]; then
@@ -87,12 +92,16 @@ jobs:
               echo "resume=true"
               echo "release_commit=${sha}"
             } >> "${GITHUB_OUTPUT}"
-          else
+          elif grep -qF "(HTTP 404)" "${err}"; then
             echo "resume=false" >> "${GITHUB_OUTPUT}"
             if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/caddy/v${VERSION}" --silent 2>/dev/null; then
               echo "::error::caddy/v${VERSION} exists but v${VERSION} does not; refusing to release into a split state."
               exit 1
             fi
+          else
+            echo "::error::GitHub API call for tag v${VERSION} failed:"
+            cat "${err}" >&2
+            exit 1
           fi
       - if: steps.state.outputs.resume != 'true'
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
## Summary

The resume detection in `release.yaml` only recognised a resume when `main` HEAD itself was the `chore: prepare release X [skip ci]` commit. If a follow-up commit landed on top — exactly what happened mid-1.12.3 release when #2421 and #2422 had to merge after the tag was created — HEAD was no longer the release commit and the workflow's tag-existence guard fired, refusing to resume even though tags + commit were already in main's history.

## Fix

Use tag existence as the resume signal instead. The tag `v<version>` is the actual artifact we're trying to land; whether main HEAD has advanced past it doesn't matter for the resume decision. The release commit SHA is read from the tag's object (with annotated-tag dereferencing).

A bare `caddy/v<version>` tag without `v<version>` still aborts as a split-state guard.

## Validation

This is the third workflow patch needed during the v1.12.3 dispatch (#2421 ARG_MAX, #2422 REST draft). With this in place, re-dispatching v1.12.3 should detect `resume=true`, skip PGO/bump/commit/tag (all already done), reach the now-fixed Draft step, create the draft via REST, dispatch downstreams, bump Homebrew. Run time ~30s.