### PR TITLE
Fix: php 8.6 compatibility

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -586,10 +586,18 @@ static int frankenphp_worker_request_startup() {
                       sizeof(SAPI_PHP_VERSION_HEADER) - 1, 1);
     }
 
+    /* PG(output_handler) is a char* before PHP 8.6, a zend_string* since */
+#if PHP_VERSION_ID < 80600
     if (PG(output_handler) && PG(output_handler)[0]) {
       zval oh;
 
       ZVAL_STRING(&oh, PG(output_handler));
+#else
+    if (PG(output_handler) && ZSTR_LEN(PG(output_handler))) {
+      zval oh;
+
+      ZVAL_STR(&oh, zend_string_dup(PG(output_handler), false));
+#endif
       php_output_start_user(&oh, 0, PHP_OUTPUT_HANDLER_STDFLAGS);
       zval_ptr_dtor(&oh);
     } else if (PG(output_buffering)) {


### PR DESCRIPTION
Best done together with https://github.com/php/frankenphp/pull/1757 because that change is already in 8.6.0-beta1