### PR TITLE
refactor: drop space-to-underscore replacement in header names

### DIFF
--- a/internal/phpheaders/phpheaders.go
+++ b/internal/phpheaders/phpheaders.go
@@ -120,8 +120,8 @@ var CommonRequestHeaders = map[string]string{
 // Cache up to 256 uncommon headers
 // This is ~2.5x faster than converting the header each time
 var (
-	headerKeyCache     = otter.Must[string, string](&otter.Options[string, string]{MaximumSize: 256})
-	headerNameReplacer = strings.NewReplacer(" ", "_", "-", "_")
+	headerKeyCache     = otter.Must(&otter.Options[string, string]{MaximumSize: 256})
+	headerNameReplacer = strings.NewReplacer("-", "_")
 	loader             = otter.LoaderFunc[string, string](func(_ context.Context, key string) (string, error) {
 		return "HTTP_" + headerNameReplacer.Replace(strings.ToUpper(key)) + "\x00", nil
 	})

--- a/internal/phpheaders/phpheaders_test.go
+++ b/internal/phpheaders/phpheaders_test.go
@@ -1,10 +1,15 @@
 package phpheaders
 
 import (
+	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllCommonHeadersAreCorrect(t *testing.T) {
@@ -19,4 +24,26 @@ func TestAllCommonHeadersAreCorrect(t *testing.T) {
 		fakeRequest.Header.Add(header, "foo")
 		assert.Contains(t, fakeRequest.Header, header, "header is not correctly capitalized: "+header)
 	}
+}
+
+// Go's net/http server rejects header names containing spaces with a 400 response
+// before the request reaches the handler, so headerNameReplacer does not need to
+// translate spaces to underscores.
+func TestHeaderWithSpaceIsRejectedByNetHTTP(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("handler should not be reached, got headers: %v", r.Header)
+	}))
+	defer ts.Close()
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\nBad Header: x\r\nConnection: close\r\n\r\n"))
+	require.NoError(t, err)
+
+	resp, err := io.ReadAll(conn)
+	require.NoError(t, err)
+	assert.Contains(t, string(resp), "400 Bad Request")
+	assert.Contains(t, string(resp), "invalid header name")
 }

--- a/internal/phpheaders/phpheaders_test.go
+++ b/internal/phpheaders/phpheaders_test.go
@@ -33,11 +33,11 @@ func TestHeaderWithSpaceIsRejectedByNetHTTP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("handler should not be reached, got headers: %v", r.Header)
 	}))
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	conn, err := net.Dial("tcp", strings.TrimPrefix(ts.URL, "http://"))
 	require.NoError(t, err)
-	defer func() { require.NoError(t, conn.Close()) }()
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 	_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\nBad Header: x\r\nConnection: close\r\n\r\n"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Drop `" " -> "_"` from `headerNameReplacer`: Go's net/http rejects header names containing spaces with `400 Bad Request: invalid header name` before requests reach the handler, so the branch is unreachable.
- Drop unused explicit type parameters on `otter.Must`.
- Add `TestHeaderWithSpaceIsRejectedByNetHTTP` proving the rejection happens at the net/http layer.