### PR TITLE
fix: don't warn on routine client-disconnect write/flush errors

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -631,8 +631,9 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 			if globalLogger.Enabled(ctx, slog.LevelWarn) {
 				globalLogger.LogAttrs(ctx, slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
 			}
-		} else if globalLogger.Enabled(ctx, slog.LevelWarn) {
-			globalLogger.LogAttrs(ctx, slog.LevelWarn, "flush error", slog.Any("error", err))
+		} else if globalLogger.Enabled(ctx, slog.LevelDebug) {
+			// e.g. a client disconnecting mid-flush: expected, not actionable
+			globalLogger.LogAttrs(ctx, slog.LevelDebug, "flush error", slog.Any("error", err))
 		}
 	}
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -624,17 +624,20 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 	if fc.responseController == nil {
 		fc.responseController = http.NewResponseController(fc.responseWriter)
 	}
-	if err := fc.responseController.Flush(); err != nil {
-		ctx := thread.context()
 
-		if errors.Is(err, http.ErrNotSupported) {
-			if globalLogger.Enabled(ctx, slog.LevelWarn) {
-				globalLogger.LogAttrs(ctx, slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
-			}
-		} else if globalLogger.Enabled(ctx, slog.LevelDebug) {
-			// e.g. a client disconnecting mid-flush: expected, not actionable
-			globalLogger.LogAttrs(ctx, slog.LevelDebug, "flush error", slog.Any("error", err))
-		}
+	err := fc.responseController.Flush()
+	if err == nil {
+		return false
+	}
+
+	msg := "flush error"
+	if errors.Is(err, http.ErrNotSupported) {
+		msg = "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue"
+	}
+
+	ctx := thread.context()
+	if globalLogger.Enabled(ctx, slog.LevelWarn) {
+		globalLogger.LogAttrs(ctx, slog.LevelWarn, msg, slog.Any("error", err))
 	}
 
 	return false

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -627,8 +627,12 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 	if err := fc.responseController.Flush(); err != nil {
 		ctx := thread.context()
 
-		if globalLogger.Enabled(ctx, slog.LevelWarn) {
-			globalLogger.LogAttrs(ctx, slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
+		if errors.Is(err, http.ErrNotSupported) {
+			if globalLogger.Enabled(ctx, slog.LevelWarn) {
+				globalLogger.LogAttrs(ctx, slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
+			}
+		} else if globalLogger.Enabled(ctx, slog.LevelWarn) {
+			globalLogger.LogAttrs(ctx, slog.LevelWarn, "flush error", slog.Any("error", err))
 		}
 	}
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -451,8 +451,8 @@ func go_ub_write(threadIndex C.uintptr_t, cBuf *C.char, length C.size_t) (C.size
 	if e != nil {
 		ctx = thread.context()
 
-		if fc.logger.Enabled(ctx, slog.LevelWarn) {
-			fc.logger.LogAttrs(ctx, slog.LevelWarn, "write error", slog.Any("error", e))
+		if fc.logger.Enabled(ctx, slog.LevelDebug) {
+			fc.logger.LogAttrs(ctx, slog.LevelDebug, "write error", slog.Any("error", e))
 		}
 	}
 
@@ -630,14 +630,14 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 		return false
 	}
 
-	msg := "flush error"
-	if errors.Is(err, http.ErrNotSupported) {
-		msg = "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue"
-	}
-
 	ctx := thread.context()
-	if globalLogger.Enabled(ctx, slog.LevelWarn) {
-		globalLogger.LogAttrs(ctx, slog.LevelWarn, msg, slog.Any("error", err))
+
+	if errors.Is(err, http.ErrNotSupported) {
+		if globalLogger.Enabled(ctx, slog.LevelWarn) {
+			globalLogger.LogAttrs(ctx, slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
+		}
+	} else if globalLogger.Enabled(ctx, slog.LevelDebug) {
+		globalLogger.LogAttrs(ctx, slog.LevelDebug, "flush error", slog.Any("error", err))
 	}
 
 	return false


### PR DESCRIPTION
## Summary

While investigating https://github.com/php/frankenphp/issues/2588, found two related logging bugs around client disconnects.

`go_sapi_flush` logged every `ResponseController.Flush()` error under the same message:

> the current responseWriter is not a flusher, if you are not using a custom build, please report this issue

That message is only accurate for `http.ErrNotSupported`. A plain disconnect/write error (e.g. an aborted HTTP/2 stream) got mislabeled the same way, misleading and able to mask the real cause when triaging issues shaped like #2588.

Also reconsidered the log level. `go_ub_write`'s equivalent "write error" was logged at warn, so the new "flush error" branch was first matched to it. But a client disconnecting mid-response is routine, and both writes and flushes happen in a loop, so a single request can log this dozens or hundreds of times, one per write/flush call after the disconnect. Not warn-worthy.

Checked how the two other Caddy-family projects here handle this same class of error:
- Caddy's reverse proxy streaming (`streaming.go`): "backConn write failed", "response flush", "streaming error" - all logged at debug.
- Mercure's SSE hub (`subscribe.go`): "Failed to write comment" (per-write, in a loop) and "Connection closed by the client" are debug; only one-off lifecycle events like "Subscriber disconnected" are info.

Matched that convention:
- `go_ub_write`'s "write error" -> debug (was warn).
- `go_sapi_flush`'s "flush error" -> debug (routine disconnect), correctly separated from "not a flusher".
- `go_sapi_flush`'s "not a flusher" -> stays warn (real misconfiguration, not a per-request occurrence).

This only fixes logging, not the segfault. I was not able to reproduce the crash reported in #2588 (see comment on the issue).

## Test plan
- `go build ./...`
- `go vet ./...`
- `go test -run "TestConnectionAbort|TestLog" ./...`