### PR TITLE
fix: hanging reboots on upscaled and then downscaled threads

### DIFF
--- a/threadinactive.go
+++ b/threadinactive.go
@@ -30,7 +30,7 @@ func (handler *inactiveThread) beforeScriptExecution() string {
 
 		// wait for external signal to start or shut down
 		thread.state.MarkAsWaiting(true)
-		thread.state.WaitFor(state.TransitionRequested, state.ShuttingDown, state.Rebooting)
+		thread.state.WaitFor(state.TransitionRequested, state.ShuttingDown, state.Rebooting, state.ForceRebooting)
 		thread.state.MarkAsWaiting(false)
 
 		return handler.beforeScriptExecution()


### PR DESCRIPTION
Fixes a small issue from #2364 where threads that are upscaled and then downscaled could prevent reboots.

Issues like this should probably be covered in a dedicated fuzzing test (not yet in this PR)