### PR TITLE
test(hotreload): drop caddytest's 5s Client.Timeout

### DIFF
--- a/caddy/hotreload_test.go
+++ b/caddy/hotreload_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
 	"github.com/stretchr/testify/require"
@@ -25,10 +26,10 @@ func TestHotReload(t *testing.T) {
 	indexFile := filepath.Join(tmpDir, "index.php")
 
 	tester := caddytest.NewTester(t)
-	// The SSE roundtrip below can exceed caddytest's default 5s
-	// http.Client.Timeout on slow CI runners (notably emulated armv7).
-	// Cancellation via the request context terminates the read instead.
-	tester.Client.Timeout = 0
+	// caddytest's default 5s http.Client.Timeout is too tight for the
+	// SSE roundtrip below on slow CI runners (notably emulated armv7).
+	// 30s keeps the test bounded so a real regression fails fast.
+	tester.Client.Timeout = 30 * time.Second
 	tester.InitServer(`
 		{
 			debug

--- a/caddy/hotreload_test.go
+++ b/caddy/hotreload_test.go
@@ -25,6 +25,10 @@ func TestHotReload(t *testing.T) {
 	indexFile := filepath.Join(tmpDir, "index.php")
 
 	tester := caddytest.NewTester(t)
+	// The SSE roundtrip below can exceed caddytest's default 5s
+	// http.Client.Timeout on slow CI runners (notably emulated armv7).
+	// Cancellation via the request context terminates the read instead.
+	tester.Client.Timeout = 0
 	tester.InitServer(`
 		{
 			debug


### PR DESCRIPTION
## Root cause

`TestHotReload` was failing on https://github.com/php/frankenphp/actions/runs/25961840516/job/76318473726 (`linux/arm/v7`, dispatched from https://github.com/php/frankenphp/pull/2430) with:

> context deadline exceeded (Client.Timeout or context cancellation while reading body)

`caddytest.NewTester` initialises `tester.Client.Timeout = 5s` (`Default.TestRequestTimeout`). That budget covers the entire roundtrip including body reads. On an emulated armv7 runner the chain `os.WriteFile` → e-dant/watcher event → `mercure` publish → SSE chunk delivery doesn't complete in 5 s, so the streaming `resp.Body.Read` is killed before the marker `index.php` is seen. The job died at exactly 5.03 s.

## Fix

Set `tester.Client.Timeout = 0` for this test. The test already cancels the read via `context.WithCancel` once the marker appears in the buffer, and Go's `-timeout` provides the outer deadline — the 5 s inner cap was redundant.

The other failing job on that run (`linux/amd64`, e-dant/watcher cmake build) is unrelated to this PR.