### PR TITLE
test: fix flaky TestAddModuleWorkerViaAdminApi

### DIFF
--- a/caddy/admin_test.go
+++ b/caddy/admin_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dunglas/frankenphp/internal/fastabs"
 
@@ -345,6 +346,24 @@ func TestAddModuleWorkerViaAdminApi(t *testing.T) {
 	assert.Greater(t, updatedWorkerCount, initialWorkerCount, "Worker count should have increased")
 	assert.True(t, workerFound, fmt.Sprintf("Worker with name %q should be found", "Worker PHP Thread - "+filename))
 
-	// Make a request to the worker to verify it's working
-	tester.AssertGetResponse("http://localhost:"+testPort+"/worker-with-counter.php", http.StatusOK, "requests:1")
+	// The /load above swaps the HTTP listener for the new config; a request
+	// racing that swap can see a reset connection before the worker ever
+	// receives it, so retry on connection-level failures only (a request
+	// that reaches the worker always counts, so retrying past that point
+	// would throw off the "requests:1" assertion below).
+	workerURL := "http://localhost:" + testPort + "/worker-with-counter.php"
+	var getResp *http.Response
+	for i := 0; i < 20; i++ {
+		getResp, err = http.Get(workerURL)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	defer func() { require.NoError(t, getResp.Body.Close()) }()
+	body, err := io.ReadAll(getResp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, getResp.StatusCode)
+	assert.Equal(t, "requests:1", string(body))
 }

--- a/caddy/admin_test.go
+++ b/caddy/admin_test.go
@@ -353,14 +353,10 @@ func TestAddModuleWorkerViaAdminApi(t *testing.T) {
 	// would throw off the "requests:1" assertion below).
 	workerURL := "http://localhost:" + testPort + "/worker-with-counter.php"
 	var getResp *http.Response
-	for i := 0; i < 20; i++ {
+	require.Eventually(t, func() bool {
 		getResp, err = http.Get(workerURL)
-		if err == nil {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	require.NoError(t, err)
+		return err == nil
+	}, 1*time.Second, 50*time.Millisecond)
 	defer func() { require.NoError(t, getResp.Body.Close()) }()
 	body, err := io.ReadAll(getResp.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`TestAddModuleWorkerViaAdminApi` POSTs a full config to the admin `/load` endpoint, which swaps the HTTP listener for the new config, then immediately GETs the newly added worker. A request racing that listener swap can hit a reset connection (`EOF`) before the worker ever sees it — seen on CI in [php/frankenphp#2604](https://github.com/php/frankenphp/pull/2604) (job [94991854286](https://github.com/php/frankenphp/actions/runs/31876064293/job/94991854286)), and matches the same class of flake fixed for the sibling autoscale tests in #2413 (which references this test too, on #2412/#2381).

Retry only on connection-level errors (`err != nil` from `http.Get`), not on the request/response itself: once a request actually reaches the worker it always increments its counter, so retrying past a successful connection would break the `requests:1` assertion.

## Test plan

- [x] `./go.sh -C caddy test ./...` passes
- [x] `./go.sh -C caddy test ./... -run TestAddModuleWorkerViaAdminApi -count=5` passes