### PR TITLE
fix: avoid out-of-bounds read when parsing the response status line

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -954,16 +954,12 @@ static int frankenphp_send_headers(sapi_headers_struct *sapi_headers) {
     return SAPI_HEADER_SENT_SUCCESSFULLY;
   }
 
-  int status;
-
-  if (SG(sapi_headers).http_status_line) {
-    status = atoi((SG(sapi_headers).http_status_line) + 9);
-  } else {
-    status = SG(sapi_headers).http_response_code;
-
-    if (!status) {
-      status = 200;
-    }
+  /* Use the response code PHP already parsed; reparsing http_status_line with
+   * a fixed +9 offset read out of bounds for lines shorter than 9 bytes, e.g.
+   * header("HTTP/"). */
+  int status = SG(sapi_headers).http_response_code;
+  if (!status) {
+    status = 200;
   }
 
   bool success = go_write_headers(frankenphp_thread_index(), status,

--- a/statusline_test.go
+++ b/statusline_test.go
@@ -1,0 +1,45 @@
+package frankenphp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/require"
+)
+
+func serveStatusScript(t *testing.T, script string) *http.Response {
+	t.Helper()
+
+	cwd, _ := os.Getwd()
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/"+script, nil)
+	fr, err := frankenphp.NewRequestWithContext(req,
+		frankenphp.WithRequestDocumentRoot(cwd+"/testdata/", false))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	require.NoError(t, frankenphp.ServeHTTP(w, fr))
+
+	return w.Result()
+}
+
+// A status line shorter than 9 bytes (e.g. header("HTTP/")) once made
+// frankenphp_send_headers read out of bounds via atoi(http_status_line + 9).
+// Run under -asan to catch a regression.
+func TestShortStatusLineDoesNotOverflow(t *testing.T) {
+	require.NoError(t, frankenphp.Init())
+	defer frankenphp.Shutdown()
+
+	resp := serveStatusScript(t, "short-status-line.php")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestCustomStatusLineIsHonored(t *testing.T) {
+	require.NoError(t, frankenphp.Init())
+	defer frankenphp.Shutdown()
+
+	resp := serveStatusScript(t, "custom-status-line.php")
+	require.Equal(t, http.StatusTeapot, resp.StatusCode)
+}

--- a/testdata/custom-status-line.php
+++ b/testdata/custom-status-line.php
@@ -1,0 +1,4 @@
+<?php
+
+header('HTTP/1.1 418 I am a teapot');
+echo 'ok';

--- a/testdata/short-status-line.php
+++ b/testdata/short-status-line.php
@@ -1,0 +1,5 @@
+<?php
+
+// A status line shorter than 9 bytes must not crash header dispatch.
+header('HTTP/');
+echo 'ok';


### PR DESCRIPTION
`frankenphp_send_headers` parsed the status with `atoi(http_status_line + 9)`, assuming a fixed 9-byte `"HTTP/x.y "` prefix. `header("HTTP/")` (5 bytes) makes `+9` read past the buffer. ASan confirms a heap-buffer-overflow read in `atoi`, 3 bytes past the `estrndup`'d line.

PHP already parses the code into `http_response_code` (via `sapi_update_response_code()`), so the reparse was redundant and unsafe. Use it directly. Tests in `statusline_test.go` (run under `-asan`) cover the short line and a valid `HTTP/1.1 418` line.