### PR TITLE
fix: don't set request body read deadline after the request is finished

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -643,8 +643,13 @@ func go_read_post(threadIndex C.uintptr_t, cBuf *C.char, countBytes C.size_t) (r
 		return 0
 	}
 
+	// The read deadline is set on the responseWriter, which is only valid until
+	// the response is finished. A script that finishes the request (e.g. via
+	// frankenphp_finish_request()) and then reads the body would otherwise set a
+	// deadline on a finalized HTTP/2 stream, dereferencing a nil pointer and
+	// crashing the process. See https://github.com/php/frankenphp/issues/2535.
 	var rc *http.ResponseController
-	if fc.requestBodyTimeout > 0 {
+	if fc.requestBodyTimeout > 0 && !fc.isDone {
 		if fc.responseController == nil {
 			fc.responseController = http.NewResponseController(fc.responseWriter)
 		}

--- a/requestbodytimeout_test.go
+++ b/requestbodytimeout_test.go
@@ -1,16 +1,21 @@
 package frankenphp_test
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 // TestRequestBodyTimeout proves that WithRequestBodyTimeout bounds a slow-POST
@@ -57,6 +62,116 @@ func TestRequestBodyTimeout(t *testing.T) {
 	require.Contains(t, string(resp), "200 OK")
 	// PHP saw an empty body: php://input read zero bytes.
 	require.Contains(t, string(resp), "read=0")
+}
+
+// TestRequestBodyTimeoutHTTP2 is the HTTP/2 counterpart of the test above: over
+// HTTP/2 the deadline lands on the stream (via x/net) rather than the net.Conn,
+// so this exercises the SetReadDeadline path that HTTP/1 never touches. A slow
+// POST that trips the idle timeout must bound the read and return cleanly.
+// The nil-dereference crash of php/frankenphp#2535 needs the writer to be used
+// after its stream is finalized; see TestSetReadDeadlineRecoversFromPanic.
+func TestRequestBodyTimeoutHTTP2(t *testing.T) {
+	require.NoError(t, frankenphp.Init())
+	defer frankenphp.Shutdown()
+
+	cwd, _ := os.Getwd()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		req, err := frankenphp.NewRequestWithContext(r,
+			frankenphp.WithRequestDocumentRoot(cwd+"/testdata/", false),
+			frankenphp.WithRequestBodyTimeout(300*time.Millisecond),
+		)
+		require.NoError(t, err)
+		require.NoError(t, frankenphp.ServeHTTP(w, req))
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	h2s := &http2.Server{}
+	srv := &http.Server{Handler: h2c.NewHandler(http.HandlerFunc(handler), h2s)}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	client := &http.Client{Transport: &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}}
+
+	// A body that never sends data: the server blocks in Body.Read until the
+	// idle timeout fires. Close the writer once the request returns.
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	req, err := http.NewRequest(http.MethodPost, "http://"+ln.Addr().String()+"/read-input.php", pr)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 4*time.Second, "slow body must be bounded by the timeout")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(body), "read=0")
+}
+
+// TestFinishRequestThenReadBodyHTTP2 reproduces php/frankenphp#2535: a script
+// that calls frankenphp_finish_request() and then reads php://input triggers
+// go_read_post after the HTTP/2 responseWriter has been finalized. Setting a
+// read deadline on that dead writer would dereference a nil pointer and crash
+// the whole process. enable_post_data_reading=Off defers the body read until
+// the explicit php://input access, i.e. after the request is finished.
+func TestFinishRequestThenReadBodyHTTP2(t *testing.T) {
+	iniDir := t.TempDir()
+	require.NoError(t, os.WriteFile(iniDir+"/php.ini", []byte("enable_post_data_reading=Off\n"), 0o600))
+	t.Setenv("PHPRC", iniDir+"/php.ini")
+
+	require.NoError(t, frankenphp.Init())
+	defer frankenphp.Shutdown()
+
+	cwd, _ := os.Getwd()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		req, err := frankenphp.NewRequestWithContext(r,
+			frankenphp.WithRequestDocumentRoot(cwd+"/testdata/", false),
+			frankenphp.WithRequestBodyTimeout(300*time.Millisecond),
+		)
+		require.NoError(t, err)
+		require.NoError(t, frankenphp.ServeHTTP(w, req))
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	h2s := &http2.Server{}
+	srv := &http.Server{Handler: h2c.NewHandler(http.HandlerFunc(handler), h2s)}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	client := &http.Client{Transport: &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}}
+
+	req, err := http.NewRequest(http.MethodPost, "http://"+ln.Addr().String()+"/finish-then-read-input.php", strings.NewReader("hello world"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 // rawServer is a minimal HTTP server exposing its listener address so a test

--- a/requestbodytimeout_test.go
+++ b/requestbodytimeout_test.go
@@ -15,8 +15,17 @@ import (
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
+
+// h2cServer builds an HTTP server that speaks cleartext HTTP/2 (h2c) using the
+// stdlib Protocols field, so a slow-body test drives the SetReadDeadline path
+// that only HTTP/2 exercises.
+func h2cServer(handler http.HandlerFunc) *http.Server {
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true)
+
+	return &http.Server{Handler: handler, Protocols: protocols}
+}
 
 // TestRequestBodyTimeout proves that WithRequestBodyTimeout bounds a slow-POST
 // client: it announces a large Content-Length, then stalls without sending the
@@ -87,8 +96,7 @@ func TestRequestBodyTimeoutHTTP2(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	h2s := &http2.Server{}
-	srv := &http.Server{Handler: h2c.NewHandler(http.HandlerFunc(handler), h2s)}
+	srv := h2cServer(handler)
 	go func() { _ = srv.Serve(ln) }()
 	defer func() { _ = srv.Close() }()
 
@@ -149,8 +157,7 @@ func TestFinishRequestThenReadBodyHTTP2(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	h2s := &http2.Server{}
-	srv := &http.Server{Handler: h2c.NewHandler(http.HandlerFunc(handler), h2s)}
+	srv := h2cServer(handler)
 	go func() { _ = srv.Serve(ln) }()
 	defer func() { _ = srv.Close() }()
 

--- a/requestbodytimeout_test.go
+++ b/requestbodytimeout_test.go
@@ -17,14 +17,33 @@ import (
 	"golang.org/x/net/http2"
 )
 
-// h2cServer builds an HTTP server that speaks cleartext HTTP/2 (h2c) using the
-// stdlib Protocols field, so a slow-body test drives the SetReadDeadline path
-// that only HTTP/2 exercises.
-func h2cServer(handler http.HandlerFunc) *http.Server {
+// newH2CServer starts a cleartext HTTP/2 (h2c) server for handler and returns
+// its address and a matching client. h2c drives the SetReadDeadline path that
+// only HTTP/2 exercises. The listener and server are closed via t.Cleanup.
+func newH2CServer(t *testing.T, handler http.HandlerFunc) (addr string, client *http.Client) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
 	protocols := new(http.Protocols)
 	protocols.SetUnencryptedHTTP2(true)
+	srv := &http.Server{Handler: handler, Protocols: protocols}
 
-	return &http.Server{Handler: handler, Protocols: protocols}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = ln.Close()
+	})
+
+	client = &http.Client{Transport: &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}}
+
+	return ln.Addr().String(), client
 }
 
 // TestRequestBodyTimeout proves that WithRequestBodyTimeout bounds a slow-POST
@@ -93,26 +112,14 @@ func TestRequestBodyTimeoutHTTP2(t *testing.T) {
 		require.NoError(t, frankenphp.ServeHTTP(w, req))
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	srv := h2cServer(handler)
-	go func() { _ = srv.Serve(ln) }()
-	defer func() { _ = srv.Close() }()
-
-	client := &http.Client{Transport: &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return net.Dial(network, addr)
-		},
-	}}
+	addr, client := newH2CServer(t, handler)
 
 	// A body that never sends data: the server blocks in Body.Read until the
 	// idle timeout fires. Close the writer once the request returns.
 	pr, pw := io.Pipe()
 	defer func() { _ = pw.Close() }()
 
-	req, err := http.NewRequest(http.MethodPost, "http://"+ln.Addr().String()+"/read-input.php", pr)
+	req, err := http.NewRequest(http.MethodPost, "http://"+addr+"/read-input.php", pr)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/octet-stream")
 
@@ -154,21 +161,9 @@ func TestFinishRequestThenReadBodyHTTP2(t *testing.T) {
 		require.NoError(t, frankenphp.ServeHTTP(w, req))
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	addr, client := newH2CServer(t, handler)
 
-	srv := h2cServer(handler)
-	go func() { _ = srv.Serve(ln) }()
-	defer func() { _ = srv.Close() }()
-
-	client := &http.Client{Transport: &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return net.Dial(network, addr)
-		},
-	}}
-
-	req, err := http.NewRequest(http.MethodPost, "http://"+ln.Addr().String()+"/finish-then-read-input.php", strings.NewReader("hello world"))
+	req, err := http.NewRequest(http.MethodPost, "http://"+addr+"/finish-then-read-input.php", strings.NewReader("hello world"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/octet-stream")
 

--- a/testdata/finish-then-read-input.php
+++ b/testdata/finish-then-read-input.php
@@ -1,0 +1,12 @@
+<?php
+
+// Finish the request (sends the response, closes the Go-side context) and only
+// then read the request body. This exercises go_read_post after the HTTP
+// responseWriter has been finalized. See php/frankenphp#2535.
+frankenphp_finish_request();
+
+// Give the Go handler goroutine time to return and finalize the HTTP/2
+// responseWriter before we touch the request body.
+usleep(200000);
+
+file_get_contents('php://input');


### PR DESCRIPTION
Fixes https://github.com/php/frankenphp/issues/2535.

## Problem

`frankenphp_finish_request()` (or any early context close) calls `closeContext()`, which closes `done`, so `ServeHTTP` returns and net/http's HTTP/2 layer runs `handlerDone()` and nils out the responseWriter's stream state. But the PHP script keeps running afterwards. If it then reads `php://input` (lazily, e.g. with `enable_post_data_reading=Off`), `go_read_post` runs and sets a read deadline on the now-finalized HTTP/2 stream. `golang.org/x/net`'s `responseWriter.SetReadDeadline` dereferences the nil stream state and takes down the whole process:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=...]
golang.org/x/net/http2.(*responseWriter).SetReadDeadline(...)
        golang.org/x/net@v0.57.0/http2/server.go:2699
net/http.(*ResponseController).SetReadDeadline(...)
github.com/dunglas/frankenphp.go_read_post(...)
        frankenphp.go:659
```

HTTP/1 is unaffected: there the deadline lands on the `net.Conn`, which outlives the handler. On HTTP/2 the deadline lives on the stream, which dies with the handler.

## Fix

Skip the read deadline once the context is finished (`fc.isDone`). The deadline only bounds a live read; after the request is finished there is nothing to bound and the writer is gone.

## Tests

- `TestFinishRequestThenReadBodyHTTP2` reproduces the crash over h2c (finish then read `php://input`); it segfaults without the fix and passes with it.
- `TestRequestBodyTimeoutHTTP2` adds HTTP/2 coverage for the deadline path, which the suite previously exercised only over HTTP/1.