### PR TITLE
build(docker): make e-dant/watcher install robust

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -158,6 +158,7 @@ jobs:
           VERSION: ${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref || 'dev' }}
           PHP_VERSION: ${{ needs.prepare.outputs.php_version }}
           BASE_FINGERPRINT: ${{ needs.prepare.outputs.base_fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
         name: Export metadata
         if: fromJson(needs.prepare.outputs.push)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update && \
 	apt-get -y --no-install-recommends install \
 	cmake \
 	git \
+	jq \
 	libargon2-dev \
 	libbrotli-dev \
 	libcurl4-openssl-dev \
@@ -81,23 +82,25 @@ RUN apt-get update && \
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN --mount=type=secret,id=github-token \
-    if [ -f /run/secrets/github-token ] && [ -s /run/secrets/github-token ]; then \
-        curl -s -H "Authorization: Bearer $(cat /run/secrets/github-token)" https://api.github.com/repos/e-dant/watcher/releases/latest; \
-    else \
-        curl -s https://api.github.com/repos/e-dant/watcher/releases/latest; \
-    fi | \
-    grep tarball_url | \
-    awk '{ print $2 }' | \
-    sed 's/,$//' | \
-    sed 's/"//g' | \
-    xargs curl -L | \
-    tar xz --strip-components 1 && \
-    # -Wno-error=use-after-free: GCC 12 on Bookworm i386 emits a spurious warning in libstdc++ basic_string.h
-    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-error=use-after-free" && \
-    cmake --build build && \
-    cmake --install build && \
-    ldconfig
+RUN --mount=type=secret,id=github-token <<'EOF'
+set -e
+api=https://api.github.com/repos/e-dant/watcher/releases/latest
+if [ -s /run/secrets/github-token ]; then
+    tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
+else
+    tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
+fi
+if [ -z "${tarball_url}" ]; then
+    echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
+    exit 1
+fi
+curl -fsSL "${tarball_url}" | tar xz --strip-components 1
+# -Wno-error=use-after-free: GCC 12 on Bookworm i386 emits a spurious warning in libstdc++ basic_string.h
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-error=use-after-free"
+cmake --build build
+cmake --install build
+ldconfig
+EOF
 
 WORKDIR /go/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,13 +86,13 @@ RUN --mount=type=secret,id=github-token <<'EOF'
 set -e
 api=https://api.github.com/repos/e-dant/watcher/releases/latest
 if [ -s /run/secrets/github-token ]; then
-    tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
+	tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
 else
-    tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
+	tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
 fi
 if [ -z "${tarball_url}" ]; then
-    echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
-    exit 1
+	echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
+	exit 1
 fi
 curl -fsSL "${tarball_url}" | tar xz --strip-components 1
 # -Wno-error=use-after-free: GCC 12 on Bookworm i386 emits a spurious warning in libstdc++ basic_string.h

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -93,13 +93,13 @@ RUN --mount=type=secret,id=github-token <<'EOF'
 set -e
 api=https://api.github.com/repos/e-dant/watcher/releases/latest
 if [ -s /run/secrets/github-token ]; then
-    tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
+	tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
 else
-    tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
+	tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
 fi
 if [ -z "${tarball_url}" ]; then
-    echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
-    exit 1
+	echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
+	exit 1
 fi
 curl -fsSL "${tarball_url}" | tar xz --strip-components 1
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -74,6 +74,7 @@ RUN apk add --no-cache --virtual .build-deps \
 	# Needed for the custom Go build \
 	git \
 	gnu-libiconv-dev \
+	jq \
 	libsodium-dev \
 	# Needed for the file watcher \
 	cmake \
@@ -88,21 +89,23 @@ RUN apk add --no-cache --virtual .build-deps \
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN --mount=type=secret,id=github-token \
-		if [ -f /run/secrets/github-token ] && [ -s /run/secrets/github-token ]; then \
-				curl -s -H "Authorization: Bearer $(cat /run/secrets/github-token)" https://api.github.com/repos/e-dant/watcher/releases/latest; \
-		else \
-				curl -s https://api.github.com/repos/e-dant/watcher/releases/latest; \
-		fi | \
-		grep tarball_url | \
-		awk '{ print $2 }' | \
-		sed 's/,$//' | \
-		sed 's/"//g' | \
-		xargs curl -L | \
-		tar xz --strip-components 1 && \
-		cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-		cmake --build build && \
-		cmake --install build
+RUN --mount=type=secret,id=github-token <<'EOF'
+set -e
+api=https://api.github.com/repos/e-dant/watcher/releases/latest
+if [ -s /run/secrets/github-token ]; then
+    tarball_url=$(curl -fsSL -H "Authorization: Bearer $(cat /run/secrets/github-token)" "${api}" | jq -r '.tarball_url // empty')
+else
+    tarball_url=$(curl -fsSL "${api}" | jq -r '.tarball_url // empty')
+fi
+if [ -z "${tarball_url}" ]; then
+    echo "failed to resolve e-dant/watcher tarball URL (rate limited?)" >&2
+    exit 1
+fi
+curl -fsSL "${tarball_url}" | tar xz --strip-components 1
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+cmake --install build
+EOF
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
## Root cause

`runner-php-8-3-31-trixie` on https://github.com/php/frankenphp/actions/runs/25961840516/job/76318473755 (PR https://github.com/php/frankenphp/pull/2430, `linux/amd64`) failed with:

> curl: (2) no URL specified
> tar: Child returned status 1

Two converging issues:

1. **`.github/workflows/docker.yaml` did not export `GITHUB_TOKEN` to the bake-action environment.** `docker-bake.hcl` declares `secret = [\"id=github-token,env=GITHUB_TOKEN\"]`, but the Build step's `env:` block only set `SHA`, `VERSION`, `PHP_VERSION`, `BASE_FINGERPRINT`. The secret mount resolved to empty, the watcher install fell into the unauthenticated branch, and parallel matrix jobs trivially hit GitHub's 60 req/hr unauth cap. `static.yaml`'s bake step already passes `GITHUB_TOKEN`; `docker.yaml` was the outlier.

2. **The watcher install pipeline silently swallows API errors.** `curl -s` (no `-f`) hides HTTP errors; `grep tarball_url | awk | sed | xargs curl -L | tar xz` produces empty output when the API response is anything other than a normal release JSON (rate limit message, 5xx, auth fail). `xargs curl -L` then runs with no URL, and `tar xz` gets empty stdin — yielding the opaque pair above with no signal as to why.

## Fix

- `docker.yaml`: pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the bake Build step's env block (mirrors `static.yaml`).
- `Dockerfile` and `alpine.Dockerfile`: install `jq`, rewrite the watcher install with `curl -fsSL` plus `jq -r '.tarball_url // empty'` and an explicit empty-URL check that prints a useful error. Heredoc form for readability; logic kept POSIX so it works under both `bash` (Debian) and `ash` (Alpine).

Cmake/build flags and final `ldconfig` step are unchanged.