### PR TITLE
test(caddy): cover server_idx registration scenarios

### DIFF
--- a/caddy/serveridx_test.go
+++ b/caddy/serveridx_test.go
@@ -1,0 +1,66 @@
+package caddy
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssignServerIdxIncrements(t *testing.T) {
+	h := httpcaddyfile.Helper{State: map[string]any{}}
+	m1 := &FrankenPHPModule{}
+	m2 := &FrankenPHPModule{}
+
+	m1.assignServerIdx(h)
+	m2.assignServerIdx(h)
+
+	require.Equal(t, 1, m1.ServerIdx)
+	require.Equal(t, 2, m2.ServerIdx)
+}
+
+func TestRegisterModulesWithSameServerIdxShareOneServer(t *testing.T) {
+	app := &FrankenPHPApp{}
+	shared1 := &FrankenPHPModule{ServerIdx: 1, resolvedDocumentRoot: "../testdata"}
+	shared2 := &FrankenPHPModule{ServerIdx: 1, resolvedDocumentRoot: "../testdata"}
+	app.modules = []*FrankenPHPModule{shared1, shared2}
+
+	require.NoError(t, app.registerModules(caddy.NewReplacer()))
+
+	require.NotNil(t, shared1.server)
+	require.Same(t, shared1.server, shared2.server, "modules with the same server_idx must share one server instance")
+}
+
+func TestRegisterModulesWithoutServerIdxGetOwnServers(t *testing.T) {
+	app := &FrankenPHPApp{}
+	auto1 := &FrankenPHPModule{resolvedDocumentRoot: "../testdata"}
+	auto2 := &FrankenPHPModule{resolvedDocumentRoot: "../testdata"}
+	indexed := &FrankenPHPModule{ServerIdx: 1, resolvedDocumentRoot: "../testdata"}
+	app.modules = []*FrankenPHPModule{auto1, indexed, auto2}
+
+	require.NoError(t, app.registerModules(caddy.NewReplacer()))
+
+	require.NotNil(t, auto1.server)
+	require.NotNil(t, auto2.server)
+	require.NotNil(t, indexed.server)
+	require.NotSame(t, auto1.server, auto2.server, "modules without server_idx must each get their own server")
+	require.NotSame(t, auto1.server, indexed.server)
+	require.NotSame(t, auto2.server, indexed.server)
+}
+
+// regression test for the double-registration scenario: a module POSTed via
+// the admin API with an explicit server_idx must not steal the server of a
+// module that already registered under the same index; it joins it instead,
+// and the first registered module defines the server configuration
+func TestRegisterModulesFirstModuleWinsPerIdx(t *testing.T) {
+	app := &FrankenPHPApp{}
+	first := &FrankenPHPModule{ServerIdx: 2, resolvedDocumentRoot: "../testdata"}
+	second := &FrankenPHPModule{ServerIdx: 2, resolvedDocumentRoot: "../testdata/env"}
+	app.modules = []*FrankenPHPModule{first, second}
+
+	require.NoError(t, app.registerModules(caddy.NewReplacer()))
+
+	require.Same(t, first.server, second.server)
+	require.Len(t, app.opts, 1, "only one server must be registered for a shared index")
+}


### PR DESCRIPTION
Follow-up to #2499, targeting `refactor/phpserver`. Test-only.

During review, an explicit `server_idx` colliding with an auto-assigned one could make one handler serve another's files; the fix (deferring registration to a single pass keyed by index) had no regression test, and nothing in `caddy/` exercised `server_idx` at all. This adds unit coverage for:

- Caddyfile parsing assigns incrementing indexes
- modules with the same `server_idx` share one server instance, registered only once
- modules without `server_idx` each get their own server
- a module with an explicit `server_idx` equal to an already registered one joins the existing server instead of re-registering it (the double-registration scenario possible with JSON configs POSTed to the admin API)

These are pure Go unit tests on `registerModules()`; an end-to-end admin API config-swap test would be a natural follow-up but needs the PHP runtime, so it is not included here.
