### PR TITLE
feat: declared background workers + frankenphp_get_worker_handle()

### DIFF
--- a/bgworker_test.go
+++ b/bgworker_test.go
@@ -1,0 +1,145 @@
+package frankenphp_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dunglas/frankenphp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requireFileEventually asserts that `path` appears on disk before the
+// deadline. Wraps require.Eventually so call sites stay short.
+func requireFileEventually(t testing.TB, path string, msgAndArgs ...any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, msgAndArgs...)
+}
+
+// TestBackgroundWorkerLifecycle boots a background worker that touches a
+// sentinel file then parks on the stop pipe. It proves the bg worker runs
+// (sentinel appears) and that Shutdown returns within a reasonable time.
+// The test asserts on Shutdown timing, so it manages Shutdown itself
+// instead of using initServers' t.Cleanup hook.
+func TestBackgroundWorkerLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	sentinel := filepath.Join(tmp, "bg-lifecycle.sentinel")
+
+	require.NoError(t, frankenphp.Init(
+		frankenphp.WithWorkers("bg-lifecycle", "testdata/bgworker/basic.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{"BG_SENTINEL": sentinel}),
+		),
+		frankenphp.WithNumThreads(2),
+	))
+
+	requireFileEventually(t, sentinel, "background worker did not touch sentinel")
+
+	done := make(chan struct{})
+	go func() {
+		frankenphp.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Shutdown did not return within 10s")
+	}
+}
+
+// TestBackgroundWorkerCrashRestarts boots a worker that exit(1)s on its
+// first run and touches a "restarted" sentinel on its second run. The
+// sentinel proves the crash-restart loop fired.
+func TestBackgroundWorkerCrashRestarts(t *testing.T) {
+	tmp := t.TempDir()
+	crashMarker := filepath.Join(tmp, "bg-crash.marker")
+	restarted := filepath.Join(tmp, "bg-crash.restarted")
+
+	initServers(t,
+		frankenphp.WithWorkers("bg-crash", "testdata/bgworker/crash.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerEnv(map[string]string{
+				"BG_CRASH_MARKER":       crashMarker,
+				"BG_RESTARTED_SENTINEL": restarted,
+			}),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	requireFileEventually(t, restarted, "background worker did not restart after crash")
+}
+
+// TestBackgroundWorkerOnServer scopes a background worker to a Server. It
+// proves that the worker inherits the server env (the sentinel directory is
+// declared on the server, not on the worker), that FRANKENPHP_WORKER holds
+// the worker name, and that the worker does not intercept HTTP requests
+// served by the same server.
+func TestBackgroundWorkerOnServer(t *testing.T) {
+	tmp := t.TempDir()
+
+	server, err := frankenphp.NewServer("sidekick-server", testDataDir, nil, map[string]string{"BG_SENTINEL_DIR": tmp}, nil)
+	require.NoError(t, err)
+
+	initServers(t,
+		frankenphp.WithServer(server),
+		frankenphp.WithWorkers("jobs", "testdata/bgworker/named.php", 1,
+			frankenphp.WithWorkerBackground(),
+			frankenphp.WithWorkerServerScope(server),
+		),
+		frankenphp.WithNumThreads(2),
+	)
+
+	// named.php touches "<BG_SENTINEL_DIR>/<FRANKENPHP_WORKER>"
+	requireFileEventually(t, filepath.Join(tmp, "jobs"), "background worker did not touch its per-name sentinel")
+
+	body := serverGet(t, server, "http://example.com/index.php")
+	assert.Contains(t, body, "I am by birth a Genevese", "the server must still serve regular requests")
+}
+
+// TestBackgroundWorkerValidation covers the declaration-time errors.
+func TestBackgroundWorkerValidation(t *testing.T) {
+	t.Cleanup(frankenphp.Shutdown)
+
+	t.Run("name is required", func(t *testing.T) {
+		err := frankenphp.Init(
+			frankenphp.WithWorkers("", "testdata/bgworker/basic.php", 1, frankenphp.WithWorkerBackground()),
+			frankenphp.WithNumThreads(2),
+		)
+		require.ErrorContains(t, err, "must have an explicit name")
+	})
+
+	t.Run("num must be >= 1", func(t *testing.T) {
+		err := frankenphp.Init(
+			frankenphp.WithWorkers("bg-zero", "testdata/bgworker/basic.php", 0, frankenphp.WithWorkerBackground()),
+			frankenphp.WithNumThreads(2),
+		)
+		require.ErrorContains(t, err, "must declare num >= 1")
+	})
+
+	t.Run("names are global", func(t *testing.T) {
+		err := frankenphp.Init(
+			frankenphp.WithWorkers("bg-shared", "testdata/bgworker/basic.php", 1, frankenphp.WithWorkerBackground()),
+			frankenphp.WithWorkers("bg-shared", "testdata/bgworker/named.php", 1, frankenphp.WithWorkerBackground()),
+			frankenphp.WithNumThreads(3),
+		)
+		require.ErrorContains(t, err, "two workers cannot have the same name")
+	})
+
+	t.Run("request matchers are rejected", func(t *testing.T) {
+		err := frankenphp.Init(
+			frankenphp.WithWorkers("bg-matched", "testdata/bgworker/basic.php", 1,
+				frankenphp.WithWorkerBackground(),
+				frankenphp.WithWorkerMatcher(func(*http.Request) bool { return true }),
+			),
+			frankenphp.WithNumThreads(2),
+		)
+		require.ErrorContains(t, err, "cannot match requests")
+	})
+}

--- a/caddy/config_test.go
+++ b/caddy/config_test.go
@@ -269,3 +269,57 @@ func TestCreateUniqueWorkerNamesQualifiedByServer(t *testing.T) {
 	// workers without a server keep the numeric postfix behavior
 	require.Equal(t, "queue_2", app.createUniqueWorkerName(wc, ""))
 }
+
+func TestWorkerBackgroundConfig(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`
+	{
+		php_server {
+			worker {
+				name jobs
+				file ../testdata/worker-with-env.php
+				num 2
+				background
+			}
+		}
+	}`)
+	module := &FrankenPHPModule{}
+
+	require.NoError(t, module.UnmarshalCaddyfile(d))
+	require.Len(t, module.Workers, 1)
+	require.True(t, module.Workers[0].Background)
+	require.Equal(t, "jobs", module.Workers[0].Name)
+}
+
+func TestWorkerBackgroundRequiresName(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`
+	{
+		php_server {
+			worker {
+				file ../testdata/worker-with-env.php
+				background
+			}
+		}
+	}`)
+	module := &FrankenPHPModule{}
+
+	err := module.UnmarshalCaddyfile(d)
+	require.ErrorContains(t, err, `background workers must have an explicit "name"`)
+}
+
+func TestWorkerBackgroundRejectsMatch(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`
+	{
+		php_server {
+			worker {
+				name jobs
+				file ../testdata/worker-with-env.php
+				match /jobs/*
+				background
+			}
+		}
+	}`)
+	module := &FrankenPHPModule{}
+
+	err := module.UnmarshalCaddyfile(d)
+	require.ErrorContains(t, err, `"match" is not supported for background workers`)
+}

--- a/caddy/workerconfig.go
+++ b/caddy/workerconfig.go
@@ -38,6 +38,8 @@ type workerConfig struct {
 	MatchPath []string `json:"match_path,omitempty"`
 	// MaxConsecutiveFailures sets the maximum number of consecutive failures before panicking (defaults to 6, set to -1 to never panick)
 	MaxConsecutiveFailures int `json:"max_consecutive_failures,omitempty"`
+	// Background marks this worker as a background (non-HTTP) worker.
+	Background bool `json:"background,omitempty"`
 
 	options        []frankenphp.WorkerOption
 	requestOptions []frankenphp.RequestOption
@@ -140,13 +142,24 @@ func unmarshalWorker(d *caddyfile.Dispenser) (workerConfig, error) {
 			}
 
 			wc.MaxConsecutiveFailures = v
+		case "background":
+			wc.Background = true
 		default:
-			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads", v)
+			return wc, wrongSubDirectiveError("worker", "name, file, num, env, watch, match, max_consecutive_failures, max_threads, background", v)
 		}
 	}
 
 	if wc.FileName == "" {
 		return wc, d.Err(`the "file" argument must be specified`)
+	}
+
+	if wc.Background {
+		if wc.Name == "" {
+			return wc, d.Err(`background workers must have an explicit "name"`)
+		}
+		if len(wc.MatchPath) != 0 {
+			return wc, d.Err(`"match" is not supported for background workers`)
+		}
 	}
 
 	if frankenphp.EmbeddedAppPath != "" && filepath.IsLocal(wc.FileName) {
@@ -163,6 +176,10 @@ func (wc *workerConfig) toWorkerOptions() []frankenphp.WorkerOption {
 		frankenphp.WithWorkerMaxFailures(wc.MaxConsecutiveFailures),
 		frankenphp.WithWorkerMaxThreads(wc.MaxThreads),
 		frankenphp.WithWorkerRequestOptions(wc.requestOptions...),
+	}
+
+	if wc.Background {
+		opts = append(opts, frankenphp.WithWorkerBackground())
 	}
 
 	// copy the caddy match logic and create a unique matcher function for this worker

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,6 +111,7 @@ You can also explicitly configure FrankenPHP using the [global option](https://c
 			watch <path> # Sets the path to watch for file changes. Can be specified more than once for multiple paths.
 			name <name> # Sets the name of the worker, used in logs and metrics. Default: absolute path of worker file
 			max_consecutive_failures <num> # Sets the maximum number of consecutive failures before the worker is considered unhealthy, -1 means the worker will always restart. Default: 6.
+			background # EXPERIMENTAL: marks this worker as a background (non-HTTP) worker; it runs the script in a loop without serving requests, "name" is required, "match" is not allowed.
 		}
 	}
 }
@@ -197,6 +198,7 @@ php_server [<matcher>] {
 		watch <path> # Sets the path to watch for file changes. Can be specified more than once for multiple paths.
 		env <key> <value> # Sets an extra environment variable to the given value. Can be specified more than once for multiple environment variables. Environment variables for this worker are also inherited from the php_server parent, but can be overwritten here.
 		match <path> # match the worker to a path pattern. Overrides try_files and can only be used in the php_server directive.
+		background # EXPERIMENTAL: marks this worker as a background (non-HTTP) worker; it runs the script in a loop without serving requests, "name" is required, "match" is not allowed.
 	}
 	worker <other_file> <num> # Can also use the short form like in the global frankenphp block.
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -16,6 +16,7 @@
 #else
 #include <php_config.h>
 #endif
+#include <main/php_streams.h>
 #include <php_ini.h>
 #include <php_main.h>
 #include <php_output.h>
@@ -120,6 +121,11 @@ HashTable *main_thread_env = NULL;
 
 static THREAD_LOCAL uintptr_t thread_index;
 static THREAD_LOCAL bool is_worker_thread = false;
+static THREAD_LOCAL bool is_background_worker = false;
+/* Stop pipe of a background worker thread: [0] is the read end, exposed to
+ * the PHP script via frankenphp_get_worker_handle(); [1] is the write end,
+ * transferred to the Go side, which closes it to signal a drain. */
+static THREAD_LOCAL int worker_stop_fds[2] = {-1, -1};
 static THREAD_LOCAL HashTable *sandboxed_env = NULL;
 /* prepared_env holds entries from php(_server)'s `env KEY VAL`, exposed to
  * getenv() and merged into $_ENV when 'E' is in variables_order. Separate from
@@ -336,7 +342,87 @@ void frankenphp_release_thread_for_kill(force_kill_slot slot) {
 #endif
 }
 
+/* Stop pipe of background workers: an anonymous pipe whose read end is
+ * exposed to the PHP script via frankenphp_get_worker_handle(). When the Go
+ * side closes the write end (on drain), the read end reaches EOF so the
+ * script can return from stream_select() and exit its loop gracefully. */
+static int frankenphp_worker_open_stop_pipe(void) {
+#ifdef PHP_WIN32
+  return _pipe(worker_stop_fds, 4096, _O_BINARY);
+#else
+  return pipe(worker_stop_fds);
+#endif
+}
+
+static void frankenphp_worker_close_stop_fds(void) {
+  for (int i = 0; i < 2; i++) {
+    if (worker_stop_fds[i] >= 0) {
+#ifdef PHP_WIN32
+      _close(worker_stop_fds[i]);
+#else
+      close(worker_stop_fds[i]);
+#endif
+      worker_stop_fds[i] = -1;
+    }
+  }
+}
+
+static int frankenphp_worker_dup_fd(int fd) {
+#ifdef PHP_WIN32
+  return _dup(fd);
+#else
+  return dup(fd);
+#endif
+}
+
+/* Marks the calling thread as a background worker, opens its stop pipe,
+ * transfers the write fd to the caller (clearing the TLS slot so a later
+ * recycle won't double-close it), and disarms max_execution_time. Returns
+ * -1 if the pipe could not be opened. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void) {
+  is_background_worker = true;
+  /* Bg workers don't enforce max_execution_time; disarm any lingering timer. */
+  zend_unset_timeout();
+
+  frankenphp_worker_close_stop_fds();
+  if (frankenphp_worker_open_stop_pipe() != 0) {
+    worker_stop_fds[0] = -1;
+    worker_stop_fds[1] = -1;
+
+    return -1;
+  }
+
+  int fd = worker_stop_fds[1];
+  worker_stop_fds[1] = -1;
+
+  return fd;
+}
+
+void frankenphp_worker_close_fd(int fd) {
+  if (fd < 0) {
+    return;
+  }
+  /* Closing the write end of the stop pipe lands as EOF on the read end,
+   * so the PHP side's stream_select returns promptly. */
+#ifdef PHP_WIN32
+  _close(fd);
+#else
+  close(fd);
+#endif
+}
+
 void frankenphp_update_local_thread_context(bool is_worker) {
+  /* A thread that ran a background worker can be recycled into an HTTP
+   * worker or a regular request thread: reset the bg TLS so
+   * frankenphp_get_worker_handle() rejects callers again, and release the
+   * stop pipe's read end. Streams handed out by
+   * frankenphp_get_worker_handle() own dup'ed fds and were already
+   * destroyed by request shutdown. */
+  if (is_background_worker) {
+    is_background_worker = false;
+    frankenphp_worker_close_stop_fds();
+  }
+
   is_worker_thread = is_worker;
 
   /* workers should keep running if the user aborts the connection */
@@ -843,6 +929,15 @@ PHP_FUNCTION(frankenphp_handle_request) {
     RETURN_THROWS();
   }
 
+  if (is_background_worker) {
+    /* background workers never receive HTTP requests */
+    zend_throw_exception(
+        spl_ce_RuntimeException,
+        "frankenphp_handle_request() cannot be called from a background worker",
+        0);
+    RETURN_THROWS();
+  }
+
 #ifdef ZEND_MAX_EXECUTION_TIMERS
   /* Disable timeouts while waiting for a request to handle */
   zend_unset_timeout();
@@ -1001,6 +1096,47 @@ PHP_FUNCTION(frankenphp_log) {
     free(ret);
     RETURN_THROWS();
   }
+}
+
+PHP_FUNCTION(frankenphp_get_worker_handle) {
+  ZEND_PARSE_PARAMETERS_NONE();
+
+  if (!is_background_worker) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "frankenphp_get_worker_handle() can only be called "
+                         "from a background worker",
+                         0);
+    RETURN_THROWS();
+  }
+
+  if (worker_stop_fds[0] < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "the background worker stop pipe is not available",
+                         0);
+    RETURN_THROWS();
+  }
+
+  /* Dup so the returned stream owns its fd: closing the stream (or request
+   * shutdown destroying it) never touches worker_stop_fds[0], which stays
+   * owned by the C side until the next setup or thread recycle. Each call
+   * returns a fresh stream over the same pipe; the EOF triggered by a drain
+   * reaches all of them. */
+  int fd = frankenphp_worker_dup_fd(worker_stop_fds[0]);
+  if (fd < 0) {
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to dup the background worker stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  php_stream *stream = php_stream_fopen_from_fd(fd, "rb", NULL);
+  if (stream == NULL) {
+    frankenphp_worker_close_fd(fd);
+    zend_throw_exception(spl_ce_RuntimeException,
+                         "failed to create a stream over the stop fd", 0);
+    RETURN_THROWS();
+  }
+
+  php_stream_to_zval(stream, return_value);
 }
 
 static void frankenphp_opcache_restart_hook(int reason) {
@@ -1525,6 +1661,12 @@ static void *php_thread(void *arg) {
        * (php 8.4 and under) */
       frankenphp_override_opcache_reset();
 #endif
+
+      /* php_request_startup re-arms max_execution_time; background workers
+       * never enforce it, disarm again. */
+      if (is_background_worker) {
+        zend_unset_timeout();
+      }
 
       zend_file_handle file_handle;
       zend_stream_init_filename(&file_handle, scriptName);

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -156,11 +156,38 @@ func Config() PHPConfig {
 	}
 }
 
-func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
+func calculateMaxThreads(opt *opt) (numWorkers int, err error) {
 	maxProcs := runtime.GOMAXPROCS(0) * 2
 	maxThreadsFromWorkers := 0
 
+	// background workers reserve their thread budget separately so they
+	// don't count against the HTTP-oriented admission checks below; the
+	// bump is applied on top of the calculated totals at the end
+	reservedThreads := 0
+	defer func() {
+		if err != nil {
+			return
+		}
+		opt.numThreads += reservedThreads
+		if opt.maxThreads > 0 {
+			// in auto mode (maxThreads < 0), the resolved value is floored
+			// to numThreads later, which already includes the reservation
+			opt.maxThreads += reservedThreads
+		}
+		numWorkers += reservedThreads
+	}()
+
 	for i, w := range opt.workers {
+		if w.isBackgroundWorker {
+			if w.num < 1 {
+				return 0, fmt.Errorf("background worker %q must declare num >= 1", w.name)
+			}
+			metrics.TotalWorkers(w.name, w.num)
+			reservedThreads += w.num
+
+			continue
+		}
+
 		if w.num <= 0 {
 			// https://github.com/php/frankenphp/issues/126
 			opt.workers[i].num = maxProcs

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -228,6 +228,10 @@ size_t frankenphp_get_thread_memory_usage(uintptr_t thread_index);
 void frankenphp_force_kill_thread(force_kill_slot slot);
 void frankenphp_release_thread_for_kill(force_kill_slot slot);
 
+/* Background worker primitives. */
+int frankenphp_set_background_worker_and_get_stop_fd_write(void);
+void frankenphp_worker_close_fd(int fd);
+
 void register_extensions(zend_module_entry **m, int len);
 
 #endif

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -54,3 +54,14 @@ function mercure_publish(string|array $topics, string $data = '', bool $private 
  * array<string, any> $context Values of the array will be converted to the corresponding Go type (if supported by FrankenPHP) and added to the context of the structured logs using https://pkg.go.dev/log/slog#Attr
  */
 function frankenphp_log(string $message, int $level = 0, array $context = []): void {}
+
+/**
+ * Returns a stop-signal stream for the current background worker. The
+ * stream reaches EOF when FrankenPHP drains the worker, so the script can
+ * park on stream_select() and exit its loop gracefully. Each call returns
+ * a fresh stream over the same underlying pipe. Only callable from inside
+ * a background worker.
+ *
+ * @return resource
+ */
+function frankenphp_get_worker_handle(): mixed {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 60f0d27c04f94d7b24c052e91ef294595a2bc421 */
+/* This is a generated file, edit frankenphp.stub.php instead.
+ * Stub hash: 105fcd19c04e2652e78ebf3abc5ab1f7d724a5d9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
@@ -41,6 +41,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_log, 0, 1, IS_VOID, 0
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, context, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_get_worker_handle, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(headers_send);
@@ -49,7 +51,7 @@ ZEND_FUNCTION(frankenphp_request_headers);
 ZEND_FUNCTION(frankenphp_response_headers);
 ZEND_FUNCTION(mercure_publish);
 ZEND_FUNCTION(frankenphp_log);
-
+ZEND_FUNCTION(frankenphp_get_worker_handle);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(frankenphp_handle_request, arginfo_frankenphp_handle_request)
@@ -63,6 +65,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FALIAS(apache_response_headers, frankenphp_response_headers, arginfo_apache_response_headers)
 	ZEND_FE(mercure_publish, arginfo_mercure_publish)
 	ZEND_FE(frankenphp_log, arginfo_frankenphp_log)
+	ZEND_FE(frankenphp_get_worker_handle, arginfo_frankenphp_get_worker_handle)
 	ZEND_FE_END
 };
 

--- a/options.go
+++ b/options.go
@@ -54,6 +54,7 @@ type workerOpt struct {
 	onServerStartup        func()
 	onServerShutdown       func()
 	server                 *Server
+	isBackgroundWorker     bool
 }
 
 // WithContext sets the main context to use.
@@ -231,6 +232,20 @@ func WithWorkerMatcher(matcherFunc func(*http.Request) bool) WorkerOption {
 func WithWorkerServerScope(s *Server) WorkerOption {
 	return func(w *workerOpt) error {
 		w.server = s
+
+		return nil
+	}
+}
+
+// EXPERIMENTAL: WithWorkerBackground marks this worker as a background
+// (non-HTTP) worker. Background workers run outside the request cycle:
+// they share the PHP runtime with HTTP threads but never receive HTTP
+// requests. The script can park on the stream returned by
+// frankenphp_get_worker_handle(), which reaches EOF when FrankenPHP
+// drains the worker, to exit gracefully on shutdown or restart.
+func WithWorkerBackground() WorkerOption {
+	return func(w *workerOpt) error {
+		w.isBackgroundWorker = true
 
 		return nil
 	}

--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -161,6 +161,10 @@ func (mainThread *phpMainThread) rebootAllThreads() bool {
 
 	for _, thread := range rebootingThreads {
 		rebootWg.Go(func() {
+			// wake up handlers parked in a blocking C call (background
+			// workers' stream_select on the stop pipe) so they can yield
+			// for the reboot without waiting for the force-kill below
+			thread.handler.drain()
 			close(thread.drainChan)
 			if thread.state.WaitForStateWithTimeout(rebootGracePeriod, state.YieldingForReboot) {
 				return

--- a/phpthread.go
+++ b/phpthread.go
@@ -39,11 +39,10 @@ type threadHandler interface {
 	beforeScriptExecution() string
 	afterScriptExecution(exitStatus int)
 	frankenPHPContext() *frankenPHPContext
-	// drain is a hook called by drainWorkerThreads right before drainChan is
-	// closed. Handlers that need to wake up a thread parked in a blocking C
-	// call (e.g. by closing a stop pipe) plug their signal in here. All
-	// current handlers are no-ops; this is the seam later handler types use
-	// without having to modify drainWorkerThreads.
+	// drain is a hook called right before drainChan is closed on shutdown
+	// and reboot. Handlers that need to wake up a thread parked in a
+	// blocking C call (background workers' stream_select on the stop pipe)
+	// plug their signal in here; the other handlers are no-ops.
 	drain()
 }
 
@@ -119,6 +118,9 @@ func (thread *phpThread) shutdown() {
 		return
 	}
 
+	// wake up handlers parked in a blocking C call (background workers'
+	// stream_select on the stop pipe); no-op for the other handlers
+	thread.handler.drain()
 	close(thread.drainChan)
 
 	// Arm force-kill after the grace period to wake any thread stuck in

--- a/requestoptions.go
+++ b/requestoptions.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -208,9 +209,15 @@ func WithRequestBodyTimeout(timeout time.Duration) RequestOption {
 // WithWorkerName sets the worker that should handle the request
 func WithWorkerName(name string) RequestOption {
 	return func(o *frankenPHPContext) error {
-		if name != "" {
-			o.worker = workersByName[name]
+		if name == "" {
+			return nil
 		}
+
+		w := workersByName[name]
+		if w != nil && w.isBackgroundWorker {
+			return errors.New("background worker " + strconv.Quote(name) + " cannot handle requests")
+		}
+		o.worker = w
 
 		return nil
 	}

--- a/testdata/bgworker/basic.php
+++ b/testdata/bgworker/basic.php
@@ -1,0 +1,20 @@
+<?php
+
+// Long-lived background worker: disable PHP max_execution_time so the
+// 30s default cannot interrupt the stream_select park. The C side calls
+// zend_unset_timeout() too, but the belt-and-suspenders here covers PHP
+// builds where that path does not fully disarm the timer.
+set_time_limit(0);
+
+// Touch the sentinel so the test can confirm the worker actually ran.
+if (!empty($_SERVER['BG_SENTINEL'])) {
+    @touch($_SERVER['BG_SENTINEL']);
+}
+
+// Park on the stop pipe until FrankenPHP drains us (drain closes the
+// write end, which lands as EOF on the read end).
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/crash.php
+++ b/testdata/bgworker/crash.php
@@ -1,0 +1,29 @@
+<?php
+
+// Crash-and-recover fixture. On the first boot (no marker), creates the
+// marker and exit(1) so the bg worker thread observes a non-zero exit
+// status. On the second boot (marker present), touches a "restarted"
+// sentinel and parks on the stop pipe. The test asserts the restarted
+// sentinel appears, proving the crash-restart loop ran.
+set_time_limit(0);
+
+$marker = $_SERVER['BG_CRASH_MARKER'] ?? '';
+$restarted = $_SERVER['BG_RESTARTED_SENTINEL'] ?? '';
+
+if ($marker === '' || $restarted === '') {
+    // Misconfigured: don't loop forever on a missing env.
+    exit(2);
+}
+
+if (!file_exists($marker)) {
+    file_put_contents($marker, '1');
+    exit(1);
+}
+
+@touch($restarted);
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/testdata/bgworker/named.php
+++ b/testdata/bgworker/named.php
@@ -1,0 +1,19 @@
+<?php
+
+// Long-lived bg worker that touches a per-name sentinel under
+// $_SERVER['BG_SENTINEL_DIR'] so tests can confirm the right instance
+// ran. The bg worker's $_SERVER['FRANKENPHP_WORKER'] value is the
+// declared name, so the same fixture serves multiple distinct names
+// across scopes.
+set_time_limit(0);
+
+$name = $_SERVER['FRANKENPHP_WORKER'] ?? 'unknown';
+if (!empty($_SERVER['BG_SENTINEL_DIR'])) {
+    @touch($_SERVER['BG_SENTINEL_DIR'] . DIRECTORY_SEPARATOR . $name);
+}
+
+$stream = frankenphp_get_worker_handle();
+$read = [$stream];
+$write = null;
+$except = null;
+stream_select($read, $write, $except, null);

--- a/threadbackgroundworker.go
+++ b/threadbackgroundworker.go
@@ -1,0 +1,217 @@
+package frankenphp
+
+// #include "frankenphp.h"
+import "C"
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/dunglas/frankenphp/internal/state"
+)
+
+// backgroundWorkerThread is the threadHandler of background worker scripts.
+// It owns their lifecycle: boot the script, re-run it when it exits, restart
+// it with a quadratic backoff when it crashes. Background workers share the
+// PHP runtime with HTTP threads but never receive HTTP requests. The script
+// can park on the stream returned by frankenphp_get_worker_handle(), which
+// reaches EOF when the thread is drained, to exit gracefully on shutdown,
+// reboot or handler transition.
+type backgroundWorkerThread struct {
+	state                  *state.ThreadState
+	thread                 *phpThread
+	worker                 *worker
+	dummyFrankenPHPContext *frankenPHPContext
+	failureCount           int // number of consecutive non-zero exits
+
+	// stopFdWrite holds the write end of this thread's stop pipe (per
+	// thread so pool workers drain independently); the read end is exposed
+	// to the script via frankenphp_get_worker_handle(). Atomic because
+	// drain() closes it from another goroutine.
+	stopFdWrite atomic.Int32
+}
+
+func convertToBackgroundWorkerThread(thread *phpThread, worker *worker) {
+	handler := &backgroundWorkerThread{
+		state:  thread.state,
+		thread: thread,
+		worker: worker,
+	}
+	handler.stopFdWrite.Store(-1)
+	thread.setHandler(handler)
+	worker.attachThread(thread)
+}
+
+func (handler *backgroundWorkerThread) name() string {
+	return "Background Worker PHP Thread - " + handler.worker.fileName
+}
+
+func (handler *backgroundWorkerThread) frankenPHPContext() *frankenPHPContext {
+	return handler.dummyFrankenPHPContext
+}
+
+// drain closes the stop pipe's write end so a script parked in
+// stream_select on the read end wakes up and can exit its loop. Called
+// right before drainChan is closed on shutdown and reboot; also reused
+// internally to release the fd on the other exit paths.
+func (handler *backgroundWorkerThread) drain() {
+	if fd := handler.stopFdWrite.Swap(-1); fd >= 0 {
+		C.frankenphp_worker_close_fd(C.int(fd))
+	}
+}
+
+// beforeScriptExecution returns the name of the script or an empty string on shutdown
+func (handler *backgroundWorkerThread) beforeScriptExecution() string {
+	switch handler.state.Get() {
+	case state.TransitionRequested:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+		return handler.thread.transitionToNewHandler()
+	case state.Ready, state.TransitionComplete:
+		handler.thread.updateContext(true)
+		if handler.worker.onThreadReady != nil {
+			handler.worker.onThreadReady(handler.thread.threadIndex)
+		}
+
+		for {
+			err := handler.setupScript()
+			if err == nil {
+				return handler.worker.fileName
+			}
+
+			if globalLogger.Enabled(globalCtx, slog.LevelError) {
+				globalLogger.LogAttrs(globalCtx, slog.LevelError, "failed to start background worker", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Any("error", err))
+			}
+
+			// fail fast during startup so Init() surfaces the error to the
+			// operator; past startup, back off and retry like a crash
+			if startupFailChan != nil {
+				startupFailChan <- err
+				handler.thread.state.Set(state.ShuttingDown)
+				return handler.beforeScriptExecution()
+			}
+
+			handler.backoff()
+			if !handler.state.Is(state.Ready) {
+				// drained during the backoff (shutdown, reboot, transition)
+				return handler.beforeScriptExecution()
+			}
+		}
+	case state.Rebooting, state.ForceRebooting:
+		return ""
+	case state.RebootReady:
+		handler.state.Set(state.Ready)
+		return handler.beforeScriptExecution()
+	case state.ShuttingDown:
+		if handler.worker.onThreadShutdown != nil {
+			handler.worker.onThreadShutdown(handler.thread.threadIndex)
+		}
+		handler.worker.detachThread(handler.thread)
+
+		// signal to stop
+		return ""
+	default:
+		panic("unexpected state: " + handler.state.Name())
+	}
+}
+
+// setupScript marks the thread as a background worker on the C side and
+// takes ownership of the stop pipe's write end.
+func (handler *backgroundWorkerThread) setupScript() error {
+	fd := int32(C.frankenphp_set_background_worker_and_get_stop_fd_write())
+	if fd < 0 {
+		return fmt.Errorf("failed to create the stop pipe of background worker %q", handler.worker.name)
+	}
+	handler.stopFdWrite.Store(fd)
+
+	switch handler.state.Get() {
+	case state.ShuttingDown, state.Rebooting, state.ForceRebooting:
+		// a concurrent drain may have run before the fd was published;
+		// close it now so the script observes EOF immediately
+		handler.drain()
+	}
+
+	fc, err := newWorkerDummyContext(handler.worker)
+	if err != nil {
+		handler.drain()
+		return err
+	}
+	handler.dummyFrankenPHPContext = fc
+
+	metrics.StartWorker(handler.worker.name)
+	// background workers have no later "reached steady state" marker like
+	// frankenphp_handle_request; they count as ready once the script starts
+	metrics.ReadyWorker(handler.worker.name)
+
+	if fc.logger.Enabled(fc.ctx, slog.LevelDebug) {
+		fc.logger.LogAttrs(fc.ctx, slog.LevelDebug, "starting background worker", slog.String("worker", handler.worker.name), slog.Int("thread", handler.thread.threadIndex))
+	}
+
+	if handler.state.Is(state.TransitionComplete) {
+		handler.state.Set(state.Ready)
+	}
+
+	return nil
+}
+
+func (handler *backgroundWorkerThread) afterScriptExecution(exitStatus int) {
+	// the write end of the stop pipe belongs to this thread; release it on
+	// every exit path so the next run gets a fresh pipe (drain() already
+	// took it when the exit was drain-triggered)
+	handler.drain()
+	worker := handler.worker
+	handler.dummyFrankenPHPContext = nil
+
+	// cooperative exit: the script is re-run with a reset backoff, unless
+	// the thread is being drained (beforeScriptExecution checks the state)
+	if exitStatus == 0 {
+		metrics.StopWorker(worker.name, StopReasonRestart)
+
+		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting background worker", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
+		}
+
+		handler.failureCount = 0
+		return
+	}
+
+	metrics.StopWorker(worker.name, StopReasonCrash)
+
+	// max_consecutive_failures only fails hard during startup, where it
+	// surfaces on startupFailChan so Init() returns the error to the
+	// operator. Past startup, a crashing background worker keeps
+	// restarting with a louder log line: silently giving up would leave
+	// the server in a broken half-state with no clear way to recover.
+	pastCap := worker.maxConsecutiveFailures >= 0 && handler.failureCount >= worker.maxConsecutiveFailures
+	if pastCap && startupFailChan != nil && !watcherIsEnabled {
+		startupFailChan <- fmt.Errorf("too many consecutive failures: background worker %s keeps crashing", worker.fileName)
+		handler.thread.state.Set(state.ShuttingDown)
+		return
+	}
+
+	logLevel := slog.LevelWarn
+	logMsg := "background worker crashed, restarting"
+	if pastCap {
+		logLevel = slog.LevelError
+		logMsg = "background worker exceeded max_consecutive_failures, still restarting"
+	}
+	if globalLogger.Enabled(globalCtx, logLevel) {
+		globalLogger.LogAttrs(globalCtx, logLevel, logMsg, slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("failures", handler.failureCount), slog.Int("exit_status", exitStatus))
+	}
+
+	handler.backoff()
+}
+
+// backoff waits before the next run of a crashed script: quadratic in the
+// number of consecutive failures, capped at 1 second.
+func (handler *backgroundWorkerThread) backoff() {
+	backoffDuration := time.Duration(handler.failureCount*handler.failureCount*100) * time.Millisecond
+	if backoffDuration > time.Second {
+		backoffDuration = time.Second
+	}
+	handler.failureCount++
+	time.Sleep(backoffDuration)
+}

--- a/worker.go
+++ b/worker.go
@@ -34,6 +34,8 @@ type worker struct {
 	onThreadShutdown       func(int)
 	queuedRequests         atomic.Int32
 	server                 *Server
+	// isBackgroundWorker marks this as a background (non-HTTP) worker
+	isBackgroundWorker bool
 }
 
 var (
@@ -67,6 +69,11 @@ func initWorkers(opts []workerOpt) error {
 		totalThreadsToStart += w.num
 		workers = append(workers, w)
 		workersByName[w.name] = w
+		// background workers never serve HTTP requests, so they stay out
+		// of the path-matching maps used to route requests to workers
+		if w.isBackgroundWorker {
+			continue
+		}
 		if w.server == nil {
 			globalWorkersByPath[w.fileName] = w
 		} else if err := w.server.addWorker(w); err != nil {
@@ -79,7 +86,11 @@ func initWorkers(opts []workerOpt) error {
 	for _, w := range workers {
 		for i := 0; i < w.num; i++ {
 			thread := getInactivePHPThread()
-			convertToWorkerThread(thread, w)
+			if w.isBackgroundWorker {
+				convertToBackgroundWorkerThread(thread, w)
+			} else {
+				convertToWorkerThread(thread, w)
+			}
 
 			workersReady.Go(func() {
 				thread.state.WaitFor(state.Ready, state.ShuttingDown, state.Done)
@@ -119,11 +130,22 @@ func newWorker(o workerOpt) (*worker, error) {
 		return nil, fmt.Errorf("worker file not found %q: %w", absFileName, err)
 	}
 
+	if o.isBackgroundWorker {
+		// the name is the script's identity (exposed via FRANKENPHP_WORKER);
+		// empty names are reserved for the catch-all workers of a future build
+		if o.name == "" {
+			return nil, fmt.Errorf("background worker %q must have an explicit name", o.fileName)
+		}
+		if o.matchRequest != nil {
+			return nil, fmt.Errorf("background worker %q cannot match requests", o.name)
+		}
+	}
+
 	if o.name == "" {
 		o.name = absFileName
 	}
 
-	if o.server == nil && globalWorkersByPath[absFileName] != nil {
+	if o.server == nil && !o.isBackgroundWorker && globalWorkersByPath[absFileName] != nil {
 		return nil, fmt.Errorf("two global workers cannot have the same filename: %q", absFileName)
 	}
 
@@ -145,7 +167,14 @@ func newWorker(o workerOpt) (*worker, error) {
 		}
 	}
 
-	o.env["FRANKENPHP_WORKER\x00"] = "1"
+	// $_SERVER['FRANKENPHP_WORKER'] is "1" for HTTP workers (existing
+	// behavior) and the worker name for background workers, so a bg
+	// script can know which declaration it runs for
+	if o.isBackgroundWorker {
+		o.env["FRANKENPHP_WORKER\x00"] = o.name
+	} else {
+		o.env["FRANKENPHP_WORKER\x00"] = "1"
+	}
 
 	w := &worker{
 		name:                   o.name,
@@ -160,6 +189,7 @@ func newWorker(o workerOpt) (*worker, error) {
 		onThreadReady:          o.onThreadReady,
 		onThreadShutdown:       o.onThreadShutdown,
 		server:                 o.server,
+		isBackgroundWorker:     o.isBackgroundWorker,
 	}
 
 	w.configureMercure(&o)


### PR DESCRIPTION
## Summary

Rewrite of #2398 on top of #2499, targeting the `refactor/phpserver` branch:
the smallest useful slice of the background-worker work, now built on
`Server` and the server names merged in #2529 instead of a parallel `Scope`
mechanism. A single commit on top of the base branch.

A worker declared with `WithWorkerBackground()` / `background` in the
Caddyfile runs its script in a loop outside the HTTP request cycle. The
`frankenphp_get_worker_handle()` primitive hands the script a stream that
reaches EOF when FrankenPHP drains the worker, so it can park on
`stream_select()` and exit gracefully on shutdown, reboot or restart.

## What's in

- **PHP API**: `frankenphp_get_worker_handle(): resource`, closes when the
  worker is drained (the Go side closes the write end of a per-thread stop
  pipe).
- **Go API**: `WithWorkerBackground()`. Background workers attach to a
  `Server` through the existing `WithWorkerServerScope()`; `num >= 1` is
  required (no lazy-start in this build) and the name is mandatory since it
  is the script's identity (`$_SERVER['FRANKENPHP_WORKER']`).
- **Lifecycle**: `backgroundWorkerThread` implements `threadHandler` and
  mirrors `workerThread`'s state machine: boot, re-run on cooperative exit
  (status 0, backoff reset), crash-restart with quadratic backoff, hard
  failure on `max_consecutive_failures` during startup only.
- **Caddy**: `background` flag inside worker blocks (php_server and global).
  `name` is required, `match` is rejected. Metrics/logs use the worker name,
  which #2529's qualification already keeps unique across `php_server`
  blocks, so two blocks can declare the same worker name.

## What the rewrite changes vs #2398

Building on `Server` deletes the parallel machinery the old PR carried and
addresses all review comments:

- `Scope`, `NextScope`, `SetScopeLabel`, the `scopeOwners` registry and
  `caddy/scopelabel.go` are gone; `Server` and the #2529 name resolution
  replace them. This also removes the reported `scopeOwners` data race and
  the `m#<label>:m#<name>` double-prefix in metric names. The feature diff
  is ~250 lines smaller than #2398.
- The C side no longer caches a `php_stream` in a TLS slot: each
  `frankenphp_get_worker_handle()` call dups the read fd into a fresh
  stream owned by its zval. No `GC_ADDREF` without release, no dangling
  pointer across restarts or thread recycling, nothing to clean up in
  `frankenphp_update_local_thread_context()` beyond the raw fds.
- The `-1` return of `frankenphp_set_background_worker_and_get_stop_fd_write()`
  is handled: `Init()` fails with a clear error during startup; past
  startup the thread backs off and retries instead of letting the script
  crash-loop on `frankenphp_get_worker_handle()` exceptions.
- The "exponential backoff" comment now says quadratic, matching the
  implementation.
- `drain()` (the `threadHandler` seam that is declared but not called yet
  on this branch) is wired into `thread.shutdown()` and
  `rebootAllThreads()`, so shutdowns and watch-triggered reboots wake
  parked background workers instead of hitting the force-kill grace period.
- Hardening beyond the review comments: `frankenphp_handle_request()`
  throws when called from a background worker (previously it would have hit
  the `.(*workerThread)` type assertion and crashed the process), and
  `WithWorkerName()` rejects requests targeting a background worker.
- Start/Ready/Stop worker metrics are balanced (background workers count as
  ready once the script starts, and every stop path emits `StopWorker`), so
  the `readyWorkers` gauge can't drift negative.

## Deferred (kept out for review surface)

- `frankenphp_ensure_background_worker()` and lazy-start machinery.
- Catch-all (empty-name) workers.
- Shared-state APIs (`frankenphp_set_vars` / `frankenphp_get_vars`).
- An orchestrator-style `frankenphp_start_background_worker()` runtime API
  (discussed in #2398); the primitives here are compatible with it.

## Test plan

- [ ] `TestBackgroundWorkerLifecycle`: bg worker boots, touches sentinel,
      parks on the stop pipe, `Shutdown()` returns within 10s.
- [ ] `TestBackgroundWorkerCrashRestarts`: `exit(1)` on first boot, the
      respawned run touches the "restarted" sentinel.
- [ ] `TestBackgroundWorkerOnServer`: server-scoped worker inherits the
      server env, `FRANKENPHP_WORKER` carries the name, HTTP requests on the
      same server still serve.
- [ ] `TestBackgroundWorkerValidation`: name required, `num >= 1`, global
      name namespace, request matchers rejected.
- [x] `TestWorkerBackgroundConfig` / `RequiresName` / `RejectsMatch`
      (Caddyfile parsing, pass locally).

The runtime tests need CI to confirm: on my current box (WSL2), per-thread
engine bootstrap of any embed ZTS build is pathologically slow, so every
`Init()`-based test times out locally, including on unmodified base commits.
