### PR TITLE
fix(release): correct mislav/bump-homebrew-formula-action inputs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,7 +291,7 @@ jobs:
         uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: frankenphp
-          tap: dunglas/frankenphp
+          homebrew-tap: dunglas/homebrew-frankenphp
           tag-name: v${{ inputs.version }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.12.3 dispatch reached the Homebrew step and failed with `unexpected HTTP 403`:

```
Unexpected input(s) 'tap', valid inputs are ['formula-name', 'formula-path', 'tag-name', 'download-url', 'download-sha256', 'homebrew-tap', 'push-to', 'base-branch', 'create-pullrequest', 'create-branch', 'commit-message']
```

I used `tap:` but the v3 action's input is `homebrew-tap:`. The unknown `tap` was silently dropped, so the action defaulted to `Homebrew/homebrew-core` and the PAT (scoped to `dunglas/homebrew-frankenphp`) was rejected.

## Fix

- `tap:` → `homebrew-tap:`
- Value `dunglas/frankenphp` (the `brew` tap shorthand) → `dunglas/homebrew-frankenphp` (the repository name the action wants)

Run that hit the bug: https://github.com/php/frankenphp/actions/runs/25921778314