### PR TITLE
fix: refuse to start on a ZTS build with Zend signals

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -46,6 +46,7 @@ var (
 	ErrInvalidRequest     = errors.New("not a FrankenPHP request")
 	ErrAlreadyStarted     = errors.New("FrankenPHP is already started")
 	ErrInvalidPHPVersion  = errors.New("FrankenPHP is only compatible with PHP 8.2+")
+	ErrZendSignals        = errors.New(`FrankenPHP is not compatible with Zend Signals, recompile PHP with the "--disable-zend-signals" configuration option`)
 	ErrMainThreadCreation = errors.New("error creating the main thread")
 	ErrScriptExecution    = errors.New("error during PHP script execution")
 	ErrNotRunning         = errors.New("server is not registered, you must first call frankenphp.Init() with the WithServer() option")
@@ -154,6 +155,21 @@ func Config() PHPConfig {
 		ZendSignals:            bool(cConfig.zend_signals),
 		ZendMaxExecutionTimers: bool(cConfig.zend_max_execution_timers),
 	}
+}
+
+// checkPHPConfig rejects the PHP builds FrankenPHP cannot run on
+func checkPHPConfig(config PHPConfig) error {
+	if config.Version.MajorVersion < 8 || (config.Version.MajorVersion == 8 && config.Version.MinorVersion < 2) {
+		return ErrInvalidPHPVersion
+	}
+
+	// FrankenPHP never calls zend_signal_startup(), so in ZTS the ini entries
+	// of the signal globals overwrite the TSRM entry of each thread
+	if config.ZTS && config.ZendSignals {
+		return ErrZendSignals
+	}
+
+	return nil
 }
 
 func calculateMaxThreads(opt *opt) (numWorkers int, _ error) {
@@ -294,9 +310,10 @@ func Init(options ...Option) error {
 
 	config := Config()
 
-	if config.Version.MajorVersion < 8 || (config.Version.MajorVersion == 8 && config.Version.MinorVersion < 2) {
+	if err := checkPHPConfig(config); err != nil {
 		shutdown()
-		return ErrInvalidPHPVersion
+
+		return err
 	}
 
 	if config.ZTS {

--- a/phpconfig_test.go
+++ b/phpconfig_test.go
@@ -1,0 +1,36 @@
+package frankenphp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckPHPConfig(t *testing.T) {
+	supported := PHPConfig{Version: PHPVersion{MajorVersion: 8, MinorVersion: 2}, ZTS: true}
+
+	t.Run("a supported build is accepted", func(t *testing.T) {
+		require.NoError(t, checkPHPConfig(supported))
+	})
+
+	t.Run("PHP older than 8.2 is rejected", func(t *testing.T) {
+		old := supported
+		old.Version.MinorVersion = 1
+		assert.ErrorIs(t, checkPHPConfig(old), ErrInvalidPHPVersion)
+	})
+
+	t.Run("Zend signals are rejected in ZTS", func(t *testing.T) {
+		signals := supported
+		signals.ZendSignals = true
+		assert.ErrorIs(t, checkPHPConfig(signals), ErrZendSignals)
+	})
+
+	t.Run("Zend signals are allowed without ZTS", func(t *testing.T) {
+		// without ZTS the ini entries address the globals directly
+		signals := supported
+		signals.ZTS = false
+		signals.ZendSignals = true
+		require.NoError(t, checkPHPConfig(signals))
+	})
+}


### PR DESCRIPTION
PHP enables Zend signals by default, `docs/compile.md` and the Dockerfiles pass `--disable-zend-signals`, and nothing checks it. Building PHP by hand without that flag gives a server that never finishes booting, with memory growing by hundreds of megabytes per second until the process is killed. No error, no log line, and the stacks only show PHP copying hash tables, so it reads like a slow machine.

What happens: FrankenPHP has its own SAPI and never calls `zend_signal_startup()`, which the cli and embed SAPIs of php-src do, so `zend_signal_globals_id` stays 0. When `zend_register_standard_ini_entries()` reaches `zend.signal_check`, `OnUpdateBool` resolves its address as `ts_resource(*(int *)mh_arg2) + mh_arg1`; `ts_resource(0)` returns the `tsrm_tls_entry` of the calling thread itself, so the bool write lands 16 bytes into it, on the `thread_id` field, and zeroes its low byte. TSRM never matches that thread again: `ts_resource_ex()` appends a new resource set and tail-recurses on every call, each level running `executor_globals_ctor()` and copying the constant, function and class tables. Watchpoint on the field, and the chain measured at 4013 entries before the process was killed.

This checks the flag PHP already reports through `frankenphp_get_config()` and fails `Init()` with an actionable error. Against a PHP built without the flag the tests now stop in 0.00s with that message instead of hanging; against a correctly built PHP the suite is unchanged.

Non-ZTS builds keep working: their ini entries address the globals directly, TSRM is not involved, so the check is limited to ZTS.

The alternative would be to call `zend_signal_startup()` like the embed SAPI does. That is not enough: with Zend signals actually running, PHP's handlers and the Go runtime's fight over the same signals and the test suite crashes, which is presumably why the flag is documented in the first place.
