### PR TITLE
docs: static builds and embedded apps are not available on Windows

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -103,6 +103,12 @@ EMBED=/path/to/your/app ./build-static.sh
 
 The resulting binary is the file named `frankenphp-<os>-<arch>` in the `dist/` directory.
 
+> [!NOTE]
+>
+> Standalone binaries can currently be created for Linux and macOS only,
+> as [static builds are not available for Windows](static.md).
+> To create a Linux binary from Windows, use the Docker-based builder or [WSL](https://learn.microsoft.com/windows/wsl/).
+
 ## Using the binary
 
 This is it! The `my-app` file (or `dist/frankenphp-<os>-<arch>` on other OSes) contains your self-contained app!

--- a/docs/static.md
+++ b/docs/static.md
@@ -19,6 +19,12 @@ When possible, we recommend using glibc-based, mostly static builds.
 
 FrankenPHP also supports [embedding the PHP app in the static binary](embed.md).
 
+> [!NOTE]
+>
+> Static builds are not available for Windows: on this platform, FrankenPHP links against the official PHP binaries,
+> which are included in [the provided archives](https://github.com/php/frankenphp/releases).
+> To create a static Linux binary from Windows, use the Docker-based builders or [WSL](https://learn.microsoft.com/windows/wsl/).
+
 ## Linux
 
 We provide Docker images to build static Linux binaries:


### PR DESCRIPTION
The static and embed docs only cover Linux and macOS. This clarifies that static builds (and therefore standalone app binaries) cannot be created for Windows, since the frankenphp SAPI of static-php-cli is not available there, and points Windows users to the official archives or Docker/WSL.

Follow-up to #2500. Native Windows standalone binaries are tracked in #2503.

---

**Update:** a static Windows `frankenphp.exe` now builds and runs once crazywhalecc/static-php-cli#1201 lands (details in #2503). This page will need revisiting then, but the limitation still holds against released static-php-cli.
