### PR TITLE
fix: dash-form headers win over underscore variants in $_SERVER

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -158,16 +158,35 @@ func addKnownVariablesToServer(fc *frankenPHPContext, trackVarsArray *C.zval) {
 }
 
 func addHeadersToServer(ctx context.Context, request *http.Request, trackVarsArray *C.zval) {
+	// Register common headers first so the dash form wins any collision with an
+	// uncommon underscore variant (e.g. X_Forwarded_For spoofing X-Forwarded-For).
+	var claimedCommonKeys map[string]struct{}
 	for field, val := range request.Header {
-		if k := commonHeaders[field]; k != nil {
-			v := strings.Join(val, ", ")
-			C.frankenphp_register_known_variable(k, toUnsafeChar(v), C.size_t(len(v)), trackVarsArray)
+		k := commonHeaders[field]
+		if k == nil {
 			continue
 		}
 
-		// if the header name could not be cached, it needs to be registered safely
-		// this is more inefficient but allows additional sanitizing by PHP
-		k := phpheaders.GetUnCommonHeader(ctx, field)
+		v := strings.Join(val, ", ")
+		C.frankenphp_register_known_variable(k, toUnsafeChar(v), C.size_t(len(v)), trackVarsArray)
+
+		if claimedCommonKeys == nil {
+			claimedCommonKeys = make(map[string]struct{}, len(request.Header))
+		}
+		claimedCommonKeys[phpheaders.CommonRequestHeaders[field]] = struct{}{}
+	}
+
+	for field, val := range request.Header {
+		if commonHeaders[field] != nil {
+			continue
+		}
+
+		// uncommon header names must be registered safely to allow PHP sanitizing
+		k, drop := phpheaders.UncommonHeaderKey(ctx, field, claimedCommonKeys)
+		if drop {
+			continue
+		}
+
 		v := strings.Join(val, ", ")
 		C.frankenphp_register_variable_safe(toUnsafeChar(k), toUnsafeChar(v), C.size_t(len(v)), trackVarsArray)
 	}

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -1043,6 +1043,27 @@ func testRejectInvalidHeaders(t *testing.T, opts *testOptions) {
 	}
 }
 
+func TestUnderscoreHeaderCannotSpoofDashForm_module(t *testing.T) {
+	testUnderscoreHeaderCannotSpoofDashForm(t, &testOptions{})
+}
+func TestUnderscoreHeaderCannotSpoofDashForm_worker(t *testing.T) {
+	testUnderscoreHeaderCannotSpoofDashForm(t, &testOptions{workerScript: "server-variable.php"})
+}
+
+// Regression test: a client's underscore header (X_Forwarded_For) must not
+// overwrite the dash form (X-Forwarded-For) set by a trusted proxy.
+func testUnderscoreHeaderCannotSpoofDashForm(t *testing.T, opts *testOptions) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		req := httptest.NewRequest("GET", "http://example.com/server-variable.php", nil)
+		req.Header.Set("X-Forwarded-For", "9.9.9.9")
+		req.Header.Set("X_Forwarded_For", "1.2.3.4")
+		body, _ := testRequest(req, handler, t)
+
+		assert.Contains(t, body, "[HTTP_X_FORWARDED_FOR] => 9.9.9.9")
+		assert.NotContains(t, body, "1.2.3.4")
+	}, opts)
+}
+
 func TestFlushEmptyResponse_module(t *testing.T) { testFlushEmptyResponse(t, &testOptions{}) }
 func TestFlushEmptyResponse_worker(t *testing.T) {
 	testFlushEmptyResponse(t, &testOptions{workerScript: "only-headers.php"})

--- a/internal/phpheaders/phpheaders.go
+++ b/internal/phpheaders/phpheaders.go
@@ -135,3 +135,18 @@ func GetUnCommonHeader(ctx context.Context, key string) string {
 
 	return phpHeaderKey
 }
+
+// UncommonHeaderKey returns the NUL-terminated $_SERVER key for a header not in
+// CommonRequestHeaders. drop is true when that key is already claimed by a
+// common (dash-form) header, so an underscore variant like X_Forwarded_For
+// cannot overwrite the dash form's value.
+func UncommonHeaderKey(ctx context.Context, field string, claimedCommonKeys map[string]struct{}) (key string, drop bool) {
+	key = GetUnCommonHeader(ctx, field)
+	if claimedCommonKeys == nil {
+		return key, false
+	}
+
+	_, drop = claimedCommonKeys[strings.TrimSuffix(key, "\x00")]
+
+	return key, drop
+}

--- a/internal/phpheaders/phpheaders_test.go
+++ b/internal/phpheaders/phpheaders_test.go
@@ -26,6 +26,24 @@ func TestAllCommonHeadersAreCorrect(t *testing.T) {
 	}
 }
 
+// Regression test for underscore-header spoofing: an underscore variant must
+// not overwrite the $_SERVER key claimed by its dash form.
+func TestUncommonHeaderKeyDashFormWins(t *testing.T) {
+	ctx := t.Context()
+	claimed := map[string]struct{}{CommonRequestHeaders["X-Forwarded-For"]: {}}
+
+	key, drop := UncommonHeaderKey(ctx, "X_forwarded_for", claimed)
+	assert.Equal(t, "HTTP_X_FORWARDED_FOR\x00", key)
+	assert.True(t, drop, "underscore variant must be dropped when the dash form is present")
+
+	// no dash form present: still registers (no regression)
+	_, drop = UncommonHeaderKey(ctx, "X_forwarded_for", nil)
+	assert.False(t, drop)
+
+	_, drop = UncommonHeaderKey(ctx, "X-My-Custom", claimed)
+	assert.False(t, drop)
+}
+
 // Go's net/http server rejects header names containing spaces with a 400 response
 // before the request reaches the handler, so headerNameReplacer does not need to
 // translate spaces to underscores.


### PR DESCRIPTION
net/http delivers `X_Forwarded_For` and `X-Forwarded-For` as distinct fields, but both canonicalize to the same `$_SERVER` key `HTTP_X_FORWARDED_FOR`. FrankenPHP registers common (dash-form) and uncommon (underscore-form) headers through separate paths while iterating `request.Header`, a Go map with randomized order, so when a request carries both forms the surviving value depends on iteration order.

A client can then land its underscore value in a key an operator trusts only from the dash form a reverse proxy sets after stripping the client copy. Same for `X-Real-Ip`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and other proxy headers.

Fix: register dash-form headers first and record the keys they claim, then drop any uncommon header whose key is already claimed. The dash form wins deterministically; uncommon headers with no common counterpart still register, so normal traffic is unaffected.