### PR TITLE
fix: log worker crashes at warn level instead of debug

### DIFF
--- a/testdata/crashing-worker.php
+++ b/testdata/crashing-worker.php
@@ -1,0 +1,15 @@
+<?php
+
+// Boots successfully, then terminates with a non-zero exit status while
+// handling its second request, simulating a worker crash after boot.
+$requests = 0;
+$handler = static function () use (&$requests) {
+    if (++$requests >= 2) {
+        exit(1);
+    }
+
+    echo 'ok';
+};
+
+while (frankenphp_handle_request($handler)) {
+}

--- a/threadworker.go
+++ b/threadworker.go
@@ -160,8 +160,10 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 
 	if !handler.isBootingScript {
 		// fatal error (could be due to exit(1), timeouts, etc.)
-		if globalLogger.Enabled(globalCtx, slog.LevelDebug) {
-			globalLogger.LogAttrs(globalCtx, slog.LevelDebug, "restarting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
+		// unlike a clean restart, this took down any in-flight request, so
+		// surface it above debug level, with the exit status needed to triage it
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "unexpected termination, restarting", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex), slog.Int("exit_status", exitStatus))
 		}
 
 		return
@@ -175,7 +177,7 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 
 	if watcherIsEnabled {
 		// worker script has probably failed due to script changes while watcher is enabled
-		if globalLogger.Enabled(globalCtx, slog.LevelError) {
+		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
 			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "(watcher enabled) worker script has not reached frankenphp_handle_request()", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
 		}
 	} else {

--- a/threadworker.go
+++ b/threadworker.go
@@ -177,8 +177,8 @@ func tearDownWorkerScript(handler *workerThread, exitStatus int) {
 
 	if watcherIsEnabled {
 		// worker script has probably failed due to script changes while watcher is enabled
-		if globalLogger.Enabled(globalCtx, slog.LevelWarn) {
-			globalLogger.LogAttrs(globalCtx, slog.LevelWarn, "(watcher enabled) worker script has not reached frankenphp_handle_request()", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
+		if globalLogger.Enabled(globalCtx, slog.LevelError) {
+			globalLogger.LogAttrs(globalCtx, slog.LevelError, "(watcher enabled) worker script has not reached frankenphp_handle_request()", slog.String("worker", worker.name), slog.Int("thread", handler.thread.threadIndex))
 		}
 	} else {
 		// rare case where worker script has failed on a restart during normal operation

--- a/worker_test.go
+++ b/worker_test.go
@@ -112,6 +112,18 @@ func TestWorkerGetOpt(t *testing.T) {
 	assert.NotRegexp(t, buf.String(), "exit_status=[1-9]")
 }
 
+func TestWorkerCrashIsLoggedAboveDebugLevel(t *testing.T) {
+	logger, buf := newTestLogger(t)
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", "http://example.com/crashing-worker.php", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+	}, &testOptions{logger: logger, workerScript: "crashing-worker.php", nbWorkers: 1, nbParallelRequests: 4})
+
+	assert.Regexp(t, `level=WARN msg="unexpected termination, restarting" worker=\S+ thread=\d+ exit_status=1`, buf.String())
+}
+
 func ExampleServeHTTP_workers() {
 	if err := frankenphp.Init(
 		frankenphp.WithWorkers("worker1", "worker1.php", 4,


### PR DESCRIPTION
A worker script that dies **after boot** (non-zero exit status) currently logs the same debug-level `"restarting"` message as a clean `FRANKENPHP_LOOP_MAX` recycle — same level, same message text. At the default log level a crash is therefore invisible to operators:
- the in-flight request surfaces as an **empty 500** (0 bytes after normal processing time),
- the application never gets to log anything — the script died mid-request,
- and `exit_status`, the one datum needed to triage the death, is only obtainable by running the whole server at debug level.
We hit this in production (Shopware on FrankenPHP 1.12.4, worker mode): `frankenphp_worker_crashes` was steadily incrementing at ~0.03% of requests, each crash converting one user request into an empty 500, with **zero** trace in any log — app log, stderr, or FrankenPHP's own output. It took us three debugging sessions to find the Prometheus counter, and we still could not see the exit statuses.
### This is a regression
Up to v1.2.x the crash path was clearly distinguished ([worker.go @ v1.2.5](https://github.com/php/frankenphp/blob/v1.2.5/worker.go)):
```go
if fc.exitStatus == 0 {
    if c := l.Check(zapcore.InfoLevel, "restarting"); c != nil { ... }
} else {
    if c := l.Check(zapcore.ErrorLevel, "unexpected termination, restarting"); c != nil {
        c.Write(zap.String("worker", absFileName), zap.Int("exit_status", int(fc.exitStatus)))
    }
}
```
That error-level line is, for instance, how the reporter of #774 noticed their problem at all. Somewhere in the worker-thread refactoring both paths converged on debug-level `"restarting"`.
### What this PR does
- The crash branch of `tearDownWorkerScript` (non-zero exit after boot, `StopReasonCrash`) now logs at **warn** with the historical, distinct message `"unexpected termination, restarting"`, keeping the `worker` / `thread` / `exit_status` attributes. Warn matches the neighboring worker-failure logs in the same function; happy to bump it to error (the 1.2.x level) if preferred.
- Clean restarts (exit 0, `LOOP_MAX` recycling) stay at debug — they are frequent and healthy, raising them would be noise.
- Fixes a mismatched guard in the watcher-enabled boot-failure path: `Enabled()` checked `LevelError` while `LogAttrs` wrote `LevelWarn`.
- Adds `testdata/crashing-worker.php` (boots fine, `exit(1)` on its second request — the exact scenario of the code comment) and a test asserting the warn-level line with `exit_status=1` is emitted.
No behavior change beyond logging.
Fixes #2601