### PR TITLE
feat: native cross-platform total memory detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.56.0
+	golang.org/x/sys v0.46.0
 )
 
 require (
@@ -61,7 +62,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/memory/memory_darwin.go
+++ b/internal/memory/memory_darwin.go
@@ -1,0 +1,13 @@
+package memory
+
+import "golang.org/x/sys/unix"
+
+// TotalSysMemory returns the total physical memory in bytes via sysctl hw.memsize
+func TotalSysMemory() uint64 {
+	memsize, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+
+	return memsize
+}

--- a/internal/memory/memory_others.go
+++ b/internal/memory/memory_others.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin && !windows
 
 package memory
 

--- a/internal/memory/memory_windows.go
+++ b/internal/memory/memory_windows.go
@@ -1,0 +1,36 @@
+package memory
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// memoryStatusEx mirrors the Win32 MEMORYSTATUSEX structure.
+// https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
+type memoryStatusEx struct {
+	length               uint32
+	memoryLoad           uint32
+	totalPhys            uint64
+	availPhys            uint64
+	totalPageFile        uint64
+	availPageFile        uint64
+	totalVirtual         uint64
+	availVirtual         uint64
+	availExtendedVirtual uint64
+}
+
+var procGlobalMemoryStatusEx = windows.NewLazySystemDLL("kernel32.dll").NewProc("GlobalMemoryStatusEx")
+
+// TotalSysMemory returns the total physical memory in bytes via GlobalMemoryStatusEx
+func TotalSysMemory() uint64 {
+	memStatus := memoryStatusEx{}
+	memStatus.length = uint32(unsafe.Sizeof(memStatus))
+
+	ret, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&memStatus)))
+	if ret == 0 {
+		return 0
+	}
+
+	return memStatus.totalPhys
+}


### PR DESCRIPTION
Alternative to #2306.

#2306 replaces the platform-specific CPU/memory probing with [gopsutil/v4](https://github.com/shirou/gopsutil). The genuinely useful part of that PR is cross-platform memory detection: `internal/memory.TotalSysMemory()` was Linux-only and returned `0` on macOS/Windows, which silently disabled automatic `max_threads` calculation.

This PR gets that win without the dependency cost.

## What it does

Adds native implementations of `TotalSysMemory()`:

- **darwin** — `sysctl hw.memsize` (via `golang.org/x/sys/unix`)
- **windows** — `GlobalMemoryStatusEx` (`kernel32.dll`, via `golang.org/x/sys/windows`)
- **linux** — unchanged (`syscall.Sysinfo`)
- **others** — unchanged fallback returning `0`

`golang.org/x/sys` was already an indirect dependency, so this promotes it to direct and pulls in **zero new modules**. #2306 adds ~8 transitive modules (`purego`, `go-ole`, `wmi`, `plan9stats`, `perfstat`, `tklauser/*`).

## Why not gopsutil

- The CPU-probe rewrite in #2306 has a data race (one shared `*process.Process` used from both the up- and down-scaling goroutines; `Percent(0)` reads and writes `lastCPUTimes`/`lastCPUTime` without a lock), and `Percent(0)` measures near-zero windows under a scaling burst, weakening the guard the original 120 ms `clock_gettime` probe provided. Not worth removing one C call in an already-CGO binary.
- #2306 also switches the memory figure from total RAM to `mem.VirtualMemory().Available`, so `max_threads=auto` would size off whatever happens to be free at boot. This PR keeps total-physical semantics on every platform.

## Verification

`internal/memory` is pure Go (no CGO), cross-compiles clean for linux/darwin/windows. On an Apple Silicon Mac, `TotalSysMemory()` returns `51539607552`, matching `sysctl -n hw.memsize` exactly. Windows path is the standard `MEMORYSTATUSEX` pattern (not runnable in CI here).
