### PR TITLE
fix(release): pass GITHUB_TOKEN to the Homebrew bump step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -384,3 +384,7 @@ jobs:
           tag-name: v${{ inputs.version }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          # The action reads the source repo (release tag, tarball checksum) with
+          # GITHUB_TOKEN; without it, it falls back to COMMITTER_TOKEN, whose
+          # fine-grained PAT only sees the tap and gets 403 on this repo.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`mislav/bump-homebrew-formula-action` uses two tokens:

```js
const internalToken = process.env.GITHUB_TOKEN || process.env.COMMITTER_TOKEN || ''
const externalToken = process.env.COMMITTER_TOKEN || ''
```

The internal token reads the source repo (release tag lookup, tarball checksum); the external one writes to the tap. Our step only set `COMMITTER_TOKEN`, so the action fell back to it for source-repo calls. `HOMEBREW_TOKEN` is a fine-grained PAT scoped to `dunglas/homebrew-frankenphp` only (fine-grained PATs have no implicit public-repo access), so every call against `php/frankenphp` failed with `unexpected HTTP 403 response`. This broke the "Bump Homebrew formula" step of the v1.12.4 release runs.

Setting `GITHUB_TOKEN` restores the intended split: workflow token for reads here, tap-scoped PAT for the formula commit.