### PR TITLE
fix: don't segfault when the PHP CLI is executed while FrankenPHP is running

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,11 +2,45 @@ package frankenphp
 
 // #include "frankenphp.h"
 import "C"
-import "unsafe"
+
+import (
+	"log/slog"
+	"unsafe"
+)
+
+// cliUsageErrorExitCode is the exit status returned by ExecuteScriptCLI and
+// ExecutePHPCode when the call cannot be executed, for instance when FrankenPHP
+// is already running in the current process.
+const cliUsageErrorExitCode = 1
+
+// refuseCLIWhileRunning reports whether a CLI execution must be refused because
+// FrankenPHP is already running in this process. ExecuteScriptCLI/ExecutePHPCode
+// start the embedded PHP CLI SAPI, and doing so on top of the already-started
+// FrankenPHP SAPI corrupts the PHP engine and crashes the whole process with a
+// segmentation fault. Run the PHP CLI in a dedicated process instead.
+// See https://github.com/php/frankenphp/issues/2342.
+func refuseCLIWhileRunning() bool {
+	if !isRunning {
+		return false
+	}
+
+	globalLogger.LogAttrs(globalCtx, slog.LevelError, "the PHP CLI cannot be executed while FrankenPHP is running; run ExecuteScriptCLI/ExecutePHPCode in a dedicated process instead")
+
+	return true
+}
 
 // ExecuteScriptCLI executes the PHP script passed as parameter.
 // It returns the exit status code of the script.
+//
+// It must not be called while FrankenPHP is running in the same process (that is,
+// after a successful [Init] and before [Shutdown]): the embedded PHP CLI SAPI
+// cannot coexist with the running FrankenPHP SAPI. In that case the call is
+// refused, an error is logged, and a non-zero exit status is returned.
 func ExecuteScriptCLI(script string, args []string) int {
+	if refuseCLIWhileRunning() {
+		return cliUsageErrorExitCode
+	}
+
 	// Ensure extensions are registered before CLI execution
 	registerExtensions()
 
@@ -19,7 +53,17 @@ func ExecuteScriptCLI(script string, args []string) int {
 	return int(C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0])), false))
 }
 
+// ExecutePHPCode evaluates the PHP code passed as parameter.
+// It returns the exit status code of the code.
+//
+// Like [ExecuteScriptCLI], it must not be called while FrankenPHP is running in
+// the same process; in that case the call is refused, an error is logged, and a
+// non-zero exit status is returned.
 func ExecutePHPCode(phpCode string) int {
+	if refuseCLIWhileRunning() {
+		return cliUsageErrorExitCode
+	}
+
 	// Ensure extensions are registered before CLI execution
 	registerExtensions()
 

--- a/cli.go
+++ b/cli.go
@@ -34,8 +34,10 @@ func refuseCLIWhileRunning() bool {
 //
 // It must not be called while FrankenPHP is running in the same process (that is,
 // after a successful [Init] and before [Shutdown]): the embedded PHP CLI SAPI
-// cannot coexist with the running FrankenPHP SAPI. In that case the call is
-// refused, an error is logged, and a non-zero exit status is returned.
+// cannot coexist with the running FrankenPHP SAPI. Run it before [Init], after
+// [Shutdown], or in a separate process (for example the same binary in "php-cli"
+// mode) instead. While FrankenPHP is running the call is refused: an error is
+// logged and a non-zero exit status is returned.
 func ExecuteScriptCLI(script string, args []string) int {
 	if refuseCLIWhileRunning() {
 		return cliUsageErrorExitCode

--- a/cli_internal_test.go
+++ b/cli_internal_test.go
@@ -1,0 +1,26 @@
+package frankenphp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit coverage for the guard added for
+// https://github.com/php/frankenphp/issues/2342: the embedded PHP CLI SAPI must
+// not be started while FrankenPHP is already running, otherwise the process
+// crashes with a segmentation fault.
+func TestRefuseCLIWhileRunning(t *testing.T) {
+	// When FrankenPHP is not running, the CLI helpers proceed normally.
+	assert.False(t, refuseCLIWhileRunning())
+
+	require.NoError(t, Init())
+	defer Shutdown()
+
+	// While running, the guard trips and the public entrypoints refuse cleanly
+	// with the usage exit code instead of crashing the process.
+	assert.True(t, refuseCLIWhileRunning())
+	assert.Equal(t, cliUsageErrorExitCode, ExecuteScriptCLI("testdata/command.php", []string{"testdata/command.php"}))
+	assert.Equal(t, cliUsageErrorExitCode, ExecutePHPCode("echo 'noop';"))
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -86,7 +86,7 @@ func TestExecuteScriptCLIWhileRunning(t *testing.T) {
 
 	// The process must exit cleanly, not be killed by a signal (before the fix
 	// it crashed with SIGSEGV, reported by ProcessState.Exited() == false).
-	assert.True(t, exitError.ProcessState.Exited(),
+	assert.True(t, exitError.Exited(),
 		"process was killed by a signal instead of exiting cleanly: %s\noutput: %s", exitError, stdoutStderr)
 	assert.Equal(t, 1, exitError.ExitCode(), "output: %s", stdoutStderr)
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecuteScriptCLI(t *testing.T) {
@@ -65,6 +66,29 @@ func TestExecuteScriptCLISignals(t *testing.T) {
 	}
 	assert.NoError(t, err, "output: %s", stdoutStderr)
 	assert.Contains(t, string(stdoutStderr), "ok")
+}
+
+// Regression test for https://github.com/php/frankenphp/issues/2342. Calling
+// ExecuteScriptCLI (or ExecutePHPCode) while FrankenPHP is already running in the
+// same process used to boot the embedded PHP CLI SAPI on top of the running
+// FrankenPHP SAPI, corrupting the engine and crashing the whole process with a
+// segmentation fault. It must now be refused cleanly with a non-zero exit status.
+func TestExecuteScriptCLIWhileRunning(t *testing.T) {
+	if _, err := os.Stat("internal/testcli/testcli"); err != nil {
+		t.Skip("internal/testcli/testcli has not been compiled, run `cd internal/testcli/ && go build`")
+	}
+
+	cmd := exec.Command("internal/testcli/testcli", "-init-first", "testdata/command.php")
+	stdoutStderr, err := cmd.CombinedOutput()
+
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError, "output: %s", stdoutStderr)
+
+	// The process must exit cleanly, not be killed by a signal (before the fix
+	// it crashed with SIGSEGV, reported by ProcessState.Exited() == false).
+	assert.True(t, exitError.ProcessState.Exited(),
+		"process was killed by a signal instead of exiting cleanly: %s\noutput: %s", exitError, stdoutStderr)
+	assert.Equal(t, 1, exitError.ExitCode(), "output: %s", stdoutStderr)
 }
 
 func ExampleExecuteScriptCLI() {

--- a/internal/testcli/main.go
+++ b/internal/testcli/main.go
@@ -17,5 +17,18 @@ func main() {
 		os.Exit(frankenphp.ExecutePHPCode(os.Args[2]))
 	}
 
+	// "-init-first script.php" starts FrankenPHP before running the CLI script,
+	// to exercise the guard against executing the PHP CLI while FrankenPHP is
+	// already running (https://github.com/php/frankenphp/issues/2342).
+	if len(os.Args) == 3 && os.Args[1] == "-init-first" {
+		if err := frankenphp.Init(); err != nil {
+			log.Fatalln(err)
+		}
+
+		status := frankenphp.ExecuteScriptCLI(os.Args[2], os.Args[2:])
+		frankenphp.Shutdown()
+		os.Exit(status)
+	}
+
 	os.Exit(frankenphp.ExecuteScriptCLI(os.Args[1], os.Args))
 }


### PR DESCRIPTION
## What

`frankenphp.ExecuteScriptCLI()` (and `ExecutePHPCode()`) crash the whole process
with a **segmentation fault** when called after `frankenphp.Init()` in the same
process (issue #2342):

```
FrankenPHP started 🐘  php_version=8.5.10-dev ...
signal: segmentation fault
```

## Why

Both functions start the embedded PHP CLI SAPI through `php_embed_init()`. That
runs `sapi_startup()` + `php_module_startup()` for the embed SAPI. When FrankenPHP
is already running, its own SAPI and the PHP engine are already started, so
booting a second SAPI on top corrupts global engine state and the process
crashes.

## What this PR does

The minimal, safe fix: **prevent the crash**. When FrankenPHP is already running,
`ExecuteScriptCLI`/`ExecutePHPCode` now log an error and return a non-zero exit
status instead of booting the embedded CLI SAPI and segfaulting. The standalone
CLI path (no prior `Init`) is untouched.

This intentionally does not add a new way to *run* CLI scripts inside a running
server (the broader idea discussed on the issue, e.g. running on a dedicated
thread/child process); it only turns an undefined-behaviour crash into a defined,
recoverable error. That larger feature can be built on top later.

Thread-safety note: the guard reads `isRunning` (and `globalLogger`) without an
extra lock, consistent with how `Init`/`Shutdown` already manage `isRunning` and
how these globals are read elsewhere in the package. CLI-after-`Init` is a
sequential misuse, not concurrent access.

## Test verification (RED → GREEN)

Run in the dev image (`dev.Dockerfile`), PHP 8.5 ZTS, `-tags nowatcher`.

**RED — unmodified `main` (only the repro/test applied):**

```
--- FAIL: TestExecuteScriptCLIWhileRunning (0.18s)
    cli_test.go:89: process was killed by a signal instead of exiting cleanly:
        signal: segmentation fault (core dumped)
    cli_test.go:91: Not equal: expected: 1  actual: -1
FAIL	github.com/dunglas/frankenphp
```

(A standalone `Init()` + `ExecuteScriptCLI()` program likewise crashes with
`signal: segmentation fault`, exit 139.)

**GREEN — with the fix (`go test -race`):**

```
=== RUN   TestRefuseCLIWhileRunning
--- PASS: TestRefuseCLIWhileRunning (0.03s)
=== RUN   TestExecuteScriptCLI
--- PASS: TestExecuteScriptCLI (0.08s)
=== RUN   TestExecuteCLICode
--- PASS: TestExecuteCLICode (0.01s)
=== RUN   TestExecuteScriptCLIWhileRunning
--- PASS: TestExecuteScriptCLIWhileRunning (0.03s)
PASS
ok  	github.com/dunglas/frankenphp	1.225s
```

Existing standalone CLI tests still pass (no regression). `refuseCLIWhileRunning`
shows 100% coverage; `go build`, `go vet`, `gofmt`, the Caddy module build and
`go mod tidy -diff` are all clean.
