### PR TITLE
cleanup: remove DrainWorkers

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -165,13 +165,6 @@ func newWorker(o workerOpt) (*worker, error) {
 	return w, nil
 }
 
-// EXPERIMENTAL: DrainWorkers initiates a graceful drain of all php threads.
-// Blocks until every drained thread yields. Force-kill is armed after a
-// grace period to wake threads parked in blocking syscalls (sleep, I/O).
-func DrainWorkers() {
-	drainPHPThreads()
-}
-
 // RestartWorkers attempts to restart all workers gracefully.
 // All workers must be restarted at the same time to prevent issues with
 // opcache resetting. Blocks until every worker thread has yielded;


### PR DESCRIPTION
This PR removes the experimental `DrainWorkers` function since it serves no purpose anymore (as also discussed in #2499).

The original use was to have a graceful shutdown of all workers on Caddy shutdown (added [here](https://github.com/php/frankenphp/pull/1405/changes)). Since shutdowns have long been fully safe, the function is not in use anymore. It might only be confusing for library users, since it does not allow recovering drained workers.