### PR TITLE
chore(docker): use heredoc syntax for multi-step RUN blocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,30 +6,29 @@ FROM php-base AS common
 
 WORKDIR /app
 
-RUN apt-get update && \
-	apt-get -y --no-install-recommends install \
-		mailcap \
-		libcap2-bin \
-	&& \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+RUN <<EOF
+set -e
+apt-get update
+apt-get -y --no-install-recommends install mailcap libcap2-bin
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
 
-RUN set -eux; \
-	mkdir -p \
-		/app/public \
-		/config/caddy \
-		/data/caddy \
-		/etc/caddy \
-		/etc/frankenphp; \
-	sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint; \
-	echo '<?php phpinfo();' > /app/public/index.php
+RUN <<EOF
+set -eux
+mkdir -p /app/public /config/caddy /data/caddy /etc/caddy /etc/frankenphp
+sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint
+echo '<?php phpinfo();' > /app/public/index.php
+EOF
 
 COPY --link caddy/frankenphp/Caddyfile /etc/caddy/Caddyfile
-RUN ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile && \
-	curl -sSLf \
-		-o /usr/local/bin/install-php-extensions \
-		https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
-	chmod +x /usr/local/bin/install-php-extensions
+RUN <<EOF
+set -e
+ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile
+curl -sSLf -o /usr/local/bin/install-php-extensions \
+	https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions
+chmod +x /usr/local/bin/install-php-extensions
+EOF
 
 CMD ["--config", "/etc/frankenphp/Caddyfile", "--adapter", "caddyfile"]
 HEALTHCHECK CMD curl -f http://localhost:2019/metrics || exit 1
@@ -62,8 +61,10 @@ ENV PATH=/usr/local/go/bin:$PATH
 ENV GOTOOLCHAIN=local
 
 # This is required to link the FrankenPHP binary to the PHP binary
-RUN apt-get update && \
-	apt-get -y --no-install-recommends install \
+RUN <<EOF
+set -e
+apt-get update
+apt-get -y --no-install-recommends install \
 	cmake \
 	git \
 	libargon2-dev \
@@ -75,9 +76,9 @@ RUN apt-get update && \
 	libsqlite3-dev \
 	libssl-dev \
 	libxml2-dev \
-	zlib1g-dev \
-	&& \
-	apt-get clean
+	zlib1g-dev
+apt-get clean
+EOF
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
@@ -117,12 +118,14 @@ ENV CGO_CPPFLAGS=$PHP_CPPFLAGS
 ENV CGO_LDFLAGS="-L/usr/local/lib -lssl -lcrypto -lreadline -largon2 -lcurl -lonig -lz $PHP_LDFLAGS"
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN GOBIN=/usr/local/bin \
-	../../go.sh install -ldflags "-w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy' -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp' -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy'" -buildvcs=true && \
-	setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
-	cp Caddyfile /etc/frankenphp/Caddyfile && \
-	frankenphp version && \
- 	frankenphp build-info
+RUN <<EOF
+set -e
+GOBIN=/usr/local/bin ../../go.sh install -ldflags "-w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy' -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp' -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy'" -buildvcs=true
+setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp
+cp Caddyfile /etc/frankenphp/Caddyfile
+frankenphp version
+frankenphp build-info
+EOF
 
 WORKDIR /go/src/app
 
@@ -134,11 +137,17 @@ ENV GODEBUG=cgocheck=0
 # copy watcher shared library
 COPY --from=builder /usr/local/lib/libwatcher* /usr/local/lib/
 # fix for the file watcher on arm
-RUN apt-get install -y --no-install-recommends libstdc++6 && \
-	apt-get clean && \
-	ldconfig
+RUN <<EOF
+set -e
+apt-get install -y --no-install-recommends libstdc++6
+apt-get clean
+ldconfig
+EOF
 
 COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
-RUN setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
-	frankenphp version && \
-	frankenphp build-info
+RUN <<EOF
+set -e
+setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp
+frankenphp version
+frankenphp build-info
+EOF

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -8,28 +8,24 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-RUN apk add --no-cache \
-	ca-certificates \
-	libcap \
-	mailcap
+RUN apk add --no-cache ca-certificates libcap mailcap
 
-RUN set -eux; \
-	mkdir -p \
-		/app/public \
-		/config/caddy \
-		/data/caddy \
-		/etc/caddy \
-		/etc/frankenphp; \
-	sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint; \
-	echo '<?php phpinfo();' > /app/public/index.php
+RUN <<EOF
+set -eux
+mkdir -p /app/public /config/caddy /data/caddy /etc/caddy /etc/frankenphp
+sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint
+echo '<?php phpinfo();' > /app/public/index.php
+EOF
 
 COPY --link caddy/frankenphp/Caddyfile /etc/caddy/Caddyfile
 
-RUN ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile && \
-	curl -sSLf \
-		-o /usr/local/bin/install-php-extensions \
-		https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
-	chmod +x /usr/local/bin/install-php-extensions
+RUN <<EOF
+set -e
+ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile
+curl -sSLf -o /usr/local/bin/install-php-extensions \
+	https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions
+chmod +x /usr/local/bin/install-php-extensions
+EOF
 
 CMD ["--config", "/etc/frankenphp/Caddyfile", "--adapter", "caddyfile"]
 HEALTHCHECK CMD curl -f http://localhost:2019/metrics || exit 1
@@ -122,12 +118,13 @@ ENV CGO_CPPFLAGS=$PHP_CPPFLAGS
 ENV CGO_LDFLAGS="-lssl -lcrypto -lreadline -largon2 -lcurl -lonig -lz $PHP_LDFLAGS"
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN GOBIN=/usr/local/bin \
-		../../go.sh install -ldflags "-w -s -extldflags '-Wl,-z,stack-size=0x80000' -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy' -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp' -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy'" -buildvcs=true && \
-	setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
-	([ -z "${NO_COMPRESS}" ] && upx --best /usr/local/bin/frankenphp || true) && \
-	frankenphp version && \
-	frankenphp build-info
+RUN <<EOF
+GOBIN=/usr/local/bin ../../go.sh install -ldflags "-w -s -extldflags '-Wl,-z,stack-size=0x80000' -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy' -X 'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp' -X 'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy'" -buildvcs=true
+setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp
+[ -z "${NO_COMPRESS}" ] && upx --best /usr/local/bin/frankenphp || true
+frankenphp version
+frankenphp build-info
+EOF
 
 WORKDIR /go/src/app
 
@@ -138,10 +135,16 @@ ENV GODEBUG=cgocheck=0
 
 # copy watcher shared library (libgcc and libstdc++ are needed for the watcher)
 COPY --from=builder /usr/local/lib/libwatcher* /usr/local/lib/
-RUN apk add --no-cache libstdc++ && \
-	ldconfig /usr/local/lib
+RUN <<EOF
+set -e
+apk add --no-cache libstdc++
+ldconfig /usr/local/lib
+EOF
 
 COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
-RUN setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
-	frankenphp version && \
-	frankenphp build-info
+RUN <<EOF
+set -e
+setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp
+frankenphp version
+frankenphp build-info
+EOF

--- a/dev-alpine.Dockerfile
+++ b/dev-alpine.Dockerfile
@@ -18,7 +18,9 @@ ENV PHPIZE_DEPS="\
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk add --no-cache \
+# hadolint ignore=SC2086
+RUN <<EOF
+apk add --no-cache \
 	$PHPIZE_DEPS \
 	argon2-dev \
 	brotli-dev \
@@ -32,10 +34,8 @@ RUN apk add --no-cache \
 	zlib-dev \
 	bison \
 	nss-tools \
-	# file watcher \
 	libstdc++ \
 	linux-headers \
-	# Dev tools \
 	git \
 	clang \
 	cmake \
@@ -44,36 +44,41 @@ RUN apk add --no-cache \
 	valgrind \
 	neovim \
 	zsh \
-	libtool && \
-	echo 'set auto-load safe-path /' > /root/.gdbinit
+	libtool
+echo 'set auto-load safe-path /' > /root/.gdbinit
+EOF
 
 WORKDIR /usr/local/src/php
-RUN git clone --branch=PHP-8.5 https://github.com/php/php-src.git . && \
-	# --enable-embed is necessary to generate libphp.so, but we don't use this SAPI directly
-	./buildconf --force && \
-	EXTENSION_DIR=/usr/lib/frankenphp/modules ./configure \
-		--enable-embed \
-		--enable-zts \
-		--disable-zend-signals \
-		--enable-zend-max-execution-timers \
-		--with-config-file-path=/etc/frankenphp/php.ini \
-		--with-config-file-scan-dir=/etc/frankenphp/php.d \
-		--enable-debug && \
-	make -j"$(nproc)" && \
-	make install && \
-	ldconfig /etc/ld.so.conf.d && \
-		mkdir -p /etc/frankenphp/php.d && \
-			cp php.ini-development /etc/frankenphp/php.ini && \
-			echo "zend_extension=opcache.so" >> /etc/frankenphp/php.ini && \
-			echo "opcache.enable=1" >> /etc/frankenphp/php.ini && \
-	php --version
+RUN <<EOF
+git clone --branch=PHP-8.5 https://github.com/php/php-src.git .
+# --enable-embed is necessary to generate libphp.so, but we don't use this SAPI directly
+./buildconf --force
+EXTENSION_DIR=/usr/lib/frankenphp/modules ./configure \
+	--enable-embed \
+	--enable-zts \
+	--disable-zend-signals \
+	--enable-zend-max-execution-timers \
+	--with-config-file-path=/etc/frankenphp/php.ini \
+	--with-config-file-scan-dir=/etc/frankenphp/php.d \
+	--enable-debug
+make -j"$(nproc)"
+make install
+ldconfig /etc/ld.so.conf.d
+mkdir -p /etc/frankenphp/php.d
+cp php.ini-development /etc/frankenphp/php.ini
+echo "zend_extension=opcache.so" >> /etc/frankenphp/php.ini
+echo "opcache.enable=1" >> /etc/frankenphp/php.ini
+php --version
+EOF
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN git clone https://github.com/e-dant/watcher . && \
-		cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-	cmake --build build/ && \
-	cmake --install build
+RUN <<EOF
+git clone https://github.com/e-dant/watcher .
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build/
+cmake --install build
+EOF
 
 WORKDIR /go/src/app
 COPY . .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,9 +18,11 @@ ENV PHPIZE_DEPS="\
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# hadolint ignore=DL3009
-RUN apt-get update && \
-	apt-get -y --no-install-recommends install \
+# hadolint ignore=DL3009,SC2086
+RUN <<EOF
+set -e
+apt-get update
+apt-get -y --no-install-recommends install \
 	$PHPIZE_DEPS \
 	libargon2-dev \
 	libbrotli-dev \
@@ -34,7 +36,6 @@ RUN apt-get update && \
 	zlib1g-dev \
 	bison \
 	libnss3-tools \
-	# Dev tools \
 	git \
 	clang \
 	cmake \
@@ -43,41 +44,47 @@ RUN apt-get update && \
 	valgrind \
 	neovim \
 	zsh \
-	libtool-bin && \
-	echo 'set auto-load safe-path /' > /root/.gdbinit && \
-	echo '* soft core unlimited' >> /etc/security/limits.conf \
-	&& \
-	apt-get clean
+	libtool-bin
+echo 'set auto-load safe-path /' > /root/.gdbinit
+echo '* soft core unlimited' >> /etc/security/limits.conf
+apt-get clean
+EOF
 
 WORKDIR /usr/local/src/php
-RUN git clone --branch=PHP-8.5 https://github.com/php/php-src.git . && \
-	# --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
-	./buildconf --force && \
-	EXTENSION_DIR=/usr/lib/frankenphp/modules ./configure \
-		--enable-embed \
-		--enable-zts \
-		--disable-zend-signals \
-		--enable-zend-max-execution-timers \
-		--with-config-file-path=/etc/frankenphp/php.ini \
-		--with-config-file-scan-dir=/etc/frankenphp/php.d \
-		--enable-debug && \
-	make -j"$(nproc)" && \
-	make install && \
-	ldconfig && \
-		mkdir -p /etc/frankenphp/php.d && \
-			cp php.ini-development /etc/frankenphp/php.ini && \
-			echo "zend_extension=opcache.so" >> /etc/frankenphp/php.ini && \
-			echo "opcache.enable=1" >> /etc/frankenphp/php.ini && \
-	php --version
+RUN <<EOF
+set -e
+git clone --branch=PHP-8.5 https://github.com/php/php-src.git .
+# --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
+./buildconf --force
+EXTENSION_DIR=/usr/lib/frankenphp/modules ./configure \
+	--enable-embed \
+	--enable-zts \
+	--disable-zend-signals \
+	--enable-zend-max-execution-timers \
+	--with-config-file-path=/etc/frankenphp/php.ini \
+	--with-config-file-scan-dir=/etc/frankenphp/php.d \
+	--enable-debug
+make -j"$(nproc)"
+make install
+ldconfig
+mkdir -p /etc/frankenphp/php.d
+cp php.ini-development /etc/frankenphp/php.ini
+echo "zend_extension=opcache.so" >> /etc/frankenphp/php.ini
+echo "opcache.enable=1" >> /etc/frankenphp/php.ini
+php --version
+EOF
 
 # Install e-dant/watcher (necessary for file watching)
 WORKDIR /usr/local/src/watcher
-RUN git clone https://github.com/e-dant/watcher . && \
-	cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-	cmake --build build/ && \
-	cmake --install build && \
-	cp build/libwatcher-c.so /usr/local/lib/libwatcher-c.so && \
-	ldconfig
+RUN <<EOF
+set -e
+git clone https://github.com/e-dant/watcher .
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build/
+cmake --install build
+cp build/libwatcher-c.so /usr/local/lib/libwatcher-c.so
+ldconfig
+EOF
 
 WORKDIR /go/src/app
 COPY --link . ./

--- a/static-builder-gnu.Dockerfile
+++ b/static-builder-gnu.Dockerfile
@@ -43,78 +43,87 @@ LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.vendor="Kévin Dunglas"
 
 # yum update
-RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
-	sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
-	sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo && \
-	yum clean all && \
-	yum makecache && \
-	yum update -y && \
-	yum install -y centos-release-scl
+RUN <<EOF
+set -e
+sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo
+sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo
+sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+yum clean all
+yum makecache
+yum update -y
+yum install -y centos-release-scl
+EOF
 
 # different arch for different scl repo
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-		sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo ; \
-		sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo ; \
-		sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo ; \
-		sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo ; \
-	else \
-		sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo ; \
-		sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo ; \
-		sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo ; \
-	fi; \
-	yum update -y && \
-	yum install -y devtoolset-10-gcc-* && \
-	echo "source scl_source enable devtoolset-10" >> /etc/bashrc && \
-	source /etc/bashrc
+RUN <<EOF
+set -e
+if [ "$(uname -m)" = "aarch64" ]; then
+	sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+	sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo
+	sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo
+	sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+else
+	sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo
+	sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo
+	sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+fi
+yum update -y
+yum install -y devtoolset-10-gcc-*
+echo "source scl_source enable devtoolset-10" >> /etc/bashrc
+source /etc/bashrc
+EOF
 
 # install build essentials
-RUN yum install -y \
-		perl \
-		make \
-		bison \
-		flex \
-		git \
-		autoconf \
-		automake \
-		tar \
-		unzip \
-		gzip \
-		gcc \
-		bzip2 \
-		patch \
-		xz \
-		libtool \
-		perl-IPC-Cmd ; \
-	curl -o make.tar.gz -fsSL https://ftp.gnu.org/gnu/make/make-4.4.tar.gz && \
-	tar -zxvf make.tar.gz && \
-	cd make-* && \
-	./configure && \
-	make && \
-	make install && \
-	ln -sf /usr/local/bin/make /usr/bin/make && \
-	cd .. && \
-	rm -Rf make* && \
-	curl -o cmake.tar.gz -fsSL https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-$(uname -m).tar.gz && \
-	mkdir /cmake && \
-	tar -xzf cmake.tar.gz -C /cmake --strip-components 1 && \
-	rm cmake.tar.gz && \
-	curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$(uname -m).tar.gz && \
-	mkdir -p /patchelf && \
-	tar -xzf patchelf.tar.gz -C /patchelf --strip-components=1 && \
-	cp /patchelf/bin/patchelf /usr/bin/ && \
-	rm patchelf.tar.gz && \
-	if [ "$(uname -m)" = "aarch64" ]; then \
-		GO_ARCH="arm64" ; \
-	else \
-		GO_ARCH="amd64" ; \
-	fi; \
-	curl -o /usr/local/bin/jq -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${GO_ARCH} && \
-	chmod +x /usr/local/bin/jq && \
-	curl -o go.tar.gz -fsSL https://go.dev/dl/$(curl -fsS https://go.dev/dl/?mode=json | jq -r "first(first(.[] | select(.stable and (.version | startswith(\"go${GO_VERSION}\")))).files[] | select(.os == \"linux\" and (.kind == \"archive\") and (.arch == \"${GO_ARCH}\"))).filename") && \
-	rm -rf /usr/local/go && \
-	tar -C /usr/local -xzf go.tar.gz && \
-	rm go.tar.gz && \
-	/usr/local/go/bin/go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+RUN <<EOF
+set -e
+yum install -y \
+	perl \
+	make \
+	bison \
+	flex \
+	git \
+	autoconf \
+	automake \
+	tar \
+	unzip \
+	gzip \
+	gcc \
+	bzip2 \
+	patch \
+	xz \
+	libtool \
+	perl-IPC-Cmd
+curl -o make.tar.gz -fsSL https://ftp.gnu.org/gnu/make/make-4.4.tar.gz
+tar -zxvf make.tar.gz
+cd make-*
+./configure
+make
+make install
+ln -sf /usr/local/bin/make /usr/bin/make
+cd ..
+rm -Rf make*
+curl -o cmake.tar.gz -fsSL "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-$(uname -m).tar.gz"
+mkdir /cmake
+tar -xzf cmake.tar.gz -C /cmake --strip-components 1
+rm cmake.tar.gz
+curl -fsSL -o patchelf.tar.gz "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$(uname -m).tar.gz"
+mkdir -p /patchelf
+tar -xzf patchelf.tar.gz -C /patchelf --strip-components=1
+cp /patchelf/bin/patchelf /usr/bin/
+rm patchelf.tar.gz
+if [ "$(uname -m)" = "aarch64" ]; then
+	GO_ARCH="arm64"
+else
+	GO_ARCH="amd64"
+fi
+curl -o /usr/local/bin/jq -fsSL "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${GO_ARCH}"
+chmod +x /usr/local/bin/jq
+curl -o go.tar.gz -fsSL "https://go.dev/dl/$(curl -fsS https://go.dev/dl/?mode=json | jq -r "first(first(.[] | select(.stable and (.version | startswith(\"go${GO_VERSION}\")))).files[] | select(.os == \"linux\" and (.kind == \"archive\") and (.arch == \"${GO_ARCH}\"))).filename")"
+rm -rf /usr/local/go
+tar -C /usr/local -xzf go.tar.gz
+rm go.tar.gz
+/usr/local/go/bin/go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+EOF
 
 ENV PATH="/opt/rh/devtoolset-10/root/usr/bin:/cmake/bin:/usr/local/go/bin:$PATH"
 

--- a/static-builder-musl.Dockerfile
+++ b/static-builder-musl.Dockerfile
@@ -40,51 +40,53 @@ LABEL org.opencontainers.image.source=https://github.com/php/frankenphp
 LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.vendor="Kévin Dunglas"
 
-RUN apk update; \
-	apk add --no-cache \
-		alpine-sdk \
-		autoconf \
-		automake \
-		bash \
-		binutils \
-		bison \
-		build-base \
-		cmake \
-		curl \
-		file \
-		flex \
-		g++ \
-		gcc \
-		git \
-		jq \
-		libgcc \
-		libstdc++ \
-		libtool \
-		linux-headers \
-		m4 \
-		make \
-		pkgconfig \
-		php84 \
-		php84-common \
-		php84-ctype \
-		php84-curl \
-		php84-dom \
-		php84-iconv \
-		php84-mbstring \
-		php84-openssl \
-		php84-pcntl \
-		php84-phar \
-		php84-posix \
-		php84-session \
-		php84-sodium \
-		php84-tokenizer \
-		php84-xml \
-		php84-xmlwriter \
-		upx \
-		wget \
-		xz ; \
-	ln -sf /usr/bin/php84 /usr/bin/php && \
-	go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+RUN <<EOF
+apk update
+apk add --no-cache \
+	alpine-sdk \
+	autoconf \
+	automake \
+	bash \
+	binutils \
+	bison \
+	build-base \
+	cmake \
+	curl \
+	file \
+	flex \
+	g++ \
+	gcc \
+	git \
+	jq \
+	libgcc \
+	libstdc++ \
+	libtool \
+	linux-headers \
+	m4 \
+	make \
+	pkgconfig \
+	php84 \
+	php84-common \
+	php84-ctype \
+	php84-curl \
+	php84-dom \
+	php84-iconv \
+	php84-mbstring \
+	php84-openssl \
+	php84-pcntl \
+	php84-phar \
+	php84-posix \
+	php84-session \
+	php84-sodium \
+	php84-tokenizer \
+	php84-xml \
+	php84-xmlwriter \
+	upx \
+	wget \
+	xz
+ln -sf /usr/bin/php84 /usr/bin/php
+go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+EOF
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1


### PR DESCRIPTION
## Summary

Converts multi-command RUN instructions across all six Dockerfiles from \\-continuation + && chains to \`<<EOF\` heredoc form:

- \`Dockerfile\`
- \`alpine.Dockerfile\`
- \`dev.Dockerfile\`
- \`dev-alpine.Dockerfile\`
- \`static-builder-musl.Dockerfile\`
- \`static-builder-gnu.Dockerfile\`

Each step becomes one command per line — easier to scan, easier to diff, and no more trailing-backslash bookkeeping.

## Notes

- Heredoc bodies start with \`set -e\` where the SHELL directive doesn't already imply errexit (the bash builders in \`Dockerfile\`, \`dev.Dockerfile\`, and \`static-builder-gnu.Dockerfile\`). The ash-based SHELLs in alpine variants already include \`-e\` so it stays implicit there.
- Behavior should be unchanged — same commands, same order. The only structural shift is the \`if/then/else\` block in \`static-builder-gnu.Dockerfile\`'s arch detection, which is rewritten without trailing \`\\\` and \`;\` continuations.
- The e-dant/watcher install block in \`Dockerfile\` and \`alpine.Dockerfile\` is intentionally left alone — https://github.com/php/frankenphp/pull/2432 already converts those specifically. Both PRs touch adjacent regions but disjoint line ranges, so a 3-way merge resolves cleanly whichever lands first.