### PR TITLE
fix(docker): respect github.ref_name when dispatched against a tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,7 +49,7 @@ jobs:
       php84_version: ${{ steps.check.outputs.php84_version }}
       php85_version: ${{ steps.check.outputs.php85_version }}
       skip: ${{ steps.check.outputs.skip }}
-      ref: ${{ steps.check.outputs.ref || (github.event_name == 'workflow_dispatch' && inputs.version) || '' }}
+      ref: ${{ steps.check.outputs.ref || (github.ref_type == 'tag' && github.ref_name) || (github.event_name == 'workflow_dispatch' && inputs.version) || '' }}
       base_fingerprint: ${{ steps.check.outputs.base_fingerprint }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

When the new release workflow dispatches `docker.yaml` against a freshly-created tag, every build job in the matrix fails at `actions/checkout@v6` with:

```
git fetch ... +refs/heads/1.12.3*:... +refs/tags/1.12.3*:...
The process '/usr/bin/git' failed with exit code 1
```

Root cause: the prepare job's `ref` output falls through to `inputs.version` (the bare `1.12.3` semver release.yaml passes alongside `--ref v1.12.3`). There's no ref named `1.12.3` on origin, so checkout errors out before anything else runs.

`windows.yaml` and `static.yaml` (REF computation) already check `github.ref_type == 'tag'` first and use `github.ref_name`. Mirror that pattern in `docker.yaml`'s prepare output.

## Effect

| Scenario | Before | After |
|---|---|---|
| Push of `v1.12.3` tag | works (falls through, checkout uses `github.ref`) | unchanged |
| Manual dispatch with `version=v1.12.3` from UI on main | works (`inputs.version` used) | unchanged |
| `gh workflow run docker.yaml --ref v1.12.3 -f version=1.12.3` (release.yaml's pattern) | fails: `ref=1.12.3` not found | works: `ref=v1.12.3` from `github.ref_name` |

## Run that hit the bug

https://github.com/php/frankenphp/actions/runs/25923390001 — every matrix job failed at checkout during v1.12.3 dispatch.

Needed before the v1.12.3 docker images can ship.