### PR TITLE
docs: deploying on Windows

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -1,6 +1,6 @@
 ---
 title: Compile FrankenPHP from sources with libphp.so
-description: Build FrankenPHP from source on Linux, macOS and FreeBSD, linking PHP as a shared library via xcaddy or go build, and add custom Caddy modules and extensions.
+description: Build FrankenPHP from source on Linux, macOS, FreeBSD and Windows, linking PHP as a shared library via xcaddy or go build, and add custom Caddy modules and extensions.
 ---
 
 # Compile from sources
@@ -9,6 +9,10 @@ This document explains how to create a FrankenPHP binary that will load PHP as a
 This is the recommended method.
 
 Alternatively, [fully and mostly static builds](static.md) can also be created.
+
+> [!NOTE]
+>
+> To compile FrankenPHP on Windows, follow [the Windows Development section of the contributing documentation](https://frankenphp.dev/docs/contributing/#windows-development).
 
 ## Install PHP
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying FrankenPHP in production with Docker Compose
-description: Deploy a PHP application to production with FrankenPHP and Docker Compose on a single Linux server, including TLS, reverse proxy, and multi-node setups.
+title: Deploying FrankenPHP in production
+description: Deploy a PHP application to production with FrankenPHP and Docker Compose on a single Linux server, including TLS, reverse proxy, and multi-node setups, or natively on Windows.
 ---
 
 # Deploying in production
@@ -189,3 +189,48 @@ brew services start dunglas/frankenphp/frankenphp
 ```
 
 The service runs FrankenPHP with the configuration file located at `$(brew --prefix)/etc/Caddyfile`.
+
+## Deploying on Windows
+
+FrankenPHP runs natively on Windows, with full support for [the worker mode](worker.md) and [hot reloading](hot-reload.md).
+
+To install it, run this in PowerShell:
+
+```powershell
+irm https://frankenphp.dev/install.ps1 | iex
+```
+
+Alternatively, [download the Windows archive from the releases page](https://github.com/php/frankenphp/releases).
+It contains the FrankenPHP executable as well as the official PHP binary for Windows.
+
+To run FrankenPHP in the background and start it automatically at boot, register it as a Windows service.
+As [recommended by the Caddy documentation](https://caddyserver.com/docs/running#windows-service), use [WinSW](https://github.com/winsw/winsw):
+
+1. Download [the latest version of WinSW](https://github.com/winsw/winsw/releases) as `frankenphp-service.exe` in the directory containing `frankenphp.exe`
+2. In the same directory, create a `frankenphp-service.xml` file:
+
+   ```xml
+   <service>
+     <id>frankenphp</id>
+     <name>FrankenPHP</name>
+     <description>The modern PHP app server (https://frankenphp.dev)</description>
+     <executable>%BASE%\frankenphp.exe</executable>
+     <arguments>run --config %BASE%\Caddyfile</arguments>
+     <log mode="roll-by-time">
+       <pattern>yyyy-MM-dd</pattern>
+     </log>
+   </service>
+   ```
+
+3. Install and start the service:
+
+   ```powershell
+   .\frankenphp-service.exe install
+   .\frankenphp-service.exe start
+   ```
+
+Windows services cannot be reloaded. To apply configuration changes gracefully, without restarting the service, run:
+
+```powershell
+.\frankenphp.exe reload --config Caddyfile
+```


### PR DESCRIPTION
FrankenPHP runs natively on Windows since v1.12 (#2119), but the docs don't mention it as a deployment target. This adds a "Deploying on Windows" section to the production guide (install, running as a Windows service with WinSW as [recommended by the Caddy docs](https://caddyserver.com/docs/running#windows-service), graceful reload) and a pointer to the Windows compilation instructions in the compile docs.

Related to #2442. Follow-ups: #2501 (static/embed, see also #2503), #2502 (macOS).