### PR TITLE
fix: exit when a PHP thread segfaults as PID 1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run library tests
+        env:
+          FRANKENPHP_TEST_PID_NAMESPACE_WITH_SUDO: "1"
         run: gotestsum -- -race ./...
       - name: Run Caddy module tests
         working-directory: caddy/

--- a/cli_test.go
+++ b/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -76,31 +77,84 @@ func TestCThreadSegfaultAsPID1(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("PID namespaces are only available on Linux")
 	}
-	if _, err := os.Stat("internal/testcli/testcli"); err != nil {
+	useSudo := os.Getenv("FRANKENPHP_TEST_PID_NAMESPACE_WITH_SUDO") == "1"
+	testCLIPath, err := filepath.Abs("internal/testcli/testcli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(testCLIPath); err != nil {
+		if useSudo {
+			t.Fatalf("internal/testcli/testcli must be compiled for the PID namespace test: %v", err)
+		}
 		t.Skip("internal/testcli/testcli has not been compiled, run `cd internal/testcli/ && go build`")
 	}
-	if _, err := exec.LookPath("unshare"); err != nil {
+	unsharePath, err := exec.LookPath("unshare")
+	if err != nil {
+		if useSudo {
+			t.Fatal("unshare is required for the PID namespace test")
+		}
 		t.Skip("unshare is not available")
 	}
-
-	probe := exec.Command("unshare", "--user", "--map-root-user", "--pid", "--fork", "true")
-	if output, err := probe.CombinedOutput(); err != nil {
-		t.Skipf("unprivileged PID namespaces are not available: %s", output)
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatal("true is required for the PID namespace test probe")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(
-		ctx,
-		"unshare",
+	command := unsharePath
+	args := []string{
 		"--user",
 		"--map-root-user",
 		"--pid",
 		"--fork",
 		"--kill-child=KILL",
-		"internal/testcli/testcli",
+		testCLIPath,
 		"--segfault",
+	}
+	rootlessOutput, rootlessErr := runPIDNamespaceProbe(
+		unsharePath,
+		"--user",
+		"--map-root-user",
+		"--pid",
+		"--fork",
+		"--kill-child=KILL",
+		truePath,
 	)
+	if rootlessErr != nil {
+		if !useSudo {
+			t.Skipf("unprivileged PID namespaces are not available: %v: %s", rootlessErr, rootlessOutput)
+		}
+
+		sudoPath, sudoErr := exec.LookPath("sudo")
+		if sudoErr != nil {
+			t.Fatal("sudo was requested for the PID namespace test but was not found")
+		}
+		sudoOutput, sudoErr := runPIDNamespaceProbe(
+			sudoPath,
+			"-n",
+			unsharePath,
+			"--pid",
+			"--fork",
+			"--kill-child=KILL",
+			truePath,
+		)
+		if sudoErr != nil {
+			t.Fatalf("failed to create a PID namespace with sudo: %v: %s", sudoErr, sudoOutput)
+		}
+		command = sudoPath
+		args = []string{
+			"-n",
+			unsharePath,
+			"--pid",
+			"--fork",
+			"--kill-child=KILL",
+			testCLIPath,
+			"--segfault",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command, args...)
 	output, err := cmd.CombinedOutput()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatalf("FrankenPHP did not exit after the PHP thread segfaulted: %s", output)
@@ -111,6 +165,16 @@ func TestCThreadSegfaultAsPID1(t *testing.T) {
 		t.Fatalf("expected FrankenPHP to exit with an error, got %v: %s", err, output)
 	}
 	assert.Equal(t, 2, exitError.ExitCode(), "output: %s", output)
+}
+
+func runPIDNamespaceProbe(command string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, command, args...).CombinedOutput()
+	if ctx.Err() != nil {
+		return output, ctx.Err()
+	}
+	return output, err
 }
 
 func ExampleExecuteScriptCLI() {

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,12 +1,14 @@
 package frankenphp_test
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
 	"os/exec"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/dunglas/frankenphp"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +67,50 @@ func TestExecuteScriptCLISignals(t *testing.T) {
 	}
 	assert.NoError(t, err, "output: %s", stdoutStderr)
 	assert.Contains(t, string(stdoutStderr), "ok")
+}
+
+// Regression test for https://github.com/php/frankenphp/issues/2558. When a
+// C-created thread segfaults while FrankenPHP is PID 1, the process must
+// exit instead of looping forever in Go's runtime.raisebadsignal.
+func TestCThreadSegfaultAsPID1(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("PID namespaces are only available on Linux")
+	}
+	if _, err := os.Stat("internal/testcli/testcli"); err != nil {
+		t.Skip("internal/testcli/testcli has not been compiled, run `cd internal/testcli/ && go build`")
+	}
+	if _, err := exec.LookPath("unshare"); err != nil {
+		t.Skip("unshare is not available")
+	}
+
+	probe := exec.Command("unshare", "--user", "--map-root-user", "--pid", "--fork", "true")
+	if output, err := probe.CombinedOutput(); err != nil {
+		t.Skipf("unprivileged PID namespaces are not available: %s", output)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(
+		ctx,
+		"unshare",
+		"--user",
+		"--map-root-user",
+		"--pid",
+		"--fork",
+		"--kill-child=KILL",
+		"internal/testcli/testcli",
+		"--segfault",
+	)
+	output, err := cmd.CombinedOutput()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("FrankenPHP did not exit after the PHP thread segfaulted: %s", output)
+	}
+
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) {
+		t.Fatalf("expected FrankenPHP to exit with an error, got %v: %s", err, output)
+	}
+	assert.Equal(t, 2, exitError.ExitCode(), "output: %s", output)
 }
 
 func ExampleExecuteScriptCLI() {

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -222,7 +222,46 @@ static void frankenphp_fill_cli_signal_set(sigset_t *s) {
 #endif
 }
 
+#if defined(__linux__)
+/* Linux ignores default-action signals re-raised by PID 1 from inside its
+ * namespace. Go's runtime preserves handlers installed before it starts and
+ * forwards synchronous faults from C-created threads to them, so this turns a
+ * PHP-thread SIGSEGV into a process exit instead of the raisebadsignal loop.
+ * See https://github.com/php/frankenphp/issues/2558 and
+ * https://github.com/golang/go/issues/59569. */
+static void frankenphp_pid1_sigsegv_handler(int sig, siginfo_t *info,
+                                            void *context) {
+  (void)sig;
+  (void)info;
+  (void)context;
+  _exit(2);
+}
+
+static void frankenphp_install_pid1_sigsegv_handler(void) {
+  if (getpid() != 1) {
+    return;
+  }
+
+  struct sigaction previous;
+  if (sigaction(SIGSEGV, NULL, &previous) != 0 ||
+      previous.sa_handler != SIG_DFL) {
+    return;
+  }
+
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+  action.sa_sigaction = frankenphp_pid1_sigsegv_handler;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  sigaction(SIGSEGV, &action, NULL);
+}
+#endif
+
 __attribute__((constructor)) static void frankenphp_libpreinit(void) {
+#if defined(__linux__)
+  frankenphp_install_pid1_sigsegv_handler();
+#endif
+
   sigset_t set;
   frankenphp_fill_cli_signal_set(&set);
   /* Single-threaded at this point (constructors run before Go's runtime),

--- a/internal/testcli/main.go
+++ b/internal/testcli/main.go
@@ -8,6 +8,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--segfault" {
+		triggerSIGSEGVOnCThread()
+		os.Exit(3)
+	}
+
 	if len(os.Args) <= 1 {
 		log.Println("Usage: testcli script.php")
 		os.Exit(1)

--- a/internal/testcli/segfault_linux.go
+++ b/internal/testcli/segfault_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package main
+
+/*
+#include <pthread.h>
+#include <unistd.h>
+
+static void *segfault(void *unused) {
+	(void)unused;
+	*(volatile int *)0 = 1;
+	return NULL;
+}
+
+static void trigger_sigsegv_on_c_thread(void) {
+	pthread_t thread;
+	if (pthread_create(&thread, NULL, segfault, NULL) != 0) {
+		_exit(3);
+	}
+	pthread_join(thread, NULL);
+}
+*/
+import "C"
+
+func triggerSIGSEGVOnCThread() {
+	C.trigger_sigsegv_on_c_thread()
+}

--- a/internal/testcli/segfault_other.go
+++ b/internal/testcli/segfault_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func triggerSIGSEGVOnCThread() {}


### PR DESCRIPTION
## Summary

- install a Linux-only SIGSEGV fallback before Go's runtime starts when FrankenPHP is PID 1
- preserve any pre-existing non-default handler and leave non-PID-1 behavior unchanged
- exit with status 2 when Go forwards a fatal fault from a C-created PHP thread
- add a deterministic PID-namespace regression test with a timeout, so the previous `runtime.raisebadsignal` loop cannot hang the suite
- explicitly enable the test's passwordless-sudo fallback in GitHub Actions, where unprivileged PID namespaces are restricted, so CI cannot silently skip the regression

The underlying signal-forwarding problem is golang/go#59569. This keeps the workaround local to FrankenPHP and avoids carrying a patched Go toolchain.

Closes #2558.

## Verification

- built the official Debian production `runner` target with Go 1.26.5 and PHP 8.4
- `go test -race -count=1 .`
- `go test -race ./...` in `caddy/`
- `TestCThreadSegfaultAsPID1` exits 2 instead of timing out
- the same helper outside PID 1 is still terminated by SIGSEGV (shell status 139)

The focused test can be run after building the existing test helper:

```console
cd internal/testcli
go build
cd ../..
go test -race -run '^TestCThreadSegfaultAsPID1$' -count=1 -v .
```

If unprivileged PID namespaces are disabled, opt into the same strict fallback used by CI:

```console
FRANKENPHP_TEST_PID_NAMESPACE_WITH_SUDO=1 go test -race -run '^TestCThreadSegfaultAsPID1$' -count=1 -v .
```
