### PR TITLE
docs: document HTTP request filtering differences

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -23,7 +23,7 @@ This guide covers a basic migration for a typical PHP application.
 ## HTTP request filtering
 
 When migrating from a stock Nginx or Apache package, check any request filtering that was done by the web server before PHP-FPM received the request.
-FrankenPHP is built on Caddy, so valid HTTP methods and headers are passed through Caddy's normal routing unless your `Caddyfile` rejects them first.
+FrankenPHP is built on Caddy, so valid HTTP methods and headers are passed through Caddy's normal routing unless your `Caddyfile` or another proxy rejects them first.
 
 For example, some web servers reject `TRACE` requests by default.
 If your application should keep that behavior, add an explicit matcher before `php_server`:
@@ -39,6 +39,7 @@ example.com {
 ```
 
 Apply the same approach to any stricter method or header policy your previous front web server enforced.
+This is also relevant for request header names: some front web servers or proxies reject or drop valid-but-uncommon HTTP field names before PHP-FPM sees them, while FrankenPHP may pass them to the PHP application.
 
 ## Step 1: replace your web server config
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -18,6 +18,27 @@ This guide covers a basic migration for a typical PHP application.
 | `php_value` / `php_admin_value`   | [`php_ini` Caddyfile directive](config.md#php-config)    |
 | `pm = static` / `pm.max_children` | `num_threads`                                            |
 | `pm = dynamic`                    | [`max_threads auto`](performance.md#max_threads)         |
+| Web server request filtering      | Caddy routes and matchers                                |
+
+## HTTP request filtering
+
+When migrating from a stock Nginx or Apache package, check any request filtering that was done by the web server before PHP-FPM received the request.
+FrankenPHP is built on Caddy, so valid HTTP methods and headers are passed through Caddy's normal routing unless your `Caddyfile` rejects them first.
+
+For example, some web servers reject `TRACE` requests by default.
+If your application should keep that behavior, add an explicit matcher before `php_server`:
+
+```caddyfile
+example.com {
+    @trace method TRACE
+    respond @trace 405
+
+    root /var/www/app/public
+    php_server
+}
+```
+
+Apply the same approach to any stricter method or header policy your previous front web server enforced.
 
 ## Step 1: replace your web server config
 


### PR DESCRIPTION
Fix #2521.

## Changes

- Document request-filtering differences to check when migrating from Nginx or Apache plus PHP-FPM.
- Add a `TRACE` method example showing how to reject it explicitly in the `Caddyfile` before `php_server`.
- Mention that stricter header-name filtering may also need to be enforced by the `Caddyfile` or another proxy when migrating.
- Keep FrankenPHP's default behavior unchanged.

## Validation

Verified with Docker using `dunglas/frankenphp:1.12.6-php8.5` and a PHP script that prints the request method and incoming `HTTP_X_*` server variables.

Default Caddyfile:

```console
GET /index.php      -> 200, method=GET
TRACE /index.php    -> 200, method=TRACE
special header name -> passed to PHP as HTTP_X_SPECIAL!#$%&*+_^|~
```

With the documented matcher:

```console
GET /index.php      -> 200, method=GET
TRACE /index.php    -> 405
special header name -> still passed to PHP unless filtered separately
```

Also ran `git diff --check`.
