### PR TITLE
test(hotreload): tolerate (n>0, EOF) on Windows SSE read

### DIFF
--- a/caddy/hotreload_test.go
+++ b/caddy/hotreload_test.go
@@ -63,16 +63,20 @@ func TestHotReload(t *testing.T) {
 
 		buf := make([]byte, 1024)
 		for {
-			_, err := resp.Body.Read(buf)
-			require.NoError(t, err)
-
-			receivedBody.Write(buf)
-
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				receivedBody.Write(buf[:n])
+			}
 			if strings.Contains(receivedBody.String(), "index.php") {
 				cancel()
 
 				break
 			}
+			// Surface the read error only after checking the buffer: on
+			// Windows the SSE server sometimes flushes the event and closes
+			// the connection in the same syscall, so Read returns (n>0, EOF)
+			// and we'd otherwise fail despite having the data we wanted.
+			require.NoError(t, err)
 		}
 
 		require.NoError(t, resp.Body.Close())


### PR DESCRIPTION
## Summary

`TestHotReload` flakes on Windows CI. The Mercure SSE server sometimes flushes the matching event and closes the connection in the same syscall, so `resp.Body.Read` returns `(n > 0, io.EOF)`. The old code did `require.NoError(t, err)` *before* looking at the bytes already in the buffer, so the test failed despite having received exactly the data it was waiting for.

## Fix

- Write the `n` bytes from this read (only, not the full 1024-byte buffer — that was including stale data on every iteration anyway).
- Check the "index.php" marker.
- Surface `err` only if the marker wasn't found yet.

Verified locally — `TestHotReload` passes 3/3 with `-count=3`.

## Flaky run that prompted this

https://github.com/php/frankenphp/actions/runs/25921984946/job/76193101402 (PR #2424 Windows job)