### PR TITLE
docs: explain why the post-force-kill reboot wait must stay unbounded

### DIFF
--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -176,6 +176,24 @@ func (mainThread *phpMainThread) rebootAllThreads() bool {
 				slog.String("timeout", rebootGracePeriod.String()),
 			)
 			thread.sendKillSignal()
+			// This wait is intentionally unbounded. force_kill_thread only
+			// interrupts the Zend VM at the next opcode boundary or wakes a
+			// real blocking syscall via EINTR (see frankenphp_force_kill_thread);
+			// a thread parked in a blocking Go/cgo call (e.g. go_ub_write to a
+			// stalled client) can't be reached by either and may never yield.
+			// It's tempting to bound this wait and give up on the thread
+			// instead of blocking the whole reboot forever, but that's unsafe:
+			// php_main() in frankenphp.c runs this same teardown on every
+			// reboot, not just final shutdown, and calls tsrm_shutdown() as
+			// soon as mainThread.state becomes Rebooting. tsrm_shutdown()
+			// requires every PHP thread to have already exited - giving up on
+			// one while its OS thread is still alive and registered in TSRM
+			// tears down global engine state out from under a thread that's
+			// still using it, a use-after-free confirmed by CI when this was
+			// tried (see the discussion on php/frankenphp#2573). The safe
+			// mitigations are reducing how often a thread ever gets stuck like
+			// this in the first place (see WithResponseWriteTimeout and the
+			// opcache_reset throttle), not recovering from it after the fact.
 			thread.state.WaitFor(state.YieldingForReboot)
 		})
 	}


### PR DESCRIPTION
Comment-only change, no behavior change.

#2573 tried to bound this wait and abandon an unresponsive thread instead of blocking the whole reboot forever — a reasonable-looking fix for #2553's escalating hang. It's unsafe: `php_main()` in `frankenphp.c` runs the same SAPI/TSRM teardown on every reboot cycle (not just final shutdown), and `tsrm_shutdown()` requires every PHP thread to have already exited first. Giving up on a thread whose OS thread is still alive and registered in TSRM tears down global engine state out from under it — a use-after-free confirmed by CI segfaults on that PR (see the discussion on #2573, now closed).

Adding this as a comment so the next attempt at #2553 doesn't rediscover the same crash the hard way. #2570 and #2574 remain the correct lever: reduce how often a thread ever gets stuck like this, since recovering from it after the fact isn't safely possible.