### PR TITLE
fix: never borrow opcache memory in persisted zvals

### DIFF
--- a/testdata/persist-roundtrip.php
+++ b/testdata/persist-roundtrip.php
@@ -4,6 +4,8 @@
 // FRANKENPHP_TEST_HOOKS is defined at build time). The script runs as a
 // plain non-worker request; the Go harness asserts the combined output.
 
+const CONST_ARR = ['a' => 1, 'b' => [2, 3], 'c' => 'literal'];
+
 enum Status: string {
     case Active = 'active';
     case Paused = 'paused';
@@ -64,6 +66,14 @@ same(
     ['status' => Status::Active, 'count' => 7],
     'array with enum',
 );
+
+// Compile-time constant array. Opcache marks these immutable and keeps them
+// in shared memory, so persist must copy instead of sharing the pointer.
+same($rt(CONST_ARR), CONST_ARR, 'const array');
+
+// Literal keys and values are interned strings, which also live in opcache
+// shared memory once the script is cached.
+same($rt(['literal_key' => 'literal_value']), ['literal_key' => 'literal_value'], 'interned key and value');
 
 // Invalid inputs throw LogicException.
 try {

--- a/zval.h
+++ b/zval.h
@@ -5,9 +5,12 @@
  * and enums. Everything else is rejected by persistent_zval_validate so
  * callers can fail fast before allocating.
  *
- * Fast paths:
- *   - Interned strings: shared memory, no copy.
- *   - Opcache-immutable arrays: shared pointer, no copy, no free.
+ * Everything reachable from a persisted tree is allocated with pemalloc and
+ * owned by that tree. Nothing is borrowed from opcache. Interned strings and
+ * immutable arrays live in opcache's shared memory, which is rewound to a
+ * startup watermark on restart (out of memory, hash overflow, or
+ * opcache_reset()), so a tree that outlives a restart would be left pointing
+ * at reused memory.
  *
  * Included by frankenphp.c; not a standalone compilation unit. */
 
@@ -39,12 +42,6 @@ static bool persistent_zval_validate(zval *z) {
   case IS_OBJECT:
     return (Z_OBJCE_P(z)->ce_flags & ZEND_ACC_ENUM) != 0;
   case IS_ARRAY: {
-    /* Opcache-immutable arrays are compile-time constants in shared
-     * memory; their leaves are guaranteed scalars or further immutable
-     * arrays. The copy/free paths below already trust this flag, so a
-     * recursive walk here would just be cycles. */
-    if ((GC_FLAGS(Z_ARRVAL_P(z)) & IS_ARRAY_IMMUTABLE) != 0)
-      return true;
     zval *val;
     ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(z), val) {
       if (!persistent_zval_validate(val))
@@ -78,40 +75,22 @@ static void persistent_zval_persist(zval *dst, zval *src) {
   case IS_DOUBLE:
     ZVAL_DOUBLE(dst, Z_DVAL_P(src));
     break;
-  case IS_STRING: {
-    zend_string *s = Z_STR_P(src);
-    if (ZSTR_IS_INTERNED(s)) {
-      ZVAL_STR(dst, s); /* interned strings live process-wide */
-    } else {
-      ZVAL_NEW_STR(dst, zend_string_init(ZSTR_VAL(s), ZSTR_LEN(s), 1));
-    }
+  case IS_STRING:
+    ZVAL_NEW_STR(dst, zend_string_init(Z_STRVAL_P(src), Z_STRLEN_P(src), 1));
     break;
-  }
   case IS_OBJECT: {
     /* Must be an enum (validated earlier in persistent_zval_validate). */
     zend_class_entry *ce = Z_OBJCE_P(src);
     persistent_zval_enum_t *e = pemalloc(sizeof(*e), 1);
-    e->class_name =
-        ZSTR_IS_INTERNED(ce->name)
-            ? ce->name
-            : zend_string_init(ZSTR_VAL(ce->name), ZSTR_LEN(ce->name), 1);
+    e->class_name = zend_string_init(ZSTR_VAL(ce->name), ZSTR_LEN(ce->name), 1);
     zval *case_name_zval = zend_enum_fetch_case_name(Z_OBJ_P(src));
     zend_string *case_str = Z_STR_P(case_name_zval);
-    e->case_name =
-        ZSTR_IS_INTERNED(case_str)
-            ? case_str
-            : zend_string_init(ZSTR_VAL(case_str), ZSTR_LEN(case_str), 1);
+    e->case_name = zend_string_init(ZSTR_VAL(case_str), ZSTR_LEN(case_str), 1);
     ZVAL_PTR(dst, e);
     break;
   }
   case IS_ARRAY: {
     HashTable *src_ht = Z_ARRVAL_P(src);
-    if ((GC_FLAGS(src_ht) & IS_ARRAY_IMMUTABLE) != 0) {
-      /* Opcache-immutable arrays live for the process lifetime and are
-       * safe to share across threads by pointer. Zero-copy, zero-free. */
-      ZVAL_ARR(dst, src_ht);
-      break;
-    }
     HashTable *dst_ht = pemalloc(sizeof(HashTable), 1);
     zend_hash_init(dst_ht, zend_hash_num_elements(src_ht), NULL, NULL, 1);
     ZVAL_ARR(dst, dst_ht);
@@ -123,16 +102,12 @@ static void persistent_zval_persist(zval *dst, zval *src) {
       zval pval;
       persistent_zval_persist(&pval, val);
       if (key) {
-        if (ZSTR_IS_INTERNED(key)) {
-          zend_hash_add_new(dst_ht, key, &pval);
-        } else {
-          zend_string *pkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 1);
-          /* Iteration guarantees the source key has its hash set.
-           * Propagating it lets zend_hash_add_new skip the re-hash. */
-          ZSTR_H(pkey) = ZSTR_H(key);
-          zend_hash_add_new(dst_ht, pkey, &pval);
-          zend_string_release(pkey);
-        }
+        zend_string *pkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 1);
+        /* Iteration guarantees the source key has its hash set.
+         * Propagating it lets zend_hash_add_new skip the re-hash. */
+        ZSTR_H(pkey) = ZSTR_H(key);
+        zend_hash_add_new(dst_ht, pkey, &pval);
+        zend_string_release(pkey);
       } else {
         zend_hash_index_add_new(dst_ht, idx, &pval);
       }
@@ -146,33 +121,26 @@ static void persistent_zval_persist(zval *dst, zval *src) {
   }
 }
 
-/* Deep-free a persistent zval tree. Idempotent on scalars. Skips
- * interned strings and immutable arrays (they are borrowed, not owned). */
+/* Deep-free a persistent zval tree. Idempotent on scalars. */
 static void persistent_zval_free(zval *z) {
   switch (Z_TYPE_P(z)) {
   case IS_STRING:
-    if (!ZSTR_IS_INTERNED(Z_STR_P(z))) {
-      zend_string_free(Z_STR_P(z));
-    }
+    zend_string_free(Z_STR_P(z));
     break;
   case IS_PTR: {
     persistent_zval_enum_t *e = (persistent_zval_enum_t *)Z_PTR_P(z);
-    if (!ZSTR_IS_INTERNED(e->class_name))
-      zend_string_free(e->class_name);
-    if (!ZSTR_IS_INTERNED(e->case_name))
-      zend_string_free(e->case_name);
+    zend_string_free(e->class_name);
+    zend_string_free(e->case_name);
     pefree(e, 1);
     break;
   }
   case IS_ARRAY: {
     HashTable *ht = Z_ARRVAL_P(z);
-    if ((GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) != 0) {
-      /* Borrowed from opcache, do not touch. */
-      break;
-    }
     zval *val;
     ZEND_HASH_FOREACH_VAL(ht, val) { persistent_zval_free(val); }
     ZEND_HASH_FOREACH_END();
+    /* zend_hash_destroy releases the string keys; the values have no
+     * destructor and were freed above. */
     zend_hash_destroy(ht);
     pefree(ht, 1);
     break;
@@ -200,11 +168,7 @@ static void persistent_zval_to_request(zval *dst, zval *src) {
     ZVAL_DOUBLE(dst, Z_DVAL_P(src));
     break;
   case IS_STRING:
-    if (ZSTR_IS_INTERNED(Z_STR_P(src))) {
-      ZVAL_STR(dst, Z_STR_P(src));
-    } else {
-      ZVAL_STRINGL(dst, Z_STRVAL_P(src), Z_STRLEN_P(src));
-    }
+    ZVAL_STRINGL(dst, Z_STRVAL_P(src), Z_STRLEN_P(src));
     break;
   case IS_PTR: {
     persistent_zval_enum_t *e = (persistent_zval_enum_t *)Z_PTR_P(src);
@@ -234,11 +198,6 @@ static void persistent_zval_to_request(zval *dst, zval *src) {
   }
   case IS_ARRAY: {
     HashTable *src_ht = Z_ARRVAL_P(src);
-    if ((GC_FLAGS(src_ht) & IS_ARRAY_IMMUTABLE) != 0) {
-      /* Zero-copy: immutable arrays are safe to expose directly. */
-      ZVAL_ARR(dst, src_ht);
-      break;
-    }
     array_init_size(dst, zend_hash_num_elements(src_ht));
     HashTable *dst_ht = Z_ARRVAL_P(dst);
 
@@ -253,14 +212,10 @@ static void persistent_zval_to_request(zval *dst, zval *src) {
         break;
       }
       if (key) {
-        if (ZSTR_IS_INTERNED(key)) {
-          zend_hash_add_new(dst_ht, key, &rval);
-        } else {
-          zend_string *rkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 0);
-          ZSTR_H(rkey) = ZSTR_H(key);
-          zend_hash_add_new(dst_ht, rkey, &rval);
-          zend_string_release(rkey);
-        }
+        zend_string *rkey = zend_string_init(ZSTR_VAL(key), ZSTR_LEN(key), 0);
+        ZSTR_H(rkey) = ZSTR_H(key);
+        zend_hash_add_new(dst_ht, rkey, &rval);
+        zend_string_release(rkey);
       } else {
         zend_hash_index_add_new(dst_ht, idx, &rval);
       }

--- a/zval_test.go
+++ b/zval_test.go
@@ -44,6 +44,8 @@ func TestPersistentZvalRoundtrip(t *testing.T) {
 	require.NotContains(t, out, "FAIL", "persist-roundtrip.php reported a failure:\n"+out)
 	require.Contains(t, out, "OK null")
 	require.Contains(t, out, "OK enum active")
+	require.Contains(t, out, "OK const array")
+	require.Contains(t, out, "OK interned key and value")
 	require.Contains(t, out, "OK stdClass rejected")
 	require.Contains(t, out, "OK resource rejected")
 	require.Contains(t, out, "OK nested stdClass rejected")


### PR DESCRIPTION
`persistent_zval_persist` shared two kinds of pointer instead of copying them: interned strings and opcache-immutable arrays. Both live in opcache shared memory, which does not survive an opcache restart.

## The problem

On restart opcache rewinds its shared memory to a startup watermark:

- `accel_interned_strings_restore_state()` does `memset(saved_top, 0, top - saved_top)` and resets `top`. Everything interned after startup and preload is zeroed.
- `zend_shared_alloc_restore_state()` rewinds each segment's `pos`, so the memory holding immutable arrays is handed out again.

The segment stays mapped, so this is not a clean segfault. A persisted tree that outlives a restart points at reused bytes.

The free path is the worst case. `persistent_zval_free` re-derived ownership by re-reading `ZSTR_IS_INTERNED` at free time. `IS_STR_INTERNED` is `GC_IMMUTABLE`, a GC flag bit, so once a restart zeroes the string header that check reads false, the borrowed pointer is treated as owned, and `zend_string_free` reaches `pefree(s, GC_FLAGS(s) & IS_STR_PERSISTENT)` with flags of 0. That hands a shared memory pointer to the request allocator. The immutable array branch has the same shape: if the flag no longer reads set, the tree is walked and `zend_hash_destroy` plus `pefree` run on a shared memory HashTable.

Restarts fire for `ACCEL_RESTART_OOM`, `ACCEL_RESTART_HASH` and `ACCEL_RESTART_USER`. FrankenPHP diverts the userland `opcache_reset()` to a thread reboot via `frankenphp_override_opcache_reset()`, so the exposure is out of memory and hash overflow.

## The fix

Persist copies everything into `pemalloc` memory. Ownership becomes an invariant of a persisted tree rather than a per-node property re-derived later, so:

- `persistent_zval_free` is unconditional.
- The borrow branches in `persistent_zval_to_request` are unreachable and are dropped.
- `persistent_zval_validate` no longer short-circuits on immutable arrays. Persist walks their leaves now, and an unsupported leaf would otherwise reach `ZEND_UNREACHABLE`.

Cost is one copy at persist time, which is the rare operation. Reads are unchanged.

## Why not materialise from the restart hook instead

Keeping the fast paths and copying borrowed references from `zend_accel_schedule_restart_hook`, which fires before the rewind, would also work in principle. I did not take it:

- the hook is PHP 8.4+ only, so 8.2 and 8.3 need this copy anyway
- it needs every live persisted tree to be reachable from one global registry
- it cannot cheaply tell a below-watermark interned string from an above-watermark one, so it would copy everything regardless, at the moment opcache has just run out of memory

## This is not covered by #2621

#2621 restores the thread reboot hook. It does not make this redundant, because the two protect different things:

- #2621 protects what dies with the thread: the op_array a worker is executing, and thread-local references
- this PR protects what outlives the thread

A persisted tree is allocated with `pemalloc`, so it is process-lifetime memory. A thread reboot does not touch it, which is exactly the point of a shared-state API, so it is still holding shared memory pointers when the rewind lands. The reboot is also PHP 8.4+ only, and it is dispatched asynchronously because `rebootAllThreads()` cannot block the thread it is rebooting, so the rewind can still be performed by another thread's RINIT before the reboot finishes. Both changes are needed.

## Reachability

Not reachable on `main` today. The only caller is `frankenphp_test_persist_roundtrip`, compiled only under `FRANKENPHP_TEST`, which persists, reads and frees inside a single call. This matters for a shared-state API (`frankenphp_set_vars` / `frankenphp_get_vars`) that keeps a persisted tree across requests.

## Tests

`persist-roundtrip.php` gains a compile-time constant array and a literal-keyed array. Those are exactly the inputs that used to take the borrow paths and now take the copy paths, so the new code is exercised for value correctness.

There is no regression test for the crash itself. Driving opcache into a restart from a test is possible, #2621 does it, but a test for this path needs something that keeps a persisted tree across requests, and nothing on `main` does.

## Verification

- CI: Tests, Integration Tests and Lint pass on PHP 8.2, 8.3, 8.4 and 8.5, plus macOS.
- On `dunglas/frankenphp:builder-php8.5`: `TestPersistentZvalRoundtrip` passes with `-DFRANKENPHP_TEST`, so the new constant-array and literal-key cases actually run, and the full library suite passes in 21.6s.
- `clang-format` and `gofmt` clean.

The failing checks are cross-architecture image builds and the static GNU binaries, which fail the same way on other open PRs that do not touch this code.
