### PR TITLE
fix: log watched file changes at debug level

### DIFF
--- a/internal/watcher/pattern.go
+++ b/internal/watcher/pattern.go
@@ -11,7 +11,14 @@ import (
 	"github.com/e-dant/watcher/watcher-go"
 )
 
-const sep = string(filepath.Separator)
+const (
+	sep                           = string(filepath.Separator)
+	changedFileLogMessage         = "filesystem change detected"
+	changedFilePathLogAttr        = "path"
+	changedFileAssociatedLogAttr  = "associated_path"
+	specialWatcherEventLogMessage = "special e-dant/watcher event"
+	watcherEventLogAttr           = "event"
+)
 
 type pattern struct {
 	patternGroup *PatternGroup
@@ -101,6 +108,7 @@ func (p *pattern) handle(event *watcher.Event) {
 	}
 
 	if p.allowReload(event) {
+		logChangedFile(event)
 		p.events <- eventHolder{p.patternGroup, event}
 	}
 }
@@ -114,11 +122,24 @@ func isValidEventType(effectType watcher.EffectType) bool {
 }
 
 func isValidPathType(event *watcher.Event) bool {
-	if event.PathType == watcher.PathTypeWatcher && globalLogger.Enabled(globalCtx, slog.LevelDebug) {
-		globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "special e-dant/watcher event", slog.Any("event", event))
+	if event.PathType == watcher.PathTypeWatcher && globalLogger != nil && globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+		globalLogger.LogAttrs(globalCtx, slog.LevelDebug, specialWatcherEventLogMessage, slog.Any(watcherEventLogAttr, event))
 	}
 
 	return event.PathType <= watcher.PathTypeHardLink
+}
+
+func logChangedFile(event *watcher.Event) {
+	if globalLogger == nil || !globalLogger.Enabled(globalCtx, slog.LevelDebug) {
+		return
+	}
+
+	attrs := []slog.Attr{slog.String(changedFilePathLogAttr, event.PathName)}
+	if event.AssociatedPathName != "" {
+		attrs = append(attrs, slog.String(changedFileAssociatedLogAttr, event.AssociatedPathName))
+	}
+
+	globalLogger.LogAttrs(globalCtx, slog.LevelDebug, changedFileLogMessage, attrs...)
 }
 
 func (p *pattern) isValidPattern(fileName string) bool {

--- a/internal/watcher/pattern.go
+++ b/internal/watcher/pattern.go
@@ -11,14 +11,7 @@ import (
 	"github.com/e-dant/watcher/watcher-go"
 )
 
-const (
-	sep                           = string(filepath.Separator)
-	changedFileLogMessage         = "filesystem change detected"
-	changedFilePathLogAttr        = "path"
-	changedFileAssociatedLogAttr  = "associated_path"
-	specialWatcherEventLogMessage = "special e-dant/watcher event"
-	watcherEventLogAttr           = "event"
-)
+const sep = string(filepath.Separator)
 
 type pattern struct {
 	patternGroup *PatternGroup
@@ -123,7 +116,7 @@ func isValidEventType(effectType watcher.EffectType) bool {
 
 func isValidPathType(event *watcher.Event) bool {
 	if event.PathType == watcher.PathTypeWatcher && globalLogger != nil && globalLogger.Enabled(globalCtx, slog.LevelDebug) {
-		globalLogger.LogAttrs(globalCtx, slog.LevelDebug, specialWatcherEventLogMessage, slog.Any(watcherEventLogAttr, event))
+		globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "special e-dant/watcher event", slog.Any("event", event))
 	}
 
 	return event.PathType <= watcher.PathTypeHardLink
@@ -134,12 +127,12 @@ func logChangedFile(event *watcher.Event) {
 		return
 	}
 
-	attrs := []slog.Attr{slog.String(changedFilePathLogAttr, event.PathName)}
+	attrs := []slog.Attr{slog.String("path", event.PathName)}
 	if event.AssociatedPathName != "" {
-		attrs = append(attrs, slog.String(changedFileAssociatedLogAttr, event.AssociatedPathName))
+		attrs = append(attrs, slog.String("associated_path", event.AssociatedPathName))
 	}
 
-	globalLogger.LogAttrs(globalCtx, slog.LevelDebug, changedFileLogMessage, attrs...)
+	globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "filesystem change detected", attrs...)
 }
 
 func (p *pattern) isValidPattern(fileName string) bool {

--- a/internal/watcher/pattern_test.go
+++ b/internal/watcher/pattern_test.go
@@ -3,6 +3,9 @@
 package watcher
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -353,6 +356,29 @@ func TestAnAssociatedEventTriggersTheWatcher(t *testing.T) {
 	go w.handle(e)
 
 	assert.Equal(t, e, (<-w.events).event)
+}
+
+func TestAcceptedEventLogsChangedPathAtDebugLevel(t *testing.T) {
+	var logs bytes.Buffer
+	previousCtx := globalCtx
+	previousLogger := globalLogger
+	globalCtx = context.Background()
+	globalLogger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() {
+		globalCtx = previousCtx
+		globalLogger = previousLogger
+	})
+
+	w := newPattern(t, "/**/*.php")
+	w.events = make(chan eventHolder, 1)
+
+	changedPath := normalizePath(t, "/path/file.php")
+	e := &watcher.Event{PathName: changedPath}
+
+	w.handle(e)
+
+	assert.Equal(t, e, (<-w.events).event)
+	assert.Contains(t, logs.String(), changedPath)
 }
 
 func relativeDir(t *testing.T, relativePath string) string {


### PR DESCRIPTION
Fixes #1443.

## Changes

- Logs each accepted watcher event at debug level with the changed file path.
- Includes the associated path when the watcher reports one.
- Keeps the existing reload behavior unchanged.

## Test verification (RED -> GREEN)

RED on `origin/main` plus the new regression test before the implementation:

```
--- FAIL: TestAcceptedEventLogsChangedPathAtDebugLevel (0.00s)
    pattern_test.go:381:
        Error:       "" does not contain "/path/file.php"
        Test:        TestAcceptedEventLogsChangedPathAtDebugLevel
FAIL
FAIL    github.com/dunglas/frankenphp/internal/watcher    0.005s
```

GREEN after the fix:

```
ok      github.com/dunglas/frankenphp/internal/watcher    0.008s
```

Command used for GREEN: `go test ./internal/watcher -count=1` in Docker with the watcher C library installed.