### PR TITLE
Fix possible integer overflow in the standard worker loop in the docs

### DIFF
--- a/docs/cn/worker.md
+++ b/docs/cn/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // 在发送 HTTP 响应后做一些事情

--- a/docs/es/worker.md
+++ b/docs/es/worker.md
@@ -94,8 +94,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Haz algo después de enviar la respuesta HTTP

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Faire quelque chose après l'envoi de la réponse HTTP

--- a/docs/it/worker.md
+++ b/docs/it/worker.md
@@ -72,8 +72,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Esegui qualcosa dopo aver inviato la risposta HTTP

--- a/docs/ja/worker.md
+++ b/docs/ja/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // HTTPレスポンス送信後に何らかの処理を実行

--- a/docs/pt-br/worker.md
+++ b/docs/pt-br/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Faz algo depois de enviar a resposta HTTP

--- a/docs/ru/worker.md
+++ b/docs/ru/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Действия после отправки HTTP-ответа

--- a/docs/tr/worker.md
+++ b/docs/tr/worker.md
@@ -91,8 +91,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // HTTP yanıtını gönderdikten sonra bir şey yapın

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -77,8 +77,8 @@ $handler = static function () use ($myApp) {
     }
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
 
     // Do something after sending the HTTP response
@@ -155,8 +155,8 @@ $handler = static function () use ($myApp, $creator) {
     echo $response->getBody();
 };
 
-$maxRequests = (int)($_SERVER['MAX_REQUESTS'] ?? 0);
-for ($nbRequests = 0; !$maxRequests || $nbRequests < $maxRequests; ++$nbRequests) {
+$maxRequests = (isset($_SERVER['MAX_REQUESTS']) && $_SERVER['MAX_REQUESTS'] > 0) ? (int)$_SERVER['MAX_REQUESTS'] : PHP_INT_MAX;
+for ($nbRequests = 0; $nbRequests < $maxRequests; ++$nbRequests) {
     $keepRunning = \frankenphp_handle_request($handler);
     gc_collect_cycles();
     if (!$keepRunning) break;


### PR DESCRIPTION
If `$_SERVER['MAX_REQUESTS']` is unset or 0, the for loop as originally shown would overflow the `$nbRequests` variable in the end.

Not that I did experience that, but I think that it would have resulted in an error page at some point (for a very, very busy server).

The code changes this to exit the worker cleanly instead.

I think this is better, even though it is just slightly less readable.