### PR TITLE
Revert "fix: removes opcache_hook again (#2564)"

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1017,14 +1017,21 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+/* Scheduled by opcache itself, on shared memory exhaustion or hash overflow.
+ * The reason is ignored: opcache_reset() is already intercepted below, so only
+ * the automatic reasons reach this hook. Guarded like the assignment in
+ * php_main(), which is its only caller, so builds without the hook do not trip
+ * -Werror=unused-function. */
+#if defined(ZTS) && PHP_VERSION_ID >= 80400
 static void frankenphp_opcache_restart_hook(int reason) {
   (void)reason;
-  go_schedule_opcache_reset(frankenphp_thread_index());
+  go_schedule_opcache_reset(frankenphp_thread_index(), true);
 }
+#endif
 
 /* {{{ thread-safe opcache reset */
 PHP_FUNCTION(frankenphp_opcache_reset) {
-  frankenphp_opcache_restart_hook(0);
+  go_schedule_opcache_reset(frankenphp_thread_index(), false);
 
   RETVAL_TRUE;
 } /* }}} */

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1017,9 +1017,14 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+static void frankenphp_opcache_restart_hook(int reason) {
+  (void)reason;
+  go_schedule_opcache_reset(frankenphp_thread_index());
+}
+
 /* {{{ thread-safe opcache reset */
 PHP_FUNCTION(frankenphp_opcache_reset) {
-  go_schedule_opcache_reset(frankenphp_thread_index());
+  frankenphp_opcache_restart_hook(0);
 
   RETVAL_TRUE;
 } /* }}} */
@@ -1704,6 +1709,13 @@ static void *php_main(void *arg) {
   }
 
   frankenphp_sapi_module.startup(&frankenphp_sapi_module);
+
+#if defined(ZTS) && PHP_VERSION_ID >= 80400
+  /* Also restart everything on opcache memory overflow or similar events, the
+   * hook is triggered right before an opcache reset is scheduled
+   */
+  zend_accel_schedule_restart_hook = frankenphp_opcache_restart_hook;
+#endif
 
   /* check if a default filter is set in php.ini and only filter if
    * it is, this is deprecated and will be removed in PHP 9 */

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -773,11 +773,58 @@ func go_is_context_done(threadIndex C.uintptr_t) C.bool {
 	return C.bool(phpThreads[threadIndex].handler.frankenPHPContext().isDone)
 }
 
-//export go_schedule_opcache_reset
-func go_schedule_opcache_reset(threadIndex C.uintptr_t) {
-	if mainThread != nil {
-		go mainThread.rebootAllThreads()
+const (
+	// Bounds on how often opcache is expected to restart by itself. Beyond
+	// this the compiled code does not fit in the configured shared memory and
+	// opcache is thrashing, which only the operator can fix.
+	automaticOpcacheRestartWindow    = time.Minute
+	automaticOpcacheRestartThreshold = 5
+)
+
+var automaticOpcacheRestarts struct {
+	sync.Mutex
+	windowStart time.Time
+	count       int
+}
+
+// recordAutomaticOpcacheRestart counts the restarts opcache schedules on its
+// own and reports true the first time the threshold is crossed in a window,
+// so the caller logs once per window instead of on every restart.
+func recordAutomaticOpcacheRestart(now time.Time) bool {
+	automaticOpcacheRestarts.Lock()
+	defer automaticOpcacheRestarts.Unlock()
+
+	if now.Sub(automaticOpcacheRestarts.windowStart) > automaticOpcacheRestartWindow {
+		automaticOpcacheRestarts.windowStart = now
+		automaticOpcacheRestarts.count = 0
 	}
+
+	automaticOpcacheRestarts.count++
+
+	return automaticOpcacheRestarts.count == automaticOpcacheRestartThreshold
+}
+
+//export go_schedule_opcache_reset
+func go_schedule_opcache_reset(threadIndex C.uintptr_t, automatic C.bool) {
+	if mainThread == nil {
+		return
+	}
+
+	// A reboot is never skipped, not even when they pile up: opcache rewinds
+	// its shared memory whether or not the threads are ready for it, so
+	// declining to reboot brings back the crash the hook exists to prevent.
+	// Repeated automatic restarts are reported instead, since the fix is to
+	// give opcache more room. rebootAllThreads() already ignores a call made
+	// while a reboot is in flight.
+	if bool(automatic) && recordAutomaticOpcacheRestart(time.Now()) && globalLogger.Enabled(globalCtx, slog.LevelError) {
+		globalLogger.LogAttrs(globalCtx, slog.LevelError,
+			"opcache keeps restarting and PHP threads are rebooting each time, raise opcache.memory_consumption and opcache.max_accelerated_files",
+			slog.Int("restarts", automaticOpcacheRestartThreshold),
+			slog.Duration("window", automaticOpcacheRestartWindow),
+		)
+	}
+
+	go mainThread.rebootAllThreads()
 }
 
 func convertArgs(args []string) (C.int, []*C.char) {

--- a/opcache_test.go
+++ b/opcache_test.go
@@ -1,0 +1,75 @@
+package frankenphp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpcacheRestartKeepsWorkerThreadsAlive guards the opcache restart hook.
+//
+// A worker holds references into opcache shared memory for its whole life. An
+// opcache restart rewinds that memory to a startup watermark while the worker
+// is still executing, because opcache defers a restart until
+// accel_is_inactive(), which is an fcntl probe that cannot see threads of the
+// calling process. The hook reboots every thread before that happens.
+//
+// Without the hook this test does not fail, it takes the process down with
+// SIGSEGV, which is the regression being guarded.
+func TestOpcacheRestartKeepsWorkerThreadsAlive(t *testing.T) {
+	t.Cleanup(func() {
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), "frankenphp-opcache-restart-test"))
+	})
+
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, _ int) {
+		get := func(path string) string {
+			w := httptest.NewRecorder()
+			handler(w, httptest.NewRequest("GET", "http://example.com"+path, nil))
+
+			return strings.TrimSpace(w.Body.String())
+		}
+
+		if body := get("/opcache/trigger.php?b=0"); body == "NOOPCACHE" {
+			t.Skip("opcache is not available in this build")
+		}
+
+		require.Equal(t, "OK", get("/opcache/worker.php"), "worker must be healthy before the restart")
+
+		// Compile until opcache performs a restart. The counters only move
+		// once a restart has actually been carried out, not merely scheduled.
+		restarted := false
+		for b := 1; b <= 20 && !restarted; b++ {
+			body := get("/opcache/trigger.php?b=" + strconv.Itoa(b))
+			if n, err := strconv.Atoi(body); err == nil && n > 0 {
+				restarted = true
+			}
+		}
+
+		if !restarted {
+			t.Skip("could not force an opcache restart in this environment")
+		}
+
+		assert.Equal(t, "OK", get("/opcache/worker.php"), "worker must survive an opcache restart")
+	}, &testOptions{
+		workerScript:       "opcache/worker.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		phpIni: map[string]string{
+			"opcache.enable":                  "1",
+			"opcache.enable_cli":              "1",
+			"opcache.memory_consumption":      "8",
+			"opcache.interned_strings_buffer": "1",
+			"opcache.max_accelerated_files":   "200",
+			"opcache.file_update_protection":  "0",
+			"opcache.validate_timestamps":     "1",
+			"opcache.revalidate_freq":         "0",
+		},
+	})
+}

--- a/opcacherestart_test.go
+++ b/opcacherestart_test.go
@@ -1,0 +1,46 @@
+package frankenphp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutomaticOpcacheRestartsAreReportedOncePerWindow(t *testing.T) {
+	reset := func() {
+		automaticOpcacheRestarts.Lock()
+		automaticOpcacheRestarts.windowStart = time.Time{}
+		automaticOpcacheRestarts.count = 0
+		automaticOpcacheRestarts.Unlock()
+	}
+
+	t.Run("stays quiet below the threshold", func(t *testing.T) {
+		reset()
+		now := time.Now()
+		for i := 1; i < automaticOpcacheRestartThreshold; i++ {
+			assert.False(t, recordAutomaticOpcacheRestart(now), "restart %d must not report", i)
+		}
+	})
+
+	t.Run("reports exactly once when the threshold is crossed", func(t *testing.T) {
+		reset()
+		now := time.Now()
+		reported := 0
+		for i := 0; i < automaticOpcacheRestartThreshold*3; i++ {
+			if recordAutomaticOpcacheRestart(now) {
+				reported++
+			}
+		}
+		assert.Equal(t, 1, reported, "a burst must be reported once, not on every restart")
+	})
+
+	t.Run("restarts spread out never reach the threshold", func(t *testing.T) {
+		reset()
+		now := time.Now()
+		for i := 0; i < automaticOpcacheRestartThreshold*3; i++ {
+			now = now.Add(automaticOpcacheRestartWindow + time.Second)
+			assert.False(t, recordAutomaticOpcacheRestart(now), "occasional restarts are normal")
+		}
+	})
+}

--- a/testdata/opcache/trigger.php
+++ b/testdata/opcache/trigger.php
@@ -1,0 +1,36 @@
+<?php
+
+// Runs on a regular thread. Compiles fresh scripts until the opcache hash
+// overflows, which schedules a restart, then reports how many restarts have
+// been performed so the caller can stop as soon as one lands.
+if (!function_exists('opcache_get_status')) {
+    echo 'NOOPCACHE';
+
+    return;
+}
+
+$dir = sys_get_temp_dir() . '/frankenphp-opcache-restart-test';
+@mkdir($dir, 0777, true);
+
+$batch = (int) ($_GET['b'] ?? 0);
+for ($i = 0; $i < 120; $i++) {
+    $file = $dir . '/g' . $batch . '_' . $i . '.php';
+    file_put_contents($file, "<?php\nfunction fn_{$batch}_{$i}() { return {$i}; }\n" . str_repeat("// pad\n", 40));
+    @include_once $file;
+}
+
+// Discarding scripts grows wasted_shared_memory, which is what lets the
+// hash-full path schedule a restart.
+foreach (glob($dir . '/*.php') as $file) {
+    @opcache_invalidate($file, true);
+}
+
+$status = @opcache_get_status(false);
+if (!is_array($status) || !isset($status['opcache_statistics'])) {
+    echo 'NOOPCACHE';
+
+    return;
+}
+
+$s = $status['opcache_statistics'];
+echo (int) ($s['oom_restarts'] + $s['hash_restarts'] + $s['manual_restarts']);

--- a/testdata/opcache/worker.php
+++ b/testdata/opcache/worker.php
@@ -1,0 +1,30 @@
+<?php
+
+// Keeps references into opcache shared memory alive across requests: the
+// literal is an interned string and the const array is IS_ARRAY_IMMUTABLE.
+// Both live in memory that opcache rewinds on a restart, so if a restart is
+// performed while this worker runs, the process dies.
+const OPCACHE_CANARY = ['a' => 1, 'b' => [2, 3], 'c' => 'literal'];
+
+$str = 'opcache_canary_interned_string';
+$arr = OPCACHE_CANARY;
+
+// Fingerprints are plain integers on the thread heap, so a rewind cannot
+// touch them.
+$expLen = strlen($str);
+$expCrc = crc32($str);
+$expArr = crc32(serialize($arr));
+
+$handler = static function () use (&$str, &$arr, $expLen, $expCrc, $expArr) {
+    if (strlen($str) !== $expLen || crc32($str) !== $expCrc || crc32(serialize($arr)) !== $expArr) {
+        echo 'CORRUPT';
+
+        return;
+    }
+
+    echo 'OK';
+};
+
+for ($running = true; $running;) {
+    $running = frankenphp_handle_request($handler);
+}


### PR DESCRIPTION
Reverts #2564, with a regression test and a fix for the concern that motivated the removal.

Without the hook, an opcache restart takes the whole process down with SIGSEGV.

## Why the hook matters

opcache defers a restart until `accel_is_inactive()`, which probes for a conflicting lock with `fcntl F_GETLK` on its own lock file. POSIX fcntl locks belong to the process and never conflict with locks that process already holds, so the probe reports "inactive" no matter how many threads are inside a request:

```
held: F_RDLCK on byte 1 (what accel_activate_add takes per request)
  same thread   probe -> F_UNLCK (reports INACTIVE)
  other thread  probe -> F_UNLCK (reports INACTIVE)
  child process probe -> F_RDLCK (reports BUSY)
```

The last line is the control: the mechanism does work across processes, which is what it was designed for, and `kill_all_lockers()` makes that assumption explicit by signalling the locking pid. It does nothing for a single-process threaded server.

So the restart gets carried out at the next `ZEND_RINIT_FUNCTION(zend_accelerator)` on any thread, while workers are still running. `accel_interned_strings_restore_state()` memsets every string interned past the startup watermark and rewinds `top`, and `zend_shared_alloc_restore_state()` rewinds each segment position. The op_array a worker is executing is handed back out to the next compile.

Workers are the worst case. They never reach `accel_post_deactivate`, because the worker request cycle only runs `MODULES_TO_RELOAD` and not `zend_activate_modules()`, so they hold shared memory references for their whole life instead of for one request.

## Reproducer

On `dunglas/frankenphp:latest` (PHP 8.5.9 ZTS, FrankenPHP 1.12.7): a worker holding an interned literal and a `const` array, plus a second route on regular threads that compiles and invalidates scripts to overflow the opcache hash.

| Run | Config | Restart | Result |
| --- | --- | --- | --- |
| A | `memory_consumption=8`, `max_accelerated_files=200` | performed | SIGSEGV, exit 139 |
| B | as A plus `max_wasted_percentage=50` | performed | SIGSEGV, exit 139 |
| C | `memory_consumption=128`, `max_accelerated_files=20000` | none possible | 960 files compiled, worker healthy, server alive |
| D | `memory_consumption=128`, `max_accelerated_files=200` | performed | SIGSEGV, exit 139 |

Run C is the control: same workload and same file churn, the only difference being that nothing can overflow. opcache's own log carries `Restart Scheduled! Reason: hash overflow` followed by `Restarting!` in exactly the runs that die.

Run D is worth a look on its own. With a 128 MB pool and `max_wasted_percentage=50` the gate in `zend_accel_schedule_restart_if_necessary()` should need 64 MB of waste, but the restart fired at 222 KB. The startup log shows `opcache.memory_consumption cannot be changed when OPcache is already set up` once per thread, which suggests `ZCG(accel_directives).memory_consumption` stays 0 on those threads and the gate divides by zero. That would mean restarts are far easier to hit under ZTS than the documented 5 % suggests. Happy to split that out if it is worth chasing separately.

## Commit 1: revert plus test

`TestOpcacheRestartKeepsWorkerThreadsAlive` sets a small opcache, starts a worker holding those references, compiles until a restart has actually been performed (the counters only move once it is carried out, not when it is scheduled), then asserts the worker still answers.

Checked in both directions on `dunglas/frankenphp:builder-php8.5`, same tree, only the hook differing:

- with the hook: `--- PASS (0.24s)`, and the log shows `rebooting all PHP threads` then `thread reboot finished num_threads=48`
- without the hook: `signal: segmentation fault (core dumped)`, `FAIL`

The test skips when opcache is unavailable or when a restart cannot be forced. Note it does not fail cleanly without the hook, it takes the test binary down, which is the nature of the bug.

## Commit 2: repeated restarts

The concern in #2564 is real: a runtime that invalidates heavily could restart opcache over and over, and rebooting the threads each time would turn that into a reboot loop.

The reboots are not throttled. opcache rewinds its shared memory whether or not the threads are ready for it, so declining a reboot brings the segfault straight back. Skipping is not a safe trade.

A sustained loop means the compiled code does not fit in `opcache.memory_consumption`, so opcache can never settle: it fills, overflows, restarts and fills again. That configuration already thrashes today, just silently. So the loop is now reported instead of hidden, with an error naming the two settings that fix it, logged once per window rather than on every restart.

`go_schedule_opcache_reset()` now knows whether the restart came from opcache or from a userland `opcache_reset()`. Only the automatic path is counted, so calling `opcache_reset()` in a loop does not produce the message. Reboot coalescing already exists, `rebootAllThreads()` returns early while a reboot is in flight.

## Test results

Full library suite passes with both commits applied: `go test .`, 23.9 s, on `builder-php8.5`.

## Scope

The hook is `#if defined(ZTS) && PHP_VERSION_ID >= 80400`, so 8.2 and 8.3 have no protection either way. The root cause is upstream opcache behaviour under ZTS rather than a FrankenPHP bug, and it is not specific to workers, but workers are where the exposure is permanent. I can take it upstream too if you prefer that venue.
