### PR TITLE
fix(tests): wait for listener readiness in TestWorkerWithInactiveWatcher

### DIFF
--- a/caddy/watcher_test.go
+++ b/caddy/watcher_test.go
@@ -3,11 +3,31 @@
 package caddy_test
 
 import (
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
+	"github.com/stretchr/testify/require"
 )
+
+// waitForListener polls a raw TCP connection instead of an HTTP request so it
+// doesn't consume a request from the worker's counter (unlike the initServer
+// helper), while still covering the same listener hot-swap race it guards against.
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "server failed to become ready")
+}
 
 func TestWorkerWithInactiveWatcher(t *testing.T) {
 	tester := caddytest.NewTester(t)
@@ -32,6 +52,8 @@ func TestWorkerWithInactiveWatcher(t *testing.T) {
 			php
 		}
 		`, "caddyfile")
+
+	waitForListener(t, "localhost:"+testPort)
 
 	tester.AssertGetResponse("http://localhost:"+testPort, http.StatusOK, "requests:1")
 	tester.AssertGetResponse("http://localhost:"+testPort, http.StatusOK, "requests:2")


### PR DESCRIPTION
\`TestWorkerWithInactiveWatcher\` calls \`tester.InitServer\` and immediately asserts against the app endpoint. \`caddytest\`'s own readiness check only polls the admin API, not the app-facing listener, so under load a request can land in the gap and get an EOF (seen in CI: https://github.com/php/frankenphp/actions/runs/29648714936/job/88091254601).

The existing \`initServer\` helper in this package works around a similar race, but it polls via a real HTTP GET, which isn't usable here since this test asserts an exact worker request counter starting at 1.

Adds \`waitForListener\`, which polls a raw TCP dial/close (no HTTP, no counter impact) until the listener accepts connections, before the counted requests.

Verified with repeated full-suite runs locally.