### PR TITLE
fix: removes opcache_hook again

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1003,14 +1003,9 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
-static void frankenphp_opcache_restart_hook(int reason) {
-  (void)reason;
-  go_schedule_opcache_reset(frankenphp_thread_index());
-}
-
 /* {{{ thread-safe opcache reset */
 PHP_FUNCTION(frankenphp_opcache_reset) {
-  frankenphp_opcache_restart_hook(0);
+  go_schedule_opcache_reset(frankenphp_thread_index());
 
   RETVAL_TRUE;
 } /* }}} */
@@ -1704,13 +1699,6 @@ static void *php_main(void *arg) {
   }
 
   frankenphp_sapi_module.startup(&frankenphp_sapi_module);
-
-#if defined(ZTS) && PHP_VERSION_ID >= 80400
-  /* Also restart everything on opcache memory overflow or similar events, the
-   * hook is triggered right before an opcache reset is scheduled
-   */
-  zend_accel_schedule_restart_hook = frankenphp_opcache_restart_hook;
-#endif
 
   /* check if a default filter is set in php.ini and only filter if
    * it is, this is deprecated and will be removed in PHP 9 */


### PR DESCRIPTION
This PR removes the opcache invalidate hook again. Might fix #2553.

A hard restart everytime the opcache resets due to memory overflow sounds like a good idea at first, but if a framework relies on a lot of opcache invalidation, restarts might become recursive.

Probably wasn't a good idea to hook into restarts like this in the first place as it's not really possible to test the behavior.