### PR TITLE
docs: clarify PHP library path for source builds

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -106,8 +106,8 @@ The recommended way is to use [xcaddy](https://github.com/caddyserver/xcaddy) to
 ```console
 CGO_ENABLED=1 \
 XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
-CGO_CFLAGS=$(php-config --includes) \
-CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
+CGO_CFLAGS="$(php-config --includes)" \
+CGO_LDFLAGS="$(php-config --ldflags) -L$(php-config --prefix)/lib $(php-config --libs)" \
 xcaddy build \
     --output frankenphp \
     --with github.com/dunglas/frankenphp/caddy \
@@ -120,6 +120,8 @@ xcaddy build \
     # --with github.com/dunglas/frankenphp/caddy=$(pwd)/caddy
 
 ```
+
+If your distribution provides a versioned command such as `php-config-zts` or `php-config8.4`, use that command consistently in the `CGO_CFLAGS` and `CGO_LDFLAGS` values.
 
 > [!TIP]
 >
@@ -138,5 +140,5 @@ Alternatively, it's possible to compile FrankenPHP without `xcaddy` by using the
 ```console
 curl -L https://github.com/php/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
+../../go.sh build
 ```


### PR DESCRIPTION
Fix #601.

## Changes

- Add the selected PHP prefix library directory to the `CGO_LDFLAGS` example used with `xcaddy`, so the linker can find FrankenPHP's hard-coded `-lphp` when libphp is installed outside the default linker paths.
- Mention that versioned `php-config` commands must be used consistently in the cgo flags.
- Use the repository `go.sh` wrapper for the direct `go build` example, now that it owns the default build tags and `php-config` handling.

## Validation

Verified in Docker with `dunglas/frankenphp:1.12.6-builder-php8.5`, Go 1.26.5 from the official Go image, and pinned `xcaddy` tag `v0.4.5`.

The build used the documented values:

```console
CGO_CFLAGS="$(php-config --includes)"
CGO_LDFLAGS="$(php-config --ldflags) -L$(php-config --prefix)/lib $(php-config --libs)"
XCADDY_GO_BUILD_FLAGS="-ldflags=\"-w -s\" -tags=nobadger,nomysql,nopgx"
xcaddy build --output /tmp/frankenphp-doc-verify \
  --with github.com/dunglas/frankenphp=/src \
  --with github.com/dunglas/frankenphp/caddy=/src/caddy
```

Result:

```console
Build complete: /tmp/frankenphp-doc-verify
/tmp/frankenphp-doc-verify version
v2.11.4 h1:XKxkMTgNSizEvKG6QHue6cAsFOteU2qA61w2tKkCWi0=
```

Also ran `git diff --check`.
