### PR TITLE
fix: don't hang requests dispatched before regular threads are ready

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -319,10 +319,6 @@ func Init(options ...Option) error {
 		return err
 	}
 
-	// reused across reloads so queued requests aren't orphaned on a stale channel
-	if regularRequestChan == nil {
-		regularRequestChan = make(chan contextHolder)
-	}
 	regularThreads = make([]*phpThread, 0, opt.numThreads-workerThreadCount)
 	for i := 0; i < opt.numThreads-workerThreadCount; i++ {
 		convertToRegularThread(getInactivePHPThread())

--- a/threadregular.go
+++ b/threadregular.go
@@ -27,7 +27,7 @@ type regularThread struct {
 var (
 	regularThreads       []*phpThread
 	regularThreadMu      = &sync.RWMutex{}
-	regularRequestChan   chan contextHolder
+	regularRequestChan   = make(chan contextHolder)
 	queuedRegularThreads = atomic.Int32{}
 )
 

--- a/threadregular_test.go
+++ b/threadregular_test.go
@@ -1,0 +1,63 @@
+package frankenphp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegularRequestChanIsCreatedBeforeInitRuns(t *testing.T) {
+	require.NotNil(t, regularRequestChan,
+		"a request dispatched between the start of Init and the first thread being attached "+
+			"must queue on a real channel: sending on a nil channel blocks forever, "+
+			"even after the channel variable is later assigned")
+}
+
+func TestRequestsQueuedBeforeThreadsAreReadyAreHandedOver(t *testing.T) {
+	regularThreadMu.Lock()
+	savedThreads := regularThreads
+	regularThreads = nil
+	regularThreadMu.Unlock()
+	savedMaxWaitTime := maxWaitTime.Swap(0)
+	savedScaleChan := scaleChan
+	scaleChan = nil
+	t.Cleanup(func() {
+		regularThreadMu.Lock()
+		regularThreads = savedThreads
+		regularThreadMu.Unlock()
+		maxWaitTime.Store(savedMaxWaitTime)
+		scaleChan = savedScaleChan
+	})
+
+	const requests = 5
+	errChans := make([]chan error, requests)
+	for i := range errChans {
+		fc := &frankenPHPContext{done: make(chan any)}
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- handleRequestWithRegularPHPThreads(contextHolder{ctx: context.Background(), frankenPHPContext: fc})
+		}()
+		errChans[i] = errChan
+	}
+
+	for i := 0; i < requests; i++ {
+		select {
+		case ch := <-regularRequestChan:
+			ch.frankenPHPContext.closeContext()
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of %d queued requests were handed over", i, requests)
+		}
+	}
+
+	for i, errChan := range errChans {
+		select {
+		case err := <-errChan:
+			assert.NoError(t, err, "request %d", i)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("dispatcher for request %d did not return after the request was handled", i)
+		}
+	}
+}


### PR DESCRIPTION
Caddy sometimes starts the HTTP server before FrankenPHP finishes initializing.
A request arriving in that window passes the `isRunning` check, but `regularRequestChan` is still `nil`, so it blocks forever in `handleRequestWithRegularPHPThreads()`.
Behind a reverse proxy, this shows up as random 499/504 on the first requests after a container starts.

We're now initializing the request channel at declaration so early requests are served anyway once the first thread is started.