### PR TITLE
fix(docker): qualify attest subject with registry hostname

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -252,8 +252,17 @@ jobs:
           tag=$(jq -cr ".target.\"${TARGET}-${VARIANT}\".tags | first" <<< ${METADATA})
           docker buildx imagetools inspect "${tag}"
           digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${tag}")
+          # Qualify the image with the registry hostname so actions/attest
+          # can resolve the docker login from the previous step: it splits
+          # subject-name on the first '/', and an unqualified "dunglas/foo"
+          # makes it look for credentials under a registry literally named
+          # "dunglas".
+          name="${tag%%:*}"
+          if [[ "${name}" != *.*/* && "${name}" != *:*/* ]]; then
+            name="docker.io/${name}"
+          fi
           {
-            echo "name=${tag%%:*}"
+            echo "name=${name}"
             echo "digest=${digest}"
           } >> "${GITHUB_OUTPUT}"
         env:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -252,25 +252,15 @@ jobs:
           tag=$(jq -cr ".target.\"${TARGET}-${VARIANT}\".tags | first" <<< ${METADATA})
           docker buildx imagetools inspect "${tag}"
           digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${tag}")
-          # Qualify the image with the registry hostname so actions/attest
-          # can resolve the docker login from the previous step: it splits
-          # subject-name on the first '/', and an unqualified "dunglas/foo"
-          # makes it look for credentials under a registry literally named
-          # "dunglas".
-          name="${tag%%:*}"
-          if [[ "${name}" != *.*/* && "${name}" != *:*/* ]]; then
-            name="docker.io/${name}"
-          fi
-          {
-            echo "name=${name}"
-            echo "digest=${digest}"
-          } >> "${GITHUB_OUTPUT}"
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}
           TARGET: ${{ matrix.target }}
           VARIANT: ${{ matrix.variant }}
       - uses: actions/attest@v4
         with:
-          subject-name: ${{ steps.inspect.outputs.name }}
+          # docker.io/ prefix is required: actions/attest splits subject-name
+          # on the first '/' to find the registry. We only push to Docker Hub.
+          subject-name: docker.io/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
## Summary

The `actions/attest@v4` step I added in #2418 failed on the v1.12.3 docker push with:

```
Error: No credentials found for registry dunglas
```

The action splits `subject-name` on the first `/` to find the registry, so an unqualified `dunglas/frankenphp` makes it look up credentials under a registry literally named `dunglas`. `docker/login-action` had already authenticated against `docker.io` in the same job, but that login doesn't match the made-up hostname.

The bug was invisible during PR CI because the push job is gated on `needs.prepare.outputs.push` (false for PR events), so the attest step never ran until v1.12.3's real dispatch.

## Fix

Prepend `docker.io/` when the inspected tag's name has no registry segment. Detection mirrors Docker's own canonicalisation: the part before the first `/` is treated as a registry only when it contains `.` or `:`, otherwise it's a Docker Hub namespace.

## Impact

- **v1.12.3 docker images**: already pushed to Docker Hub (`docker.io/dunglas/frankenphp:1.12.3` and variants exist). They're just not attested. Acceptable for this release.
- **Future releases**: this PR fixes the attestation path so `gh attestation verify oci://docker.io/dunglas/frankenphp@sha256:... --owner php` will resolve.

Failing run: https://github.com/php/frankenphp/actions/runs/25944498602