### PR TITLE
fix: log and count opcache restarts

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,7 +23,7 @@ When [Caddy metrics](https://caddyserver.com/docs/metrics) are enabled, FrankenP
 - `frankenphp_worker_crashes{worker="[worker_name]"}`: The number of times a worker has unexpectedly terminated.
 - `frankenphp_worker_restarts{worker="[worker_name]"}`: The number of times a worker has been deliberately restarted.
 - `frankenphp_worker_queue_depth{worker="[worker_name]"}`: The number of queued requests.
-- `frankenphp_opcache_restarts{reason="[reason]"}`: The number of times opcache restarted its shared memory on its own, by reason (`out of memory`, `hash overflow`, `user`). Each restart is also logged. Under ZTS, running PHP threads may hold stale references to the rewound memory, so raise `opcache.memory_consumption` and `opcache.max_accelerated_files` when this counter grows.
+- `frankenphp_opcache_restarts{reason="[reason]"}`: (experimental) The number of times opcache restarted its shared memory on its own, by reason (`out of memory`, `hash overflow`, `user`). This counter should always be zero: a restart rewinds memory that running PHP threads may still reference, which can crash the process. A non-zero value means opcache is undersized for the application, raise `opcache.memory_consumption` and `opcache.max_accelerated_files`. Each restart is also logged. This metric will be removed once opcache handles restarts safely under ZTS.
 
 For worker metrics, the `[worker_name]` placeholder is replaced by the worker name in the Caddyfile, otherwise the absolute path of the worker file will be used.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,6 +23,7 @@ When [Caddy metrics](https://caddyserver.com/docs/metrics) are enabled, FrankenP
 - `frankenphp_worker_crashes{worker="[worker_name]"}`: The number of times a worker has unexpectedly terminated.
 - `frankenphp_worker_restarts{worker="[worker_name]"}`: The number of times a worker has been deliberately restarted.
 - `frankenphp_worker_queue_depth{worker="[worker_name]"}`: The number of queued requests.
+- `frankenphp_opcache_restarts{reason="[reason]"}`: The number of times opcache restarted its shared memory on its own, by reason (`out of memory`, `hash overflow`, `user`). Each restart is also logged. Under ZTS, running PHP threads may hold stale references to the rewound memory, so raise `opcache.memory_consumption` and `opcache.max_accelerated_files` when this counter grows.
 
 For worker metrics, the `[worker_name]` placeholder is replaced by the worker name in the Caddyfile, otherwise the absolute path of the worker file will be used.
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1021,7 +1021,7 @@ PHP_FUNCTION(frankenphp_log) {
  * do not trip -Werror=unused-function. */
 #if defined(ZTS) && PHP_VERSION_ID >= 80400
 static void frankenphp_opcache_restart_hook(int reason) {
-  go_log_opcache_restart(reason);
+  go_opcache_restart_scheduled(reason);
 }
 #endif
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1017,6 +1017,14 @@ PHP_FUNCTION(frankenphp_log) {
   }
 }
 
+/* Guarded like its only assignment in php_main(), so builds without the hook
+ * do not trip -Werror=unused-function. */
+#if defined(ZTS) && PHP_VERSION_ID >= 80400
+static void frankenphp_opcache_restart_hook(int reason) {
+  go_log_opcache_restart(reason);
+}
+#endif
+
 /* {{{ thread-safe opcache reset */
 PHP_FUNCTION(frankenphp_opcache_reset) {
   go_schedule_opcache_reset(frankenphp_thread_index());
@@ -1704,6 +1712,11 @@ static void *php_main(void *arg) {
   }
 
   frankenphp_sapi_module.startup(&frankenphp_sapi_module);
+
+#if defined(ZTS) && PHP_VERSION_ID >= 80400
+  /* Report the opcache restarts that opcache schedules on its own */
+  zend_accel_schedule_restart_hook = frankenphp_opcache_restart_hook;
+#endif
 
   /* check if a default filter is set in php.ini and only filter if
    * it is, this is deprecated and will be removed in PHP 9 */

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -784,23 +784,17 @@ func go_schedule_opcache_reset(threadIndex C.uintptr_t) {
 // zend_accel_restart_reason (ext/opcache/ZendAccelerator.h).
 var opcacheRestartReasons = [...]string{"out of memory", "hash overflow", "user"}
 
-// go_log_opcache_restart reports the restarts opcache schedules on its own.
-// Under ZTS they rewind shared memory that running threads still point into,
-// which surfaces as an unexplained crash or slowdown, so make the event
-// visible. The line is written inline even though opcache can be holding its
-// shared memory lock: that costs far less than the restart it precedes, and a
-// line deferred to a goroutine would be lost when the restart takes the
-// process down.
-//
-//export go_log_opcache_restart
-func go_log_opcache_restart(reason C.int) {
-	if !globalLogger.Enabled(globalCtx, slog.LevelWarn) {
-		return
-	}
-
+//export go_opcache_restart_scheduled
+func go_opcache_restart_scheduled(reason C.int) {
 	reasonText := "unknown"
 	if i := int(reason); i >= 0 && i < len(opcacheRestartReasons) {
 		reasonText = opcacheRestartReasons[i]
+	}
+
+	metrics.OpcacheRestart(reasonText)
+
+	if !globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+		return
 	}
 
 	globalLogger.LogAttrs(globalCtx, slog.LevelWarn,

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -780,6 +780,35 @@ func go_schedule_opcache_reset(threadIndex C.uintptr_t) {
 	}
 }
 
+// Restart reasons opcache reports to the hook, in the order of
+// zend_accel_restart_reason (ext/opcache/ZendAccelerator.h).
+var opcacheRestartReasons = [...]string{"out of memory", "hash overflow", "user"}
+
+// go_log_opcache_restart reports the restarts opcache schedules on its own.
+// Under ZTS they rewind shared memory that running threads still point into,
+// which surfaces as an unexplained crash or slowdown, so make the event
+// visible. The line is written inline even though opcache can be holding its
+// shared memory lock: that costs far less than the restart it precedes, and a
+// line deferred to a goroutine would be lost when the restart takes the
+// process down.
+//
+//export go_log_opcache_restart
+func go_log_opcache_restart(reason C.int) {
+	if !globalLogger.Enabled(globalCtx, slog.LevelWarn) {
+		return
+	}
+
+	reasonText := "unknown"
+	if i := int(reason); i >= 0 && i < len(opcacheRestartReasons) {
+		reasonText = opcacheRestartReasons[i]
+	}
+
+	globalLogger.LogAttrs(globalCtx, slog.LevelWarn,
+		"opcache restart scheduled, running PHP threads may hold stale references to its shared memory: raise opcache.memory_consumption and opcache.max_accelerated_files to make restarts less likely",
+		slog.String("reason", reasonText),
+	)
+}
+
 func convertArgs(args []string) (C.int, []*C.char) {
 	argc := C.int(len(args))
 	argv := make([]*C.char, argc)

--- a/metrics.go
+++ b/metrics.go
@@ -405,9 +405,10 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 			Name: "frankenphp_queue_depth",
 			Help: "Number of regular queued requests",
 		}),
+		// experimental: to be removed once opcache handles restarts safely under ZTS
 		opcacheRestarts: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "frankenphp_opcache_restarts",
-			Help: "Number of restarts of opcache's shared memory, by reason",
+			Help: "Number of restarts of opcache's shared memory, by reason (experimental, should stay at zero)",
 		}, []string{"reason"}),
 		totalWorkers:       nil,
 		busyWorkers:        nil,

--- a/metrics.go
+++ b/metrics.go
@@ -40,6 +40,8 @@ type Metrics interface {
 	DequeuedWorkerRequest(name string)
 	QueuedRequest()
 	DequeuedRequest()
+	// OpcacheRestart collects the restarts of opcache's shared memory, by reason
+	OpcacheRestart(reason string)
 }
 
 type nullMetrics struct{}
@@ -81,6 +83,8 @@ func (n nullMetrics) DequeuedWorkerRequest(string) {}
 func (n nullMetrics) QueuedRequest()   {}
 func (n nullMetrics) DequeuedRequest() {}
 
+func (n nullMetrics) OpcacheRestart(string) {}
+
 type PrometheusMetrics struct {
 	registry           prometheus.Registerer
 	totalThreads       prometheus.Gauge
@@ -94,6 +98,7 @@ type PrometheusMetrics struct {
 	workerRequestCount *prometheus.CounterVec
 	workerQueueDepth   *prometheus.GaugeVec
 	queueDepth         prometheus.Gauge
+	opcacheRestarts    *prometheus.CounterVec
 	mu                 sync.RWMutex
 }
 
@@ -332,6 +337,13 @@ func (m *PrometheusMetrics) DequeuedRequest() {
 	m.queueDepth.Dec()
 }
 
+func (m *PrometheusMetrics) OpcacheRestart(reason string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	m.opcacheRestarts.WithLabelValues(reason).Inc()
+}
+
 func (m *PrometheusMetrics) Shutdown() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -339,6 +351,7 @@ func (m *PrometheusMetrics) Shutdown() {
 	m.registry.Unregister(m.totalThreads)
 	m.registry.Unregister(m.busyThreads)
 	m.registry.Unregister(m.queueDepth)
+	m.registry.Unregister(m.opcacheRestarts)
 
 	if m.totalWorkers != nil {
 		m.registry.Unregister(m.totalWorkers)
@@ -392,6 +405,10 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 			Name: "frankenphp_queue_depth",
 			Help: "Number of regular queued requests",
 		}),
+		opcacheRestarts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "frankenphp_opcache_restarts",
+			Help: "Number of restarts of opcache's shared memory, by reason",
+		}, []string{"reason"}),
 		totalWorkers:       nil,
 		busyWorkers:        nil,
 		workerRequestTime:  nil,
@@ -415,6 +432,17 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 	if err := m.registry.Register(m.queueDepth); err != nil &&
 		!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
 		panic(err)
+	}
+
+	if err := m.registry.Register(m.opcacheRestarts); err != nil &&
+		!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+		panic(err)
+	}
+
+	// expose the series at zero so a rate or an alert on them works from the
+	// first restart on, instead of missing it for lack of a previous sample
+	for _, reason := range opcacheRestartReasons {
+		m.opcacheRestarts.WithLabelValues(reason)
 	}
 
 	return m

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -212,3 +212,30 @@ func TestPrometheusMetrics_TestStopReasonCrash(t *testing.T) {
 
 	}
 }
+
+func TestPrometheusMetrics_OpcacheRestart(t *testing.T) {
+	m := NewPrometheusMetrics(prometheus.NewRegistry())
+	m.OpcacheRestart("hash overflow")
+	m.OpcacheRestart("hash overflow")
+	m.OpcacheRestart("out of memory")
+
+	// known reasons are exposed from the start, unknown ones only once seen
+	require.NoError(t, testutil.CollectAndCompare(m.opcacheRestarts, strings.NewReader(`
+		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason
+		# TYPE frankenphp_opcache_restarts counter
+		frankenphp_opcache_restarts{reason="hash overflow"} 2
+		frankenphp_opcache_restarts{reason="out of memory"} 1
+		frankenphp_opcache_restarts{reason="user"} 0
+	`)))
+
+	m.OpcacheRestart("unknown")
+
+	require.NoError(t, testutil.CollectAndCompare(m.opcacheRestarts, strings.NewReader(`
+		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason
+		# TYPE frankenphp_opcache_restarts counter
+		frankenphp_opcache_restarts{reason="hash overflow"} 2
+		frankenphp_opcache_restarts{reason="out of memory"} 1
+		frankenphp_opcache_restarts{reason="unknown"} 1
+		frankenphp_opcache_restarts{reason="user"} 0
+	`)))
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -221,7 +221,7 @@ func TestPrometheusMetrics_OpcacheRestart(t *testing.T) {
 
 	// known reasons are exposed from the start, unknown ones only once seen
 	require.NoError(t, testutil.CollectAndCompare(m.opcacheRestarts, strings.NewReader(`
-		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason
+		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason (experimental, should stay at zero)
 		# TYPE frankenphp_opcache_restarts counter
 		frankenphp_opcache_restarts{reason="hash overflow"} 2
 		frankenphp_opcache_restarts{reason="out of memory"} 1
@@ -231,7 +231,7 @@ func TestPrometheusMetrics_OpcacheRestart(t *testing.T) {
 	m.OpcacheRestart("unknown")
 
 	require.NoError(t, testutil.CollectAndCompare(m.opcacheRestarts, strings.NewReader(`
-		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason
+		# HELP frankenphp_opcache_restarts Number of restarts of opcache's shared memory, by reason (experimental, should stay at zero)
 		# TYPE frankenphp_opcache_restarts counter
 		frankenphp_opcache_restarts{reason="hash overflow"} 2
 		frankenphp_opcache_restarts{reason="out of memory"} 1


### PR DESCRIPTION
Split out of #2621, which is closed: this keeps only the reporting, not the thread reboot.

opcache schedules a restart of its shared memory when the cache is full, on exhaustion or hash overflow, and more than `opcache.max_wasted_percentage` of it was wasted by invalidations. It then carries the restart out at the next request start on whichever thread comes first, and caching is off until then. Under ZTS the restart runs while other threads are still running: the deferral gate `accel_is_inactive()` probes for a conflicting lock with `fcntl F_GETLK`, and POSIX fcntl locks belong to the process, so the probe never sees the threads of the process holding them (on Windows the gate is a counter that does see them, so the restart is deferred instead). Workers are the worst case, they hold shared memory references for their whole life instead of for one request.

What an operator sees today is a segfault or a sudden slowdown with nothing in the logs pointing at opcache. opcache does report the event, but only at `opcache.log_verbosity_level=4` and in its own log.

This PR makes the event visible and does nothing else. As a log line:

```
WARN opcache restart scheduled, caching stops until the next request start carries it out while other threads may still reference the old memory: raise opcache.memory_consumption, opcache.max_accelerated_files or opcache.max_wasted_percentage  reason=hash
```

And as a counter, since a log line cannot be alerted on:

```
frankenphp_opcache_restarts{reason="hash"} 1
```

`zend_accel_schedule_restart_hook` is the only signal reachable from Go for this, so it is set again, but this time it only logs and counts. No thread reboot, so nothing here can loop the way #2564 was worried about. The hook fires when the restart is scheduled, not when it runs: php-src has no hook for that yet, php/php-src#23828 adds one.

Same `#if defined(ZTS) && PHP_VERSION_ID >= 80400` guard as before, so PHP 8.4 and up on ZTS builds; elsewhere the counter is not exposed at all rather than sitting at zero. `reason` follows `zend_accel_restart_reason`, named like the counters of `opcache_get_status()`: `oom`, `hash`, `manual`. `manual` should be unreachable since `opcache_reset()` is overridden, so seeing it means the override did not take, which is worth knowing too.

On the metric: `Metrics` keeps its shape, the counter comes through an optional `OpcacheMetrics` interface with the one `OpcacheRestart(reason)` method, detected with a type assertion like `ServerMetrics` in #2617. `PrometheusMetrics` implements it and backs it with a `frankenphp_opcache_restarts` counter registered up front like the thread gauges; an implementation passed to `WithMetrics()` that doesn't have it compiles unchanged and only misses the counter, the restart is logged either way. The known reasons are pre-populated at zero so a rate or an alert on the series works from the first restart on, instead of missing it for lack of a previous sample. The counter is incremented before the log-level gate, so the event is recorded even when warnings are silenced.

The hook path has a unit test: log line, reason mapping and counter. Forcing a real restart stays out of the suite, it needs exhaustion plus wasted memory and is what takes the process down.

