### PR TITLE
feat: add WithRequestBodyTimeout to bound slow request bodies

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -5,6 +5,7 @@ package caddy
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -13,6 +14,11 @@ import (
 const (
 	defaultDocumentRoot = "public"
 	defaultWatchPattern = "./**/*.{env,php,twig,yaml,yml}"
+
+	// defaultRequestBodyTimeout is the idle timeout applied to request body
+	// reads when the directive is omitted; mirrors nginx's client_body_timeout.
+	// Set request_body_timeout to 0 to disable.
+	defaultRequestBodyTimeout = caddy.Duration(60 * time.Second)
 )
 
 func init() {

--- a/caddy/config_test.go
+++ b/caddy/config_test.go
@@ -111,7 +111,22 @@ func TestModuleRequestBodyTimeout(t *testing.T) {
 	module := &FrankenPHPModule{}
 
 	require.NoError(t, module.UnmarshalCaddyfile(d))
-	require.Equal(t, caddy.Duration(5*time.Second), module.RequestBodyTimeout)
+	require.NotNil(t, module.RequestBodyTimeout)
+	require.Equal(t, caddy.Duration(5*time.Second), *module.RequestBodyTimeout)
+}
+
+func TestModuleRequestBodyTimeoutDisabled(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`
+	{
+		php {
+			request_body_timeout 0
+		}
+	}`)
+	module := &FrankenPHPModule{}
+
+	require.NoError(t, module.UnmarshalCaddyfile(d))
+	require.NotNil(t, module.RequestBodyTimeout)
+	require.Equal(t, caddy.Duration(0), *module.RequestBodyTimeout)
 }
 
 func TestModuleWorkerDuplicateFilenamesFail(t *testing.T) {

--- a/caddy/config_test.go
+++ b/caddy/config_test.go
@@ -3,7 +3,9 @@ package caddy
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/stretchr/testify/require"
 )
@@ -97,6 +99,19 @@ func TestPhpServerEmbedReuseIsPositional(t *testing.T) {
 	for i := range first {
 		require.Equal(t, first[i].Name, second[i].Name, "the duplicate embed must reuse pools by position for worker %d", i)
 	}
+}
+
+func TestModuleRequestBodyTimeout(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`
+	{
+		php {
+			request_body_timeout 5s
+		}
+	}`)
+	module := &FrankenPHPModule{}
+
+	require.NoError(t, module.UnmarshalCaddyfile(d))
+	require.Equal(t, caddy.Duration(5*time.Second), module.RequestBodyTimeout)
 }
 
 func TestModuleWorkerDuplicateFilenamesFail(t *testing.T) {

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
@@ -47,6 +48,8 @@ type FrankenPHPModule struct {
 	Workers []workerConfig `json:"workers,omitempty"`
 	// RouteGroup is set automatically to pair the route embeds of one php_server directive (#2477). Do not set it manually.
 	RouteGroup string `json:"route_group,omitempty"`
+	// RequestBodyTimeout is an idle timeout on request body reads: a stalled (slow POST) client is cut off while a steady upload of any size succeeds. Zero (the default) disables it.
+	RequestBodyTimeout caddy.Duration `json:"request_body_timeout,omitempty"`
 
 	resolvedDocumentRoot        string
 	preparedEnv                 frankenphp.PreparedEnv
@@ -125,6 +128,10 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("invalid split_path: %w", err)
 	}
 	f.requestOptions = append(f.requestOptions, opt)
+
+	if f.RequestBodyTimeout > 0 {
+		f.requestOptions = append(f.requestOptions, frankenphp.WithRequestBodyTimeout(time.Duration(f.RequestBodyTimeout)))
+	}
 
 	if f.ResolveRootSymlink == nil {
 		f.ResolveRootSymlink = new(true)
@@ -313,8 +320,21 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return err
 				}
 
+			case "request_body_timeout":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				v, err := caddy.ParseDuration(d.Val())
+				if err != nil {
+					return err
+				}
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+				f.RequestBodyTimeout = caddy.Duration(v)
+
 			default:
-				return wrongSubDirectiveError("php or php_server", "hot_reload, name, root, split, env, resolve_root_symlink, worker", d.Val())
+				return wrongSubDirectiveError("php or php_server", "hot_reload, name, root, split, env, resolve_root_symlink, request_body_timeout, worker", d.Val())
 			}
 		}
 	}

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -48,8 +48,8 @@ type FrankenPHPModule struct {
 	Workers []workerConfig `json:"workers,omitempty"`
 	// RouteGroup is set automatically to pair the route embeds of one php_server directive (#2477). Do not set it manually.
 	RouteGroup string `json:"route_group,omitempty"`
-	// RequestBodyTimeout is an idle timeout on request body reads: a stalled (slow POST) client is cut off while a steady upload of any size succeeds. Zero (the default) disables it.
-	RequestBodyTimeout caddy.Duration `json:"request_body_timeout,omitempty"`
+	// RequestBodyTimeout is an idle timeout on request body reads: a stalled (slow POST) client is cut off while a steady upload of any size succeeds. Defaults to 60s when omitted; set to 0 to disable.
+	RequestBodyTimeout *caddy.Duration `json:"request_body_timeout,omitempty"`
 
 	resolvedDocumentRoot        string
 	preparedEnv                 frankenphp.PreparedEnv
@@ -129,8 +129,12 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 	}
 	f.requestOptions = append(f.requestOptions, opt)
 
-	if f.RequestBodyTimeout > 0 {
-		f.requestOptions = append(f.requestOptions, frankenphp.WithRequestBodyTimeout(time.Duration(f.RequestBodyTimeout)))
+	if f.RequestBodyTimeout == nil {
+		f.RequestBodyTimeout = new(defaultRequestBodyTimeout)
+	}
+
+	if *f.RequestBodyTimeout > 0 {
+		f.requestOptions = append(f.requestOptions, frankenphp.WithRequestBodyTimeout(time.Duration(*f.RequestBodyTimeout)))
 	}
 
 	if f.ResolveRootSymlink == nil {
@@ -331,7 +335,7 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if d.NextArg() {
 					return d.ArgErr()
 				}
-				f.RequestBodyTimeout = caddy.Duration(v)
+				f.RequestBodyTimeout = new(caddy.Duration(v))
 
 			default:
 				return wrongSubDirectiveError("php or php_server", "hot_reload, name, root, split, env, resolve_root_symlink, request_body_timeout, worker", d.Val())

--- a/context.go
+++ b/context.go
@@ -24,6 +24,9 @@ type frankenPHPContext struct {
 	originalRequest *http.Request
 	worker          *worker
 
+	// idle timeout per body read; zero disables it
+	requestBodyTimeout time.Duration
+
 	docURI         string
 	pathInfo       string
 	scriptName     string

--- a/docs/config.md
+++ b/docs/config.md
@@ -189,6 +189,7 @@ php_server [<matcher>] {
 	resolve_root_symlink false # Disables resolving the `root` directory to its actual value by evaluating a symbolic link, if one exists (enabled by default).
 	env <key> <value> # Sets an extra environment variable to the given value. Can be specified more than once for multiple environment variables.
 	file_server off # Disables the built-in file_server directive.
+	request_body_timeout <duration> # Sets an idle timeout on request body reads: a stalled (slow POST) client is cut off while a steady upload of any size succeeds. Default: 60s. Set to 0 to disable.
 	worker { # Creates a worker specific to this server. Can be specified more than once for multiple workers.
 		file <path> # Sets the path to the worker script, can be relative to the php_server root
 		num <num> # Sets the number of PHP threads to start, defaults to 2x the number of available

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,6 +51,7 @@ These are the surfaces FrankenPHP owns. A vulnerability here is a FrankenPHP vul
 - **CGO memory boundary**: Go string pinning and `C.CString()` / `free()` lifetimes across the Go ↔ C boundary.
 - **Caddy admin API**: the `/frankenphp/workers/restart` and `/frankenphp/threads` endpoints, exposed through Caddy's admin API (which listens on `localhost:2019` by default). Exposing that endpoint beyond localhost is an operator decision.
 - **Trusted proxy handling**: incoming `X-Forwarded-*` headers always reach PHP as tainted `$_SERVER['HTTP_X_FORWARDED_*']` values; they are only trusted to derive the real client IP and scheme when [`trusted_proxies`](production.md#running-behind-a-reverse-proxy) is configured.
+- **Slow request bodies**: a client that announces a body then dribbles or stalls it holds the handling thread for the duration. With a bounded thread pool, enough such connections exhaust it (slow-POST DoS). FrankenPHP applies a 60s idle timeout on body reads by default ([`request_body_timeout`](config.md#caddyfile-config)), resetting the deadline before each read so a steady upload of any size succeeds while a stalled one is cut off and the thread released.
 
 ## Out of scope
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -643,12 +643,29 @@ func go_read_post(threadIndex C.uintptr_t, cBuf *C.char, countBytes C.size_t) (r
 		return 0
 	}
 
+	var rc *http.ResponseController
+	if fc.requestBodyTimeout > 0 {
+		if fc.responseController == nil {
+			fc.responseController = http.NewResponseController(fc.responseWriter)
+		}
+		rc = fc.responseController
+	}
+
 	p := unsafe.Slice((*byte)(unsafe.Pointer(cBuf)), countBytes)
 	var err error
 	for readBytes < countBytes && err == nil {
+		if rc != nil {
+			// reset before each read: bound a stall, not a steady upload
+			_ = rc.SetReadDeadline(time.Now().Add(fc.requestBodyTimeout))
+		}
+
 		var n int
 		n, err = fc.request.Body.Read(p[readBytes:])
 		readBytes += C.size_t(n)
+	}
+
+	if rc != nil {
+		_ = rc.SetReadDeadline(time.Time{})
 	}
 
 	return

--- a/requestbodytimeout_test.go
+++ b/requestbodytimeout_test.go
@@ -1,0 +1,87 @@
+package frankenphp_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestBodyTimeout proves that WithRequestBodyTimeout bounds a slow-POST
+// client: it announces a large Content-Length, then stalls without sending the
+// body. Without the option the PHP thread would block in Body.Read until the
+// connection closed; with it, the read is cut off and the request completes.
+func TestRequestBodyTimeout(t *testing.T) {
+	require.NoError(t, frankenphp.Init())
+	defer frankenphp.Shutdown()
+
+	cwd, _ := os.Getwd()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		req, err := frankenphp.NewRequestWithContext(r,
+			frankenphp.WithRequestDocumentRoot(cwd+"/testdata/", false),
+			frankenphp.WithRequestBodyTimeout(300*time.Millisecond),
+		)
+		require.NoError(t, err)
+		require.NoError(t, frankenphp.ServeHTTP(w, req))
+	}
+
+	ts := newRawServer(t, handler)
+	defer ts.Close()
+
+	conn, err := net.Dial("tcp", ts.Addr())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Announce a 1 MiB body, then send nothing: a classic slow POST.
+	fmt.Fprintf(conn,
+		"POST /read-input.php HTTP/1.1\r\nHost: %s\r\nContent-Type: application/octet-stream\r\nContent-Length: 1048576\r\nConnection: close\r\n\r\n",
+		ts.Addr(),
+	)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	start := time.Now()
+	resp, err := io.ReadAll(conn)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+
+	// The 300ms idle timeout (applied at most twice by PHP's read loop) must
+	// release the thread well before the client's 5s read deadline.
+	require.Less(t, elapsed, 4*time.Second, "slow body must be bounded by the timeout")
+	require.Contains(t, string(resp), "200 OK")
+	// PHP saw an empty body: php://input read zero bytes.
+	require.Contains(t, string(resp), "read=0")
+}
+
+// rawServer is a minimal HTTP server exposing its listener address so a test
+// can drive it with a raw TCP connection (needed to simulate a stalled body).
+type rawServer struct {
+	ln  net.Listener
+	srv *http.Server
+}
+
+func newRawServer(t *testing.T, handler http.HandlerFunc) *rawServer {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{Handler: handler}
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+
+	return &rawServer{ln: ln, srv: srv}
+}
+
+func (s *rawServer) Addr() string { return s.ln.Addr().String() }
+
+func (s *rawServer) Close() {
+	_ = s.srv.Close()
+	_ = s.ln.Close()
+}

--- a/requestbodytimeout_test.go
+++ b/requestbodytimeout_test.go
@@ -36,13 +36,14 @@ func TestRequestBodyTimeout(t *testing.T) {
 
 	conn, err := net.Dial("tcp", ts.Addr())
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Announce a 1 MiB body, then send nothing: a classic slow POST.
-	fmt.Fprintf(conn,
+	_, err = fmt.Fprintf(conn,
 		"POST /read-input.php HTTP/1.1\r\nHost: %s\r\nContent-Type: application/octet-stream\r\nContent-Length: 1048576\r\nConnection: close\r\n\r\n",
 		ts.Addr(),
 	)
+	require.NoError(t, err)
 
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	start := time.Now()

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unicode/utf8"
 
 	"github.com/dunglas/frankenphp/internal/fastabs"
@@ -174,6 +175,18 @@ func WithOriginalRequest(r *http.Request) RequestOption {
 func WithRequestLogger(logger *slog.Logger) RequestOption {
 	return func(o *frankenPHPContext) error {
 		o.logger = logger
+
+		return nil
+	}
+}
+
+// WithRequestBodyTimeout sets an idle timeout on request body reads: a stalled
+// (slow POST) client is cut off while a steady upload of any size succeeds.
+// Zero (the default) disables it. Requires a ResponseWriter that exposes a read
+// deadline (net/http and Caddy do); otherwise the read has no timeout.
+func WithRequestBodyTimeout(timeout time.Duration) RequestOption {
+	return func(o *frankenPHPContext) error {
+		o.requestBodyTimeout = timeout
 
 		return nil
 	}

--- a/testdata/read-input.php
+++ b/testdata/read-input.php
@@ -1,0 +1,3 @@
+<?php
+
+echo 'read=' . strlen(file_get_contents('php://input'));


### PR DESCRIPTION
## Problem

`go_read_post` loops on `request.Body.Read` with no per-read deadline. A client that announces a body (or a large `Content-Length`) then dribbles or stalls holds a PHP thread for the lifetime of the connection. With a bounded thread pool, `max_threads` such connections exhaust the pool and legitimate requests get rejected at `max_wait_time`. This is a slow-POST DoS. It's bounded and recoverable, not a code defect, but the default posture is weaker than the common nginx+php-fpm stack, which buffers the body and ships a default `client_body_timeout`.

## What this adds

`WithRequestBodyTimeout(d)` sets an idle timeout on body reads: the deadline resets before each read via `http.ResponseController.SetReadDeadline`, so a steady upload of any size succeeds while a stalled one is cut off and the thread is released. Best effort: if the `ResponseWriter` can't expose a deadline, the read proceeds without one.

The `request_body_timeout` Caddyfile directive (and its JSON equivalent on `php`/`php_server`) exposes the same control. It now defaults to 60s, matching nginx's `client_body_timeout`, so slow-POST protection is on without configuration. Set `request_body_timeout 0` to disable. The library-level `WithRequestBodyTimeout` zero value still disables it: embedders opt in, only Caddyfile and JSON deployments get the default.

**Behavior change:** a `php_server` or `php` deployment that doesn't set the directive starts enforcing a 60s idle timeout on request body reads after upgrading. The timeout is idle, not total, so a steady upload of any size still completes; only a stalled body is cut off.

Docs: the directive is documented in `docs/config.md`, and `docs/security.md` gains a slow-request-body entry under the in-scope attack surface.

## Why not just Caddy `read_timeout`

`read_timeout` maps to `http.Server.ReadTimeout`, a total deadline for the entire request including the body, set server-wide. That's the wrong tool for three reasons, which is why it's off by default:

| Aspect | `read_timeout` (`ReadTimeout`) | `WithRequestBodyTimeout` |
|---|---|---|
| Semantics | total wall-clock for headers+body | idle: fires only on a stall |
| Large uploads | a slow-but-steady upload hits the cap | steady upload of any size passes |
| Scope | server-wide | per request / per route |
| SSE, websockets, Mercure | also bounds long-lived reads, can break them | only the body read |

It also does nothing for library users of frankenphp, who have no Caddy. For a deployment with no SSE and no large uploads, `read_timeout` is the simpler zero-code answer; this option is for the cases it can't express.
