### PR TITLE
test: wait for transition goroutines to exit

### DIFF
--- a/phpmainthread_test.go
+++ b/phpmainthread_test.go
@@ -95,8 +95,9 @@ func TestTransitionThreadsWhileDoingRequests(t *testing.T) {
 	t.Cleanup(Shutdown)
 
 	var (
-		isDone atomic.Bool
-		wg     sync.WaitGroup
+		isDone        atomic.Bool
+		wg            sync.WaitGroup
+		transitionsWG sync.WaitGroup
 	)
 
 	numThreads := 10
@@ -122,8 +123,10 @@ func TestTransitionThreadsWhileDoingRequests(t *testing.T) {
 
 	// try all possible permutations of transition, transition every ms
 	transitions := allPossibleTransitions(worker1Path, worker2Path)
+	transitionsWG.Add(numThreads)
 	for i := range numThreads {
 		go func(thread *phpThread, start int) {
+			defer transitionsWG.Done()
 			for {
 				for j := start; j < len(transitions); j++ {
 					if isDone.Load() {
@@ -158,6 +161,9 @@ func TestTransitionThreadsWhileDoingRequests(t *testing.T) {
 	// we are finished as soon as all 1000 requests are done
 	wg.Wait()
 	isDone.Store(true)
+	// wait for transition goroutines to exit before Shutdown to avoid them
+	// racing with a subsequent test's initPHPThreads via mainThread.state
+	transitionsWG.Wait()
 }
 
 func TestFinishBootingAWorkerScript(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestTransitionThreadsWhileDoingRequests` spawned 10 transition goroutines that loop calling `thread.shutdown()` (which reads `mainThread.state` at https://github.com/php/frankenphp/blob/main/phpthread.go#L133). `isDone.Store(true)` told them to stop, but the test returned without waiting, so a goroutine could still be inside `shutdown()` when the next test (`TestFinishBootingAWorkerScript`) called `initPHPThreads` and wrote a fresh `mainThread.state` — producing the macOS `-race` failure seen in https://github.com/php/frankenphp/actions/runs/26035637665/job/76532863576.

Tracked the transition goroutines with a `sync.WaitGroup` and wait on it after `isDone.Store(true)`.