### PR TITLE
fuzz: disable Zend's arena allocator under go-118-fuzz-build

### DIFF
--- a/zendalloc_gofuzz.go
+++ b/zendalloc_gofuzz.go
@@ -1,0 +1,10 @@
+//go:build gofuzz
+
+package frankenphp
+
+import "os"
+
+func init() {
+	// Zend's own arena allocator hides bugs from the sanitizers OSS-Fuzz builds with.
+	os.Setenv("USE_ZEND_ALLOC", "0")
+}


### PR DESCRIPTION
## Summary

Part of adding FrankenPHP to [OSS-Fuzz](https://github.com/google/oss-fuzz). The OSS-Fuzz Dockerfile/build.sh compile PHP from source and build the existing `FuzzRequest` native Go fuzz target ([frankenphp_test.go](frankenphp_test.go)) with `compile_native_go_fuzzer`, linking against a sanitizer-instrumented `libphp`.

Zend's own arena allocator reuses freed memory in ways that hide bugs from ASan/MSan. Disabling it (`USE_ZEND_ALLOC=0`) is already required for the sanitizer CI jobs in [.github/workflows/sanitizers.yaml](.github/workflows/sanitizers.yaml), but that env var can't reach a libFuzzer binary built by OSS-Fuzz the same way:

- `build.sh` runs in a throwaway build container; ClusterFuzz later executes the compiled fuzzer as a fresh process on a different bot with no inherited environment.
- The libFuzzer `.options` file's `[env]` section looks like it should fill the gap, but ClusterFuzz whitelists it down to two unrelated variables (`AFL_DONT_DEFER`, `GODEBUG`), so `USE_ZEND_ALLOC` there is silently dropped.

Setting it from an `init()` gated on the `gofuzz` build tag reaches the process before PHP starts, without affecting any non-fuzzing build (the CLI, the Caddy module, or anything else built by consumers of this module).

## Test plan

- [ ] Verified against a local checkout of `google/oss-fuzz` (`infra/helper.py build_image`/`build_fuzzers`) with a matching `projects/frankenphp/{project.yaml,Dockerfile,build.sh}`, to be submitted as a separate PR to that repo.