### PR TITLE
ci: fix lint failures blocking main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-actions: write
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -138,7 +138,8 @@ static void *frankenphp_parent_death_watcher(void *arg) {
     _exit(1);
   }
   struct kevent event;
-  while (kevent(kq, NULL, 0, &event, 1, NULL) < 0 && errno == EINTR);
+  while (kevent(kq, NULL, 0, &event, 1, NULL) < 0 && errno == EINTR)
+    ;
   _exit(1);
 }
 #endif


### PR DESCRIPTION
Main is red on the Lint Code Base job for two deterministic reasons.

## clang-format
`frankenphp.c:141` — the empty `while` body must sit on its own line.

## zizmor `github-app`
zizmor 1.26 added the `github-app` audit, which flags `actions/create-github-app-token` invocations that inherit blanket installation permissions. Scoped the release app token (`dunglas-release`) to what it actually uses:

- `contents: write` — commits, tags, refs, GitHub releases
- `actions: write` — `gh workflow run` dispatch of downstream builds (static/docker/windows)

Both verified locally: `zizmor` reports no findings, `clang-format --dry-run --Werror` is clean.