### PR TITLE
ci: run independent steps in parallel

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -194,22 +194,23 @@ jobs:
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
           VARIANT: ${{ matrix.variant }}
-      - name: Upload builder metadata
-        if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: metadata-builder-${{ matrix.variant }}-${{ steps.prepare.outputs.sanitized_platform }}
-          path: /tmp/metadata/builder/*
-          if-no-files-found: error
-          retention-days: 1
-      - name: Upload runner metadata
-        if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: metadata-runner-${{ matrix.variant }}-${{ steps.prepare.outputs.sanitized_platform }}
-          path: /tmp/metadata/runner/*
-          if-no-files-found: error
-          retention-days: 1
+      - parallel:
+          - name: Upload builder metadata
+            if: fromJson(needs.prepare.outputs.push)
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: metadata-builder-${{ matrix.variant }}-${{ steps.prepare.outputs.sanitized_platform }}
+              path: /tmp/metadata/builder/*
+              if-no-files-found: error
+              retention-days: 1
+          - name: Upload runner metadata
+            if: fromJson(needs.prepare.outputs.push)
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: metadata-runner-${{ matrix.variant }}-${{ steps.prepare.outputs.sanitized_platform }}
+              path: /tmp/metadata/runner/*
+              if-no-files-found: error
+              retention-days: 1
       - name: Run tests
         if: ${{ !fromJson(needs.prepare.outputs.push) }}
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
           VALIDATE_GO_MODULES: false
-          # actionlint (super-linter v8.7.0) doesn't know the "parallel" step key yet; re-enable once it does
+          # re-enable once actionlint supports the "parallel" step key: https://github.com/rhysd/actionlint/issues/693
           VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_PHP_PHPCS: false
           VALIDATE_PHP_PHPSTAN: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,6 +35,8 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
           VALIDATE_GO_MODULES: false
+          # actionlint (super-linter v8.7.0) doesn't know the "parallel" step key yet; re-enable once it does
+          VALIDATE_GITHUB_ACTIONS: false
           VALIDATE_PHP_PHPCS: false
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,24 +75,25 @@ jobs:
         run: sudo ../caddy/frankenphp/frankenphp start
       - name: Run integrations tests
         run: ./reload_test.sh
-      - name: Lint Go code
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        if: matrix.php-versions == '8.5'
-        with:
-          version: latest
-      - name: Lint Caddy module Go code
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        if: matrix.php-versions == '8.5'
-        with:
-          version: latest
-          working-directory: caddy/
-      - name: Ensure go.mod is tidy
-        if: matrix.php-versions == '8.5'
-        run: go mod tidy -diff
-      - name: Ensure caddy/go.mod is tidy
-        if: matrix.php-versions == '8.5'
-        run: go mod tidy -diff
-        working-directory: caddy/
+      - parallel:
+          - name: Lint Go code
+            uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+            if: matrix.php-versions == '8.5'
+            with:
+              version: latest
+          - name: Lint Caddy module Go code
+            uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+            if: matrix.php-versions == '8.5'
+            with:
+              version: latest
+              working-directory: caddy/
+          - name: Ensure go.mod is tidy
+            if: matrix.php-versions == '8.5'
+            run: go mod tidy -diff
+          - name: Ensure caddy/go.mod is tidy
+            if: matrix.php-versions == '8.5'
+            run: go mod tidy -diff
+            working-directory: caddy/
   integration-tests:
     name: Integration Tests (Linux, PHP ${{ matrix.php-versions }})
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,18 +75,18 @@ jobs:
         run: sudo ../caddy/frankenphp/frankenphp start
       - name: Run integrations tests
         run: ./reload_test.sh
+      - name: Lint Go code
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        if: matrix.php-versions == '8.5'
+        with:
+          version: latest
+      - name: Lint Caddy module Go code
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        if: matrix.php-versions == '8.5'
+        with:
+          version: latest
+          working-directory: caddy/
       - parallel:
-          - name: Lint Go code
-            uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-            if: matrix.php-versions == '8.5'
-            with:
-              version: latest
-          - name: Lint Caddy module Go code
-            uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-            if: matrix.php-versions == '8.5'
-            with:
-              version: latest
-              working-directory: caddy/
           - name: Ensure go.mod is tidy
             if: matrix.php-versions == '8.5'
             run: go mod tidy -diff

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -82,48 +82,49 @@ jobs:
         with:
           working-directory: frankenphp
 
-      - name: Install Vcpkg Libraries
-        working-directory: frankenphp
-        run: "vcpkg install"
+      - parallel:
+          - name: Install Vcpkg Libraries
+            working-directory: frankenphp
+            run: "vcpkg install"
 
-      - name: Download Watcher
-        run: |
-          $latestTag = gh release list --repo e-dant/watcher --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName'
-          Write-Host "Latest Watcher version: $latestTag"
+          - name: Download Watcher
+            run: |
+              $latestTag = gh release list --repo e-dant/watcher --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName'
+              Write-Host "Latest Watcher version: $latestTag"
 
-          gh release download $latestTag --repo e-dant/watcher --pattern "*x86_64-pc-windows-msvc.tar" -O watcher.tar
+              gh release download $latestTag --repo e-dant/watcher --pattern "*x86_64-pc-windows-msvc.tar" -O watcher.tar
 
-          tar -xf "watcher.tar" -C "$env:GITHUB_WORKSPACE"
-          Rename-Item -Path "$env:GITHUB_WORKSPACE\x86_64-pc-windows-msvc" -NewName "watcher"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              tar -xf "watcher.tar" -C "$env:GITHUB_WORKSPACE"
+              Rename-Item -Path "$env:GITHUB_WORKSPACE\x86_64-pc-windows-msvc" -NewName "watcher"
+            env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download PHP
-        run: |
-          $webContent = Invoke-WebRequest -Uri $env:PHP_DOWNLOAD_BASE
-          $links = $webContent.Links.Href | Where-Object { $_ -match "php-\d+\.\d+\.\d+-Win32-vs17-x64\.zip$" }
+          - name: Download PHP
+            run: |
+              $webContent = Invoke-WebRequest -Uri $env:PHP_DOWNLOAD_BASE
+              $links = $webContent.Links.Href | Where-Object { $_ -match "php-\d+\.\d+\.\d+-Win32-vs17-x64\.zip$" }
 
-          if (-not $links) { throw "Could not find PHP zip files at $env:PHP_DOWNLOAD_BASE" }
+              if (-not $links) { throw "Could not find PHP zip files at $env:PHP_DOWNLOAD_BASE" }
 
-          $latestFile = $links | Sort-Object { if ($_ -match '(\d+\.\d+\.\d+)') { [version]$matches[1] } } | Select-Object -Last 1
+              $latestFile = $links | Sort-Object { if ($_ -match '(\d+\.\d+\.\d+)') { [version]$matches[1] } } | Select-Object -Last 1
 
-          $version = if ($latestFile -match '(\d+\.\d+\.\d+)') { $matches[1] }
-          Write-Host "Detected latest PHP version: $version"
+              $version = if ($latestFile -match '(\d+\.\d+\.\d+)') { $matches[1] }
+              Write-Host "Detected latest PHP version: $version"
 
-          "PHP_VERSION=$version" >> $env:GITHUB_ENV
+              "PHP_VERSION=$version" >> $env:GITHUB_ENV
 
-          $phpZip = "php-$version-Win32-vs17-x64.zip"
-          $develZip = "php-devel-pack-$version-Win32-vs17-x64.zip"
+              $phpZip = "php-$version-Win32-vs17-x64.zip"
+              $develZip = "php-devel-pack-$version-Win32-vs17-x64.zip"
 
-          $dirName = "frankenphp-windows-x86_64"
+              $dirName = "frankenphp-windows-x86_64"
 
-          "DIR_NAME=$dirName" >> $env:GITHUB_ENV
+              "DIR_NAME=$dirName" >> $env:GITHUB_ENV
 
-          Invoke-WebRequest -Uri "$env:PHP_DOWNLOAD_BASE/$phpZip" -OutFile "$env:TEMP\php.zip"
-          Expand-Archive -Path "$env:TEMP\php.zip" -DestinationPath "$env:GITHUB_WORKSPACE\$dirName"
+              Invoke-WebRequest -Uri "$env:PHP_DOWNLOAD_BASE/$phpZip" -OutFile "$env:TEMP\php.zip"
+              Expand-Archive -Path "$env:TEMP\php.zip" -DestinationPath "$env:GITHUB_WORKSPACE\$dirName"
 
-          Invoke-WebRequest -Uri "$env:PHP_DOWNLOAD_BASE/$develZip" -OutFile "$env:TEMP\php-devel.zip"
-          Expand-Archive -Path "$env:TEMP\php-devel.zip" -DestinationPath "$env:GITHUB_WORKSPACE\php-devel"
+              Invoke-WebRequest -Uri "$env:PHP_DOWNLOAD_BASE/$develZip" -OutFile "$env:TEMP\php-devel.zip"
+              Expand-Archive -Path "$env:TEMP\php-devel.zip" -DestinationPath "$env:GITHUB_WORKSPACE\php-devel"
 
       - name: Prepare env
         run: |


### PR DESCRIPTION
GitHub Actions added native parallel steps: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

Grouped independent steps that were previously run sequentially for no reason:

- `tests.yaml` (`tests-linux`): the four PHP-8.5-only lint/tidy checks (Go lint, Caddy module Go lint, `go.mod` tidy check, `caddy/go.mod` tidy check)
- `windows.yaml` (`build`): vcpkg install, Watcher download, PHP download — all independent and only consumed later by `Prepare env`
- `docker.yaml` (`build`): builder/runner metadata artifact uploads, which write to disjoint paths

Each group now takes as long as its slowest step instead of the sum of all of them.

Not touched:
- The `-race` test steps in `tests.yaml`, to avoid CPU contention on shared runners affecting the race detector
- The `static.yaml` manifest-push chains, since each side is itself a 2-step sequential chain rather than a single step

This is a brand-new (~6 weeks old) Actions feature not yet in the main workflow-syntax docs, so worth watching the first few CI runs closely — in particular whether `lint.yaml`'s super-linter accepts the new `parallel` key.