### PR TITLE
fix: report total threads as gauge (#2481)

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -744,7 +744,7 @@ func TestMetrics(t *testing.T) {
 	// Check metrics
 	expectedMetrics := `
 	# HELP frankenphp_total_threads Total number of PHP threads
-	# TYPE frankenphp_total_threads counter
+	# TYPE frankenphp_total_threads gauge
 	frankenphp_total_threads ` + cpus + `
 
 	# HELP frankenphp_busy_threads Number of busy PHP threads
@@ -820,7 +820,7 @@ func TestWorkerMetrics(t *testing.T) {
 	// Check metrics
 	expectedMetrics := `
 	# HELP frankenphp_total_threads Total number of PHP threads
-	# TYPE frankenphp_total_threads counter
+	# TYPE frankenphp_total_threads gauge
 	frankenphp_total_threads ` + cpus + `
 
 	# HELP frankenphp_busy_threads Number of busy PHP threads
@@ -977,7 +977,7 @@ func TestNamedWorkerMetrics(t *testing.T) {
 	// Check metrics
 	expectedMetrics := `
 	# HELP frankenphp_total_threads Total number of PHP threads
-	# TYPE frankenphp_total_threads counter
+	# TYPE frankenphp_total_threads gauge
 	frankenphp_total_threads ` + cpus + `
 
 	# HELP frankenphp_busy_threads Number of busy PHP threads
@@ -1073,7 +1073,7 @@ func TestAutoWorkerConfig(t *testing.T) {
 	// Check metrics
 	expectedMetrics := `
 	# HELP frankenphp_total_threads Total number of PHP threads
-	# TYPE frankenphp_total_threads counter
+	# TYPE frankenphp_total_threads gauge
 	frankenphp_total_threads ` + cpus + `
 
 	# HELP frankenphp_busy_threads Number of busy PHP threads
@@ -1440,7 +1440,7 @@ func TestMultiWorkersMetrics(t *testing.T) {
 	// Check metrics
 	expectedMetrics := `
 	# HELP frankenphp_total_threads Total number of PHP threads
-	# TYPE frankenphp_total_threads counter
+	# TYPE frankenphp_total_threads gauge
 	frankenphp_total_threads ` + cpus + `
 
 	# HELP frankenphp_busy_threads Number of busy PHP threads

--- a/metrics.go
+++ b/metrics.go
@@ -83,7 +83,7 @@ func (n nullMetrics) DequeuedRequest() {}
 
 type PrometheusMetrics struct {
 	registry           prometheus.Registerer
-	totalThreads       prometheus.Counter
+	totalThreads       prometheus.Gauge
 	busyThreads        prometheus.Gauge
 	totalWorkers       *prometheus.GaugeVec
 	busyWorkers        *prometheus.GaugeVec
@@ -258,7 +258,7 @@ func (m *PrometheusMetrics) TotalThreads(num int) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	m.totalThreads.Add(float64(num))
+	m.totalThreads.Set(float64(num))
 }
 
 func (m *PrometheusMetrics) StartRequest() {
@@ -380,7 +380,7 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 
 	m := &PrometheusMetrics{
 		registry: registry,
-		totalThreads: prometheus.NewCounter(prometheus.CounterOpts{
+		totalThreads: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "frankenphp_total_threads",
 			Help: "Total number of PHP threads",
 		}),

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -10,13 +10,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	totalThreadsMetricName      = "frankenphp_total_threads"
+	initialTotalThreadsMetric   = 3
+	reconfiguredThreadsMetric   = 2
+	expectedTotalThreadsMetrics = `
+		# HELP frankenphp_total_threads Total number of PHP threads
+		# TYPE frankenphp_total_threads gauge
+		frankenphp_total_threads 2
+	`
+)
+
 func createPrometheusMetrics() *PrometheusMetrics {
 	return &PrometheusMetrics{
 		registry:     prometheus.NewRegistry(),
-		totalThreads: prometheus.NewCounter(prometheus.CounterOpts{Name: "frankenphp_total_threads"}),
+		totalThreads: prometheus.NewGauge(prometheus.GaugeOpts{Name: "frankenphp_total_threads"}),
 		busyThreads:  prometheus.NewGauge(prometheus.GaugeOpts{Name: "frankenphp_busy_threads"}),
 		queueDepth:   prometheus.NewGauge(prometheus.GaugeOpts{Name: "frankenphp_queue_depth"}),
 	}
+}
+
+func TestPrometheusMetrics_TotalThreadsReportsCurrentValue(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(registry)
+
+	m.TotalThreads(initialTotalThreadsMetric)
+	m.TotalThreads(reconfiguredThreadsMetric)
+
+	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedTotalThreadsMetrics), totalThreadsMetricName))
 }
 
 func TestPrometheusMetrics_TotalWorkers(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix #2481

- Register `frankenphp_total_threads` as a Prometheus gauge.
- Report the current configured thread count with `Set` instead of accumulating with `Add`.
- Update metric test expectations for the Caddy integration tests.

## Test verification (RED -> GREEN)

RED, on `main` with only the new regression test added:

```text
--- FAIL: TestPrometheusMetrics_TotalThreadsReportsCurrentValue (0.00s)
    metrics_test.go:40:
        Error:       Received unexpected error:
                     # HELP frankenphp_total_threads Total number of PHP threads
                    -# TYPE frankenphp_total_threads counter
                    -frankenphp_total_threads 5
                    +# TYPE frankenphp_total_threads gauge
                    +frankenphp_total_threads 2
FAIL
```

GREEN, after the fix:

```text
ok  	command-line-arguments	0.009s
```

Additional targeted metrics run:

```text
ok  	command-line-arguments	0.008s
```

## Full local suite

Local environment notes:

- The host does not have Go installed, so validation was run in Docker.
- `go test ./...` in a plain Go container failed before tests because native PHP/watcher headers were absent.
- `go test -tags nowatcher ./...` with `php-dev` reached native linking but failed because the minimal container lacked PHP link libraries.
- After adding PHP link libraries, the focused root-package command passed:

```text
ok  	github.com/dunglas/frankenphp	0.032s
```

- The complete root-package run with the same native dependencies was killed by the container with exit code 137 before producing test results.

## Files changed

| File | Change |
|------|--------|
| `metrics.go` | Change `totalThreads` from `Counter` to `Gauge` and use `Set`. |
| `metrics_test.go` | Add regression coverage for type and current-value semantics. |
| `caddy/caddy_test.go` | Update expected metric type to `gauge`. |
